### PR TITLE
Support in-transaction disk quota management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EXTENSION = diskquota
 DATA = diskquota--1.0.sql
 SRCDIR = ./
 FILES = $(shell find $(SRCDIR) -type f -name "*.c")
-OBJS = diskquota.o enforcement.o quotamodel.o activetable.o
+OBJS = diskquota.o enforcement.o quotamodel.o activetable.o pg_utils.o
 
 REGRESS = dummy
 REGRESS_OPTS = --temp-config=test_diskquota.conf --temp-instance=/tmp/pg_diskquota_test  --schedule=diskquota_schedule

--- a/activetable.c
+++ b/activetable.c
@@ -114,22 +114,6 @@ init_shm_worker_active_tables(void)
 }
 
 /*
- * Init lock of active table map 
- */
-void init_lock_active_tables(void)
-{
-	bool found = false;
-	active_table_shm_lock = ShmemInitStruct("disk_quota_active_table_shm_lock",
-											sizeof(disk_quota_shared_state),
-											&found);
-
-	if (!found)
-	{
-		active_table_shm_lock->lock = &(GetNamedLWLockTranche("disk_quota_active_table_shm_lock"))->lock;
-	}
-}
-
-/*
  * Fetch active table file size statistics.
  * If force is true, then fetch all the tables.
  */
@@ -230,7 +214,7 @@ get_active_tables_stats()
 								HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
 
 	/* Move active table from shared memory to local active table map */
-	LWLockAcquire(active_table_shm_lock->lock, LW_EXCLUSIVE);
+	LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
 
 	hash_seq_init(&iter, active_tables_map);
 
@@ -251,7 +235,7 @@ get_active_tables_stats()
 		hash_search(active_tables_map, active_table_file_entry, HASH_REMOVE, NULL);
 	}
 
-	LWLockRelease(active_table_shm_lock->lock);
+	LWLockRelease(diskquota_locks.active_table_lock);
 
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize = sizeof(Oid);
@@ -314,11 +298,11 @@ report_active_table_SmgrStat(SMgrRelation reln)
 	item.relfilenode = reln->smgr_rnode.node.relNode;
 	item.tablespaceoid = reln->smgr_rnode.node.spcNode;
 
-	LWLockAcquire(active_table_shm_lock->lock, LW_EXCLUSIVE);
+	LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
 	entry = hash_search(active_tables_map, &item, HASH_ENTER_NULL, &found);
 	if (entry && !found)
 		*entry = item;
-	LWLockRelease(active_table_shm_lock->lock);
+	LWLockRelease(diskquota_locks.active_table_lock);
 
 	if (!found && entry == NULL) {
 		/* We may miss the file size change of this relation at current refresh interval.*/

--- a/activetable.c
+++ b/activetable.c
@@ -23,13 +23,16 @@
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/relfilenodemap.h"
+#include "utils/syscache.h"
 
 #include "activetable.h"
+#include "pg_utils.h"
 
 HTAB *active_tables_map = NULL;
 static smgrcreate_hook_type prev_smgrcreate_hook = NULL;
 static smgrextend_hook_type prev_smgrextend_hook = NULL;
 static smgrtruncate_hook_type prev_smgrtruncate_hook = NULL;
+static smgrdounlinkall_hook_type prev_smgrdounlinkall_hook = NULL;
 static void active_table_hook_smgrcreate(SMgrRelation reln,
 							  ForkNumber forknum,
 							  bool isRedo);
@@ -41,8 +44,11 @@ static void active_table_hook_smgrextend(SMgrRelation reln,
 static void active_table_hook_smgrtruncate(SMgrRelation reln,
 							  ForkNumber forknum,
 							  BlockNumber blocknum);
+static void active_table_hook_smgrunlink(SMgrRelation *reln,
+                              int nrels,
+                              bool isRedo);
 
-static void report_active_table_SmgrStat(SMgrRelation reln);
+static void report_active_table_SmgrStat(SMgrRelation reln, ActiveType at);
 static HTAB* get_active_tables_stats(void);
 static HTAB* get_all_tables_stats(void);
 
@@ -65,6 +71,9 @@ init_active_table_hook(void)
 
 	prev_smgrtruncate_hook = smgrtruncate_hook;
 	smgrtruncate_hook = active_table_hook_smgrtruncate;
+
+	prev_smgrdounlinkall_hook = smgrdounlinkall_hook;
+	smgrdounlinkall_hook = active_table_hook_smgrunlink;
 }
 
 static void
@@ -72,7 +81,7 @@ active_table_hook_smgrcreate(SMgrRelation reln,
 							  pg_attribute_unused() ForkNumber forknum,
 							  pg_attribute_unused() bool isRedo)
 {
-	report_active_table_SmgrStat(reln);
+	report_active_table_SmgrStat(reln, AT_CREATE);
 }
 
 static void
@@ -82,7 +91,7 @@ active_table_hook_smgrextend(SMgrRelation reln,
 							  pg_attribute_unused() char *buffer,
 							  pg_attribute_unused() bool skipFsync)
 {
-	report_active_table_SmgrStat(reln);
+	report_active_table_SmgrStat(reln, AT_EXTEND);
 }
 
 static void
@@ -90,7 +99,18 @@ active_table_hook_smgrtruncate(SMgrRelation reln,
 							  pg_attribute_unused() ForkNumber forknum,
 							  pg_attribute_unused() BlockNumber blocknum)
 {
-	report_active_table_SmgrStat(reln);
+	report_active_table_SmgrStat(reln, AT_TRUNCATE);
+}
+
+static void active_table_hook_smgrunlink(SMgrRelation *reln,
+                                         pg_attribute_unused() int nrels,
+                                         pg_attribute_unused() bool isRedo)
+{
+	int i;
+	for (i = 0; i < nrels; i++)
+	{
+		report_active_table_SmgrStat(reln[i], AT_UNLINK);
+	}
 }
 
 /*
@@ -102,7 +122,7 @@ init_shm_worker_active_tables(void)
 	HASHCTL ctl;
 	memset(&ctl, 0, sizeof(ctl));
 
-	ctl.keysize = sizeof(DiskQuotaActiveTableEntry);
+	ctl.keysize = sizeof(RelFileNode);
 	ctl.entrysize = sizeof(DiskQuotaActiveTableEntry);
 	ctl.hash = tag_hash;
 
@@ -142,10 +162,10 @@ get_all_tables_stats()
 	HeapScanDesc relScan;
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(Oid);
+	ctl.keysize = sizeof(RelFileNode);
 	ctl.entrysize = sizeof(DiskQuotaActiveTableEntry);
 	ctl.hcxt = CurrentMemoryContext;
-	ctl.hash = oid_hash;
+	ctl.hash = tag_hash;
 
 	local_table_stats_map = hash_create("local table map with table size info",
 								1024,
@@ -159,6 +179,7 @@ get_all_tables_stats()
 	{
 		Oid relOid;
 		DiskQuotaActiveTableEntry *entry;
+		RelFileNode node;
 
 		Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tuple);
 		if (classForm->relkind != RELKIND_RELATION &&
@@ -170,11 +191,15 @@ get_all_tables_stats()
 		if (relOid < FirstNormalObjectId)
 			continue;
 
-		entry = (DiskQuotaActiveTableEntry *) hash_search(local_table_stats_map, &relOid, HASH_ENTER, NULL);
+		node.spcNode = MyDatabaseTableSpace;
+		node.dbNode = MyDatabaseId;
+		node.relNode = classForm->relfilenode;
 
-		entry->tableoid = relOid;
-		entry->tablesize = (Size) DatumGetInt64(DirectFunctionCall1(pg_total_relation_size,
-					ObjectIdGetDatum(relOid)));
+		entry = (DiskQuotaActiveTableEntry *) hash_search(local_table_stats_map, &node, HASH_ENTER, NULL);
+
+		entry->node = node;
+		entry->type = AT_EXTEND;
+		entry->tablesize = diskquota_get_table_size_by_oid(relOid);
 
 	}
 
@@ -183,7 +208,7 @@ get_all_tables_stats()
 
     return local_table_stats_map;	
 }
-/*
+/**
  * Get local active table with table oid and table size info.
  * This function first copies active table map from shared memory 
  * to local active table map with refilenode info. Then traverses
@@ -203,7 +228,7 @@ get_active_tables_stats()
 	Oid relOid;
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(DiskQuotaActiveTableFileEntry);
+	ctl.keysize = sizeof(RelFileNode);
 	ctl.entrysize = sizeof(DiskQuotaActiveTableFileEntry);
 	ctl.hcxt = CurrentMemoryContext;
 	ctl.hash = tag_hash;
@@ -223,25 +248,24 @@ get_active_tables_stats()
 		bool  found;
 		DiskQuotaActiveTableFileEntry *entry;
 
-		if (active_table_file_entry->dbid != MyDatabaseId)
+		if (active_table_file_entry->node.dbNode != MyDatabaseId)
 		{
 			continue;
 		}
 
 		/* Add the active table entry into local hash table*/
-		entry = hash_search(local_active_table_file_map, active_table_file_entry, HASH_ENTER, &found);
-		if (entry)
-			*entry = *active_table_file_entry;
-		hash_search(active_tables_map, active_table_file_entry, HASH_REMOVE, NULL);
+		entry = hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_ENTER, &found);
+		*entry = *active_table_file_entry;
+		hash_search(active_tables_map, &active_table_file_entry->node, HASH_REMOVE, &found);
 	}
 
 	LWLockRelease(diskquota_locks.active_table_lock);
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(Oid);
+	ctl.keysize = sizeof(RelFileNode);
 	ctl.entrysize = sizeof(DiskQuotaActiveTableEntry);
 	ctl.hcxt = CurrentMemoryContext;
-	ctl.hash = oid_hash;
+	ctl.hash = tag_hash;
 
 	local_active_table_stats_map = hash_create("local active table map with relfilenode info",
 								1024,
@@ -253,59 +277,184 @@ get_active_tables_stats()
 	/* scan whole local map, get the oid of each table and calculate the size of them */
 	while ((active_table_file_entry = (DiskQuotaActiveTableFileEntry *) hash_seq_search(&iter)) != NULL)
 	{
-		Size tablesize;
 		bool found;
-		
-		relOid = RelidByRelfilenode(active_table_file_entry->tablespaceoid, active_table_file_entry->relfilenode);
 
-		//TODO replace DirectFunctionCall1 by a new total relation size function, which could handle Invalid relOid
-		/* avoid to generate ERROR if relOid is not existed (i.e. table has been droped) */
-		PG_TRY();
+		switch (active_table_file_entry->tablestatus)
 		{
-			tablesize = (Size) DatumGetInt64(DirectFunctionCall1(pg_total_relation_size,
-						ObjectIdGetDatum(relOid)));
+			case TABLE_COMMIT_CREATE:
+			case TABLE_COMMIT_CHANGE:
+				relOid = RelidByRelfilenode(active_table_file_entry->node.spcNode,
+				                            active_table_file_entry->node.relNode);
+				if (relOid != InvalidOid) {
+					active_table_entry = hash_search(local_active_table_stats_map, &active_table_file_entry->node,
+					                                 HASH_ENTER, &found);
+					active_table_entry->node = active_table_file_entry->node;
+					active_table_entry->tablesize = diskquota_get_table_size_by_oid(relOid);
+					active_table_entry->type = AT_EXTEND;
+					hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_REMOVE, NULL);
+				} else {
+					active_table_file_entry->ispushedback = true;
+				}
+				break;
+			case TABLE_IN_TRANSX_CHANGE:
+			case TABLE_IN_TRANSX_CREATE:
+				active_table_entry = hash_search(local_active_table_stats_map, &active_table_file_entry->node,
+				                                 HASH_ENTER, &found);
+				active_table_entry->node = active_table_file_entry->node;
+				active_table_entry->tablesize = diskquota_get_table_size_by_relfilenode(&active_table_entry->node);
+				active_table_entry->namespace = active_table_file_entry->inXnamespace;
+				active_table_entry->owner = active_table_file_entry->inXowner;
+				active_table_entry->type = AT_EXTEND;
+				hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_REMOVE, NULL);
+				break;
+			case TABLE_COMMIT_DELETE:
+			case TABLE_IN_TRANSX_DELETE:
+				active_table_entry = hash_search(local_active_table_stats_map, &active_table_file_entry->node,
+				                                 HASH_ENTER, &found);
+				active_table_entry->node = active_table_file_entry->node;
+				active_table_entry->type = AT_UNLINK;
+				hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_REMOVE, NULL);
+				break;
+			default:
+				/* Unknown status of entry, ignore it*/
+				ereport(LOG, (errmsg("found an entry in unexpected status, table status is %d, relnode is %d", active_table_file_entry->tablestatus,
+					 active_table_file_entry->node.relNode)));
+				hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_REMOVE, NULL);
+				break;
+
 		}
-		PG_CATCH();
-		{
-			FlushErrorState();
-			tablesize = 0;
-		}
-		PG_END_TRY();
-		active_table_entry = hash_search(local_active_table_stats_map, &relOid, HASH_ENTER, &found);
-		active_table_entry->tableoid = relOid;
-		active_table_entry->tablesize = tablesize;
 	}
-	elog(DEBUG1, "active table number is:%ld", hash_get_num_entries(local_active_table_file_map));
+
+	/* If table is not found, it could be in transaction, so push back to share memory */
+
+	if (hash_get_num_entries(local_active_table_file_map) > 0)
+	{
+		bool  found;
+		DiskQuotaActiveTableFileEntry *entry;
+
+		/* traverse local active table map and rewrite them into share memory */
+		hash_seq_init(&iter, local_active_table_file_map);
+		LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
+
+		while ((active_table_file_entry = (DiskQuotaActiveTableFileEntry *) hash_seq_search(&iter)) != NULL)
+		{
+			entry = hash_search(active_tables_map, &active_table_file_entry->node, HASH_ENTER_NULL, &found);
+			if (entry)
+			{
+				*entry = *active_table_file_entry;
+			}
+		}
+		LWLockRelease(diskquota_locks.active_table_lock);
+	}
+
 	hash_destroy(local_active_table_file_map);
 	return local_active_table_stats_map;
 }
 
-/*
+/**
  *  Hook function in smgr to report the active table
  *  information and stroe them in active table shared memory
  *  diskquota worker will consuming these active tables and
  *  recalculate their file size to update diskquota model.
  */
 static void
-report_active_table_SmgrStat(SMgrRelation reln)
+report_active_table_SmgrStat(SMgrRelation reln, ActiveType at)
 {
-	DiskQuotaActiveTableFileEntry *entry;
-	DiskQuotaActiveTableFileEntry item;
+	DiskQuotaActiveTableFileEntry *entry = NULL;
 	bool found = false;
 
-	MemSet(&item, 0, sizeof(DiskQuotaActiveTableFileEntry));
-	item.dbid = reln->smgr_rnode.node.dbNode;
-	item.relfilenode = reln->smgr_rnode.node.relNode;
-	item.tablespaceoid = reln->smgr_rnode.node.spcNode;
+	/* ignore the system table relfilenode */
+	if (reln->smgr_rnode.node.relNode < FirstNormalObjectId)
+		return;
 
 	LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
-	entry = hash_search(active_tables_map, &item, HASH_ENTER_NULL, &found);
-	if (entry && !found)
-		*entry = item;
-	LWLockRelease(diskquota_locks.active_table_lock);
+	entry = hash_search(active_tables_map, &reln->smgr_rnode.node, HASH_ENTER_NULL, &found);
+	if (entry && !entry->ispushedback)
+	{
+		entry->node = reln->smgr_rnode.node;
+		switch (at)
+		{
+			case AT_EXTEND :
+			case AT_TRUNCATE :
+				entry->tablestatus = TABLE_COMMIT_CHANGE;
+				entry->inXnamespace = InvalidOid;
+				entry->inXowner = InvalidOid;
+				break;
+			case AT_CREATE:
+				entry->tablestatus = TABLE_COMMIT_CREATE;
+				entry->inXnamespace = InvalidOid;
+				entry->inXowner = InvalidOid; 
+				break;
+			case AT_UNLINK:
+				entry->tablestatus = TABLE_COMMIT_DELETE;
+				entry->inXnamespace = InvalidOid;
+				entry->inXowner = InvalidOid; 
+				break;
+			default:
+				entry->tablestatus = TABLE_UNKNOWN;
+				break;
+		}
 
-	if (!found && entry == NULL) {
+	}
+	/*
+	 * if the entry is still in active list and marked as un-committed,
+	 * this means the entry is only visible in transaction, and need to process here
+	 * TODO: this is time consuming, may need to let user to choose enable or disable
+	 */
+	else if (entry && found && entry->ispushedback)
+	{
+		Oid relOid;
+		HeapTuple tuple;
+		Form_pg_class rel;
+	
+		/* 
+		 * If the entry status is TABLE_NOT_FOUND, but its action type is AT_UNLINK. This means
+		 * the transaction is under committing or aborting, hence we just need ignore this active
+		 * entry and send its unlink status back to worker.
+		 */
+		if (at == AT_UNLINK)
+		{
+			entry->tablestatus = TABLE_IN_TRANSX_DELETE;
+		}
+		else
+		{
+			relOid = RelidByRelfilenode(entry->node.spcNode, entry->node.relNode);
+			tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relOid));
+			if (HeapTupleIsValid(tuple))
+			{
+				rel = (Form_pg_class) GETSTRUCT(tuple);
+				entry->inXnamespace = rel->relnamespace;
+				entry->inXowner = rel->relowner;
+				switch (at)
+				{
+				case AT_EXTEND :
+				case AT_TRUNCATE :
+					entry->tablestatus = TABLE_IN_TRANSX_CHANGE;
+					break;
+				case AT_CREATE:
+					entry->tablestatus = TABLE_IN_TRANSX_CREATE;
+					break;
+				default:
+					entry->tablestatus = TABLE_UNKNOWN;
+					break;
+				}
+				ReleaseSysCache(tuple);
+			}
+			else
+			{
+				ereport(LOG, (errmsg("Unknown database file with tablespace:relfilenode is %d:%d"
+									 ,entry->node.spcNode, entry->node.relNode)));
+				entry->tablestatus = TABLE_UNKNOWN;
+
+			}
+		}
+
+	}
+	else if (entry == NULL)
+	{
 		/* We may miss the file size change of this relation at current refresh interval.*/
 		ereport(WARNING, (errmsg("Share memory is not enough for active tables.")));
+
 	}
+	LWLockRelease(diskquota_locks.active_table_lock);
 }

--- a/activetable.h
+++ b/activetable.h
@@ -24,5 +24,4 @@ extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
 
 extern HTAB *active_tables_map;
-extern disk_quota_shared_state *active_table_shm_lock;
 #endif

--- a/activetable.h
+++ b/activetable.h
@@ -3,18 +3,45 @@
 
 #include "diskquota.h"
 
+/* Type of status of returned active table objects*/
+typedef enum
+{
+	TABLE_COMMIT_CHANGE = 0,
+	TABLE_COMMIT_CREATE = 1,
+	TABLE_COMMIT_DELETE = 2,
+	TABLE_IN_TRANSX_CHANGE = 3,
+	TABLE_IN_TRANSX_CREATE = 4,
+	TABLE_IN_TRANSX_DELETE = 5,
+	TABLE_NOT_FOUND = 6,
+	TABLE_UNKNOWN = 99,
+} ATStatus;
+
+typedef enum
+{
+	AT_CREATE = 1,
+	AT_EXTEND = 2,
+	AT_TRUNCATE = 3,
+	AT_UNLINK = 4,
+} ActiveType;
+
 /* Cache to detect the active table list */
 typedef struct DiskQuotaActiveTableFileEntry
 {
-	Oid         dbid;
-	Oid         relfilenode;
-	Oid         tablespaceoid;
+	RelFileNode     node;
+	Oid             inXnamespace;
+	Oid             inXowner;
+	ATStatus        tablestatus;
+	bool			ispushedback;
+
 } DiskQuotaActiveTableFileEntry;
 
 typedef struct DiskQuotaActiveTableEntry
 {
-	Oid     tableoid;
-	Size    tablesize;
+	RelFileNode     node;
+	int64           tablesize;
+	Oid             namespace;
+	Oid             owner;
+	ActiveType      type;
 } DiskQuotaActiveTableEntry;
 
 

--- a/diskquota--1.0.sql
+++ b/diskquota--1.0.sql
@@ -5,33 +5,37 @@
 
 CREATE SCHEMA diskquota;
 
-set search_path='diskquota';
-
 -- Configuration table
 create table diskquota.quota_config (targetOid oid, quotatype int, quotalimitMB int8, PRIMARY KEY(targetOid, quotatype));
 
 SELECT pg_catalog.pg_extension_config_dump('diskquota.quota_config', '');
 
-CREATE FUNCTION set_schema_quota(text, text)
+CREATE FUNCTION diskquota.set_schema_quota(text, text)
 RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE FUNCTION set_role_quota(text, text)
+CREATE FUNCTION diskquota.set_role_quota(text, text)
 RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE VIEW show_schema_quota_view AS
+CREATE FUNCTION diskquota.diskquota_start_worker()
+RETURNS void STRICT
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+CREATE VIEW diskquota.show_schema_quota_view AS
 SELECT pg_namespace.nspname as schema_name, pg_class.relnamespace as schema_oid, quota.quotalimitMB as quota_in_mb, sum(pg_total_relation_size(pg_class.oid)) as nspsize_in_bytes
 FROM pg_namespace, pg_class, diskquota.quota_config as quota
 WHERE pg_class.relnamespace = quota.targetoid and pg_class.relnamespace = pg_namespace.oid and quota.quotatype=0
 GROUP BY pg_class.relnamespace, pg_namespace.nspname, quota.quotalimitMB;
 
-CREATE VIEW show_role_quota_view AS
+CREATE VIEW diskquota.show_role_quota_view AS
 SELECT pg_roles.rolname as role_name, pg_class.relowner as role_oid, quota.quotalimitMB as quota_in_mb, sum(pg_total_relation_size(pg_class.oid)) as rolsize_in_bytes
 FROM pg_roles, pg_class, diskquota.quota_config as quota
 WHERE pg_class.relowner = quota.targetoid and pg_class.relowner = pg_roles.oid and quota.quotatype=1
 GROUP BY pg_class.relowner, pg_roles.rolname, quota.quotalimitMB;
 
-reset search_path;
+SELECT diskquota.diskquota_start_worker();
+DROP FUNCTION diskquota.diskquota_start_worker();

--- a/diskquota.c
+++ b/diskquota.c
@@ -14,18 +14,31 @@
  */
 #include "postgres.h"
 
+#include "access/tupdesc.h"
+#include "access/xact.h"
+#include "catalog/indexing.h"
 #include "catalog/namespace.h"
+#include "catalog/objectaccess.h"
 #include "catalog/pg_collation.h"
+#include "catalog/pg_database.h"
+#include "catalog/pg_extension.h"
+#include "catalog/pg_type.h"
+#include "commands/dbcommands.h"
+#include "commands/extension.h"
 #include "executor/spi.h"
 #include "miscadmin.h"
+#include "nodes/makefuncs.h"
 #include "pgstat.h"
 #include "postmaster/bgworker.h"
 #include "storage/ipc.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
+#include "utils/fmgroids.h"
 #include "utils/formatting.h"
+#include "utils/memutils.h"
 #include "utils/numeric.h"
-#include "utils/varlena.h"
+#include "utils/snapmgr.h"
+#include "utils/syscache.h"
 
 #include "activetable.h"
 #include "diskquota.h"
@@ -34,14 +47,15 @@ PG_MODULE_MAGIC;
 /* disk quota helper function */
 PG_FUNCTION_INFO_V1(set_schema_quota);
 PG_FUNCTION_INFO_V1(set_role_quota);
+PG_FUNCTION_INFO_V1(diskquota_start_worker);
 
 /* flags set by signal handlers */
 static volatile sig_atomic_t got_sighup = false;
 static volatile sig_atomic_t got_sigterm = false;
+static volatile sig_atomic_t got_sigusr1 = false;
 
 /* GUC variables */
 int	diskquota_naptime = 0;
-char *diskquota_monitored_database_list = NULL;
 int diskquota_max_active_tables = 0;
 
 typedef struct DiskQuotaWorkerEntry DiskQuotaWorkerEntry;
@@ -49,12 +63,17 @@ typedef struct DiskQuotaWorkerEntry DiskQuotaWorkerEntry;
 /* disk quota worker info used by launcher to manage the worker processes. */
 struct DiskQuotaWorkerEntry
 {
-	char dbname[NAMEDATALEN];
+	Oid dbid;
+	int pid; /* worker pid */
 	BackgroundWorkerHandle *handle;
 };
 
+DiskQuotaLocks diskquota_locks;
+volatile MessageBox * message_box = NULL;
 /* using hash table to support incremental update the table size entry.*/
 static HTAB *disk_quota_worker_map = NULL;
+static object_access_hook_type next_object_access_hook;
+static int num_db = 0;
 
 /* functions of disk quota*/
 void _PG_init(void);
@@ -64,11 +83,20 @@ void disk_quota_launcher_main(Datum);
 
 static void disk_quota_sigterm(SIGNAL_ARGS);
 static void disk_quota_sighup(SIGNAL_ARGS);
-static List *get_database_list(void);
 static int64 get_size_in_mb(char *str);
-static void refresh_worker_list(void);
 static void set_quota_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type);
-static int start_worker(char* dbname);
+static int start_worker_by_dboid(Oid dbid);
+static void create_monitor_db_table();
+static inline void exec_simple_utility(const char *sql);
+static void exec_simple_spi(const char *sql, int expected_code);
+static bool add_db_to_config(Oid dbid);
+static void del_db_from_config(Oid dbid);
+static void process_message_box();
+static void process_message_box_internal(MessageResult *code);
+static void dq_object_access_hook(ObjectAccessType access, Oid classId,
+				Oid objectId, int subId, void *arg);
+static const char *err_code_to_err_message(MessageResult code);
+extern void diskquota_invalidate_db(Oid dbid);
 
 /*
  * Entrypoint of diskquota module.
@@ -81,6 +109,9 @@ void
 _PG_init(void)
 {
 	BackgroundWorker worker;
+	if (!process_shared_preload_libraries_in_progress)
+		elog(ERROR, "It is too late to load diskquota.so :"
+			   " please put diskquota into 'shared_preload_libraries' in GUC");
 
 	init_disk_quota_shmem();
 	init_disk_quota_enforcement();
@@ -100,19 +131,6 @@ _PG_init(void)
 							NULL,
 							NULL);
 
-	if (!process_shared_preload_libraries_in_progress)
-		return;
-
-	DefineCustomStringVariable("diskquota.monitor_databases",
-								gettext_noop("database list with disk quota monitored."),
-								NULL,
-								&diskquota_monitored_database_list,
-								"",
-								PGC_SIGHUP, GUC_LIST_INPUT,
-								NULL,
-								NULL,
-								NULL);
-
 	DefineCustomIntVariable("diskquota.max_active_tables",
 							"max number of active tables monitored by disk-quota",
 							NULL,
@@ -126,6 +144,10 @@ _PG_init(void)
 							NULL,
 							NULL);
 
+	/* Add dq_object_access_hook to handle drop extension event.*/
+	next_object_access_hook = object_access_hook;
+	object_access_hook = dq_object_access_hook;
+
 	/* set up common data for diskquota launcher worker */
 	worker.bgw_flags = BGWORKER_SHMEM_ACCESS |
 		BGWORKER_BACKEND_DATABASE_CONNECTION;
@@ -135,7 +157,7 @@ _PG_init(void)
 	sprintf(worker.bgw_function_name, "disk_quota_launcher_main");
 	worker.bgw_notify_pid = 0;
 
-	snprintf(worker.bgw_name, BGW_MAXLEN, "disk quota launcher");
+	snprintf(worker.bgw_name, BGW_MAXLEN, "[diskquota] - launcher");
 
 	RegisterBackgroundWorker(&worker);
 }
@@ -179,6 +201,21 @@ disk_quota_sighup(SIGNAL_ARGS)
 	errno = save_errno;
 }
 
+/*
+ * Signal handler for SIGUSR1
+ * 		Set a flag to tell the launcher to handle message box
+ */
+static void
+disk_quota_sigusr1(SIGNAL_ARGS)
+{
+	int save_errno = errno;
+	got_sigusr1 = true;
+
+	if (MyProc)
+		SetLatch(&MyProc->procLatch);
+
+	errno = save_errno;
+}
 
 /* ---- Functions for disk quota worker process ---- */
 
@@ -189,12 +226,13 @@ disk_quota_sighup(SIGNAL_ARGS)
 void
 disk_quota_worker_main(Datum main_arg)
 {
-	char *dbname=MyBgworkerEntry->bgw_name;
-	elog(LOG,"start disk quota worker process to monitor database:%s", dbname);
+	char *dbname = MyBgworkerEntry->bgw_extra;
+	elog(LOG,"[diskquota]:start disk quota worker process to monitor database:%s", dbname);
 
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, disk_quota_sighup);
 	pqsignal(SIGTERM, disk_quota_sigterm);
+	pqsignal(SIGUSR1, disk_quota_sigusr1);
 
 	/* We're now ready to receive signals */
 	BackgroundWorkerUnblockSignals();
@@ -241,7 +279,220 @@ disk_quota_worker_main(Datum main_arg)
 		}
 	}
 
-	proc_exit(1);
+	diskquota_invalidate_db(MyDatabaseId);
+	proc_exit(0);
+}
+
+/**
+ * create table to record the list of monitored databases
+ * we need a place to store the database with diskquota enabled
+ * (via CREATE EXTENSION diskquota). Currently, we store them into
+ * heap table in diskquota_namespace schema of postgres database.
+ * When database restarted, diskquota laucher will start worker processes
+ * for these databases.
+ */
+static void
+create_monitor_db_table()
+{
+	const char *sql;
+	sql = "create schema if not exists diskquota_namespace;"
+		"create table if not exists diskquota_namespace.database_list(dbid oid not null unique);";
+	exec_simple_utility(sql);
+}
+
+static inline void
+exec_simple_utility(const char *sql)
+{
+	StartTransactionCommand();
+	exec_simple_spi(sql, SPI_OK_UTILITY);
+	CommitTransactionCommand();
+}
+
+static void
+exec_simple_spi(const char *sql, int expected_code)
+{
+	int ret;
+
+	ret = SPI_connect();
+	if (ret != SPI_OK_CONNECT)
+		elog(ERROR, "connect error, code=%d", ret);
+	PushActiveSnapshot(GetTransactionSnapshot());
+	ret = SPI_execute(sql, false, 0);
+	if (ret != expected_code)
+		elog(ERROR, "sql:'%s', code %d", sql, ret);
+	SPI_finish();
+	PopActiveSnapshot();
+}
+
+static bool
+is_valid_dbid(Oid dbid)
+{
+    HeapTuple       tuple;
+
+    if (dbid == InvalidOid)
+            return false;
+    tuple = SearchSysCache1(DATABASEOID, ObjectIdGetDatum(dbid));
+    if (!HeapTupleIsValid(tuple))
+            return false;
+    ReleaseSysCache(tuple);
+    return true;
+}
+/*
+ * in early stage, start all worker processes of diskquota-enabled databases
+ * from diskquota_namespace.database_list
+ */
+static void
+start_workers_from_dblist()
+{
+	TupleDesc tupdesc;
+	Oid fake_dbid[128];
+	int fake_count = 0;
+	int num = 0;
+	int ret;
+	int i;
+	StartTransactionCommand();
+	PushActiveSnapshot(GetTransactionSnapshot());
+	ret = SPI_connect();
+	if (ret != SPI_OK_CONNECT)
+		elog(ERROR, "connect error, code=%d", ret);
+	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", false, 0);
+	if (ret != SPI_OK_SELECT)
+		elog(ERROR, "select diskquota_namespace.database_list");
+	tupdesc = SPI_tuptable->tupdesc;
+	if (tupdesc->natts != 1 || tupdesc->attrs[0].atttypid != OIDOID)
+		elog(ERROR, "[diskquota] table database_list corrupt, laucher will exit");
+
+	for (i = 0; num < SPI_processed; i++)
+	{
+		HeapTuple tup;
+		Oid dbid;
+		Datum dat;
+		bool isnull;
+
+	    tup	= SPI_tuptable->vals[i];
+		dat = SPI_getbinval(tup, tupdesc, 1, &isnull);
+		if (isnull)
+		{
+			elog(ERROR, "dbid cann't be null");
+		}
+		dbid = DatumGetObjectId(dat);
+		if (!is_valid_dbid(dbid))
+		{
+			fake_dbid[fake_count++] = dbid;
+			continue;
+		}
+		if (start_worker_by_dboid(dbid) < 1)
+		{
+			elog(WARNING, "[diskquota]: start worker process of database(%d) failed", dbid);
+		}
+		num++;
+	}
+	num_db = num;
+	SPI_finish();
+	PopActiveSnapshot();
+	CommitTransactionCommand();
+
+	/*  TODO: clean invalid database */
+
+}
+
+static bool
+add_db_to_config(Oid dbid)
+{
+	StringInfoData str;
+
+	initStringInfo(&str);
+	appendStringInfo(&str, "insert into diskquota_namespace.database_list values(%d);", dbid);
+	exec_simple_spi(str.data, SPI_OK_INSERT);
+	return true;
+}
+
+static void
+del_db_from_config(Oid dbid)
+{
+	StringInfoData str;
+
+	initStringInfo(&str);
+	appendStringInfo(&str, "delete from diskquota_namespace.database_list where dbid=%d;", dbid);
+	exec_simple_spi(str.data, SPI_OK_DELETE);
+}
+
+/*
+ * When drop exention database, diskquota laucher will receive a message
+ * to kill the diskquota worker process which monitoring the target database. 
+ */
+static void
+try_kill_db_worker(Oid dbid)
+{
+	DiskQuotaWorkerEntry *hash_entry;
+	bool found;
+	hash_entry = (DiskQuotaWorkerEntry *)hash_search(disk_quota_worker_map,
+											(void *)&dbid,
+											HASH_REMOVE, &found);
+	if (found)
+	{
+		BackgroundWorkerHandle *handle;
+		handle = hash_entry->handle;
+		TerminateBackgroundWorker(handle);
+		pfree(handle);
+	}
+}
+
+/*
+ * handle create extension diskquota
+ * if we know the exact error which caused failure,
+ * we set it, and error out
+ */
+static void
+on_add_db(Oid dbid, MessageResult *code)
+{
+	if (num_db >= 10)
+	{
+		*code = ERR_EXCEED;
+		elog(ERROR, "[diskquota] too database to monitor");
+	}
+	if (!is_valid_dbid(dbid))
+	{
+		*code = ERR_INVALID_DBID;
+		elog(ERROR, "[diskquota] invalid database oid");
+	}
+
+	/*
+	 * add dbid to diskquota_namespace.database_list
+	 * set *code to ERR_ADD_TO_DB if any error occurs
+	 */
+	PG_TRY();
+	{
+		add_db_to_config(dbid);
+	}
+	PG_CATCH();
+	{
+		*code = ERR_ADD_TO_DB;
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	if (start_worker_by_dboid(dbid) < 1)
+	{
+		*code = ERR_START_WORKER;
+		elog(ERROR, "[diskquota] failed to start worker - dbid=%d", dbid);
+	}
+}
+
+/*
+ * handle message: drop extension diskquota
+ * do our best to:
+ * 1. kill the associated worker process
+ * 2. delete dbid from diskquota_namespace.database_list
+ * 3. invalidate black-map entries from shared memory
+ */
+static void
+on_del_db(Oid dbid)
+{
+	if (dbid == InvalidOid)
+		return;
+	try_kill_db_worker(dbid);
+	del_db_from_config(dbid);
 }
 
 /* ---- Functions for lancher process ---- */
@@ -252,44 +503,32 @@ disk_quota_worker_main(Datum main_arg)
 void
 disk_quota_launcher_main(Datum main_arg)
 {
-	List *dblist;
-	ListCell *cell;
 	HASHCTL		hash_ctl;
-	int db_count = 0;
 
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, disk_quota_sighup);
 	pqsignal(SIGTERM, disk_quota_sigterm);
+	pqsignal(SIGUSR1, disk_quota_sigusr1);
 
 	/* We're now ready to receive signals */
 	BackgroundWorkerUnblockSignals();
 
+	message_box->launcher_pid = MyProcPid;
+	/* Connect to our database */
+	BackgroundWorkerInitializeConnection("postgres", NULL, 0);
+	create_monitor_db_table();
+
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.keysize = NAMEDATALEN;
+	hash_ctl.keysize = sizeof(Oid);
 	hash_ctl.entrysize = sizeof(DiskQuotaWorkerEntry);
+	hash_ctl.hash = oid_hash;
 
 	disk_quota_worker_map = hash_create("disk quota worker map",
-										  1024,
-										  &hash_ctl,
-										  HASH_ELEM);
+						  1024,
+						  &hash_ctl,
+						  HASH_ELEM | HASH_FUNCTION);
 
-	dblist = get_database_list();
-	elog(LOG,"diskquota launcher started");
-	foreach(cell, dblist)
-	{
-		char *db_name;
-
-		if (db_count >= 10)
-			break;
-		db_name = (char *)lfirst(cell);
-		if (db_name == NULL || *db_name == '\0')
-		{
-			elog(LOG, "invalid db name='%s' in diskquota.monitor_databases", db_name);
-			continue;
-		}
-		start_worker(db_name);
-		db_count++;
-	}
+	start_workers_from_dblist();
 	/*
 	 * Main loop: do this until the SIGTERM handler tells us to terminate
 	 */
@@ -311,7 +550,12 @@ disk_quota_launcher_main(Datum main_arg)
 		/* emergency bailout if postmaster has died */
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);
-
+		/* process message box, now someone is holding message_box_lock */
+		if (got_sigusr1)
+		{
+			got_sigusr1 = false;
+			process_message_box();
+		}
 		/*
 		 * In case of a SIGHUP, just reload the configuration.
 		 */
@@ -319,8 +563,6 @@ disk_quota_launcher_main(Datum main_arg)
 		{
 			got_sighup = false;
 			ProcessConfigFile(PGC_SIGHUP);
-			/* terminate not monitored worker process and start new worker process */
-			refresh_worker_list();
 		}
 
 	}
@@ -329,138 +571,19 @@ disk_quota_launcher_main(Datum main_arg)
 }
 
 /*
- * database list found in GUC diskquota.monitored_database_list
- */
-static List *
-get_database_list(void)
-{
-	List	   *dblist = NULL;
-	char       *dbstr;
-
-	dbstr = pstrdup(diskquota_monitored_database_list);
-
-	if (!SplitIdentifierString(dbstr, ',', &dblist))
-	{
-		elog(WARNING, "cann't get database list from guc:'%s'", diskquota_monitored_database_list);
-		return NULL;
-	}
-	return dblist;
-}
-
-/*
- * When launcher receive SIGHUP, it will call refresh_worker_list()
- * to terminate worker processes whose connected database no longer need
- * to be monitored, and start new worker processes to watch new database.
- */
-static void
-refresh_worker_list(void)
-{
-	List *monitor_dblist;
-	List *removed_workerlist;
-	ListCell *cell;
-	ListCell *removed_workercell;
-	bool flag = false;
-	bool found;
-	DiskQuotaWorkerEntry *hash_entry;
-	HASH_SEQ_STATUS status;
-	int db_count = 0;
-
-	removed_workerlist = NIL;
-	monitor_dblist = get_database_list();
-	/*
-	 * refresh the worker process based on the configuration file change.
-	 * step 1 is to terminate worker processes whose connected database
-	 * not in monitor database list.
-	 */
-	elog(LOG,"Refresh monitored database list.");
-	hash_seq_init(&status, disk_quota_worker_map);
-
-	while ((hash_entry = (DiskQuotaWorkerEntry*) hash_seq_search(&status)) != NULL)
-	{
-		flag = false;
-		foreach(cell, monitor_dblist)
-		{
-			char *db_name;
-
-			if (db_count >= 10)
-				break;
-			db_name = (char *)lfirst(cell);
-			if (db_name == NULL || *db_name == '\0')
-			{
-				continue;
-			}
-			if (strcmp(db_name, hash_entry->dbname) == 0 )
-			{
-				flag = true;
-				break;
-			}
-		}
-		if (!flag)
-		{
-			removed_workerlist = lappend(removed_workerlist, hash_entry->dbname);
-		}
-	}
-
-	foreach(removed_workercell, removed_workerlist)
-	{
-		DiskQuotaWorkerEntry* workerentry;
-		char *db_name;
-		BackgroundWorkerHandle *handle;
-
-		db_name = (char *)lfirst(removed_workercell);
-
-		workerentry = (DiskQuotaWorkerEntry *)hash_search(disk_quota_worker_map,
-															(void *)db_name,
-															HASH_REMOVE, &found);
-		if(found)
-		{
-			handle = workerentry->handle;
-			TerminateBackgroundWorker(handle);
-		}
-	}
-
-	/* step 2: start new worker which first appears in monitor database list. */
-	db_count = 0;
-	foreach(cell, monitor_dblist)
-	{
-		DiskQuotaWorkerEntry* workerentry;
-		char *db_name;
-		pid_t pid;
-
-		if (db_count >= 10)
-			break;
-		db_name = (char *)lfirst(cell);
-		if (db_name == NULL || *db_name == '\0')
-		{
-			continue;
-		}
-		workerentry = (DiskQuotaWorkerEntry *)hash_search(disk_quota_worker_map,
-															(void *)db_name,
-															HASH_FIND, &found);
-		if (found)
-		{
-			/* in case worker is not in BGWH_STARTED mode, restart it. */
-			if (GetBackgroundWorkerPid(workerentry->handle, &pid) != BGWH_STARTED)
-				start_worker(db_name);
-		}
-		else
-		{
-			start_worker(db_name);
-		}
-	}
-}
-
-/*
  * Dynamically launch an disk quota worker process.
  */
 static int
-start_worker(char* dbname)
+start_worker_by_dboid(Oid dbid)
 {
 	BackgroundWorker worker;
 	BackgroundWorkerHandle *handle;
 	BgwHandleStatus status;
-	pid_t		pid;
+	MemoryContext old_ctx;
+	char *dbname;
+	pid_t pid;
 	bool found;
+	bool ok;
 	DiskQuotaWorkerEntry* workerentry;
 
 	memset(&worker, 0, sizeof(BackgroundWorker));
@@ -470,16 +593,22 @@ start_worker(char* dbname)
 	worker.bgw_restart_time = BGW_NEVER_RESTART;
 	sprintf(worker.bgw_library_name, "diskquota");
 	sprintf(worker.bgw_function_name, "disk_quota_worker_main");
-	snprintf(worker.bgw_name, BGW_MAXLEN, "%s", dbname);
+
+	dbname = get_database_name(dbid);
+	Assert(dbname != NULL);
+	snprintf(worker.bgw_name, sizeof(worker.bgw_name), "[diskquota] %s", dbname);
+	snprintf(worker.bgw_extra, sizeof(worker.bgw_extra), "%s", dbname);
+	pfree(dbname);
 	/* set bgw_notify_pid so that we can use WaitForBackgroundWorkerStartup */
 	worker.bgw_notify_pid = MyProcPid;
 	worker.bgw_main_arg = (Datum) 0;
 
-	if (!RegisterDynamicBackgroundWorker(&worker, &handle))
+	old_ctx = MemoryContextSwitchTo(TopMemoryContext);
+	ok = RegisterDynamicBackgroundWorker(&worker, &handle);
+	MemoryContextSwitchTo(old_ctx);
+	if (!ok)
 		return -1;
-
 	status = WaitForBackgroundWorkerStartup(handle, &pid);
-
 	if (status == BGWH_STOPPED)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
@@ -490,15 +619,17 @@ start_worker(char* dbname)
 				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
 			  errmsg("cannot start background processes without postmaster"),
 				 errhint("Kill all remaining database processes and restart the database.")));
+
 	Assert(status == BGWH_STARTED);
 
 	/* put the worker handle into the worker map */
 	workerentry = (DiskQuotaWorkerEntry *)hash_search(disk_quota_worker_map,
-														(void *)dbname,
+														(void *)&dbid,
 														HASH_ENTER, &found);
 	if (!found)
 	{
 		workerentry->handle = handle;
+		workerentry->pid = pid;
 	}
 
 	return pid;
@@ -765,4 +896,168 @@ get_size_in_mb(char *str)
 											   NumericGetDatum(num)));
 
 	return result;
+}
+
+/*
+ * trigger start diskquota worker when create extension diskquota
+ * This function is called at backend side, and will send message to 
+ * diskquota launcher. Luacher process is responsible for starting the real
+ * diskquota worker process.
+ */
+Datum
+diskquota_start_worker(PG_FUNCTION_ARGS)
+{
+	int rc;
+	elog(LOG, "[diskquota]:DB = %d, MyProc=%p launcher pid=%d", MyDatabaseId, MyProc, message_box->launcher_pid);
+	LWLockAcquire(diskquota_locks.message_box_lock, LW_EXCLUSIVE);
+	message_box->req_pid = MyProcPid;
+	message_box->cmd = CMD_CREATE_EXTENSION;
+	message_box->result = ERR_PENDING;
+	message_box->data[0] = MyDatabaseId;
+	/* setup sig handler to receive message */
+	rc = kill(message_box->launcher_pid, SIGUSR1);
+	if (rc == 0)
+	{
+		int count = 120; /* wait time 12 secs */
+		while(count-- > 0)
+		{
+			rc = WaitLatch(&MyProc->procLatch,
+						   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+						   100L, PG_WAIT_EXTENSION);
+			if (rc & WL_POSTMASTER_DEATH)
+				break;
+			ResetLatch(&MyProc->procLatch);
+			if (message_box->result != ERR_PENDING)
+				break;
+		}
+	}
+	message_box->req_pid = 0;
+	LWLockRelease(diskquota_locks.message_box_lock);
+	if (message_box->result != ERR_OK)
+		elog(ERROR, "%s", err_code_to_err_message((MessageResult)message_box->result));
+	PG_RETURN_VOID();
+}
+
+static void
+process_message_box_internal(MessageResult *code)
+{
+	Assert(message_box->launcher_pid == MyProcPid);
+	switch (message_box->cmd)
+	{
+		case CMD_CREATE_EXTENSION:
+			on_add_db(message_box->data[0], code);
+			num_db++;
+			break;
+		case CMD_DROP_EXTENSION:
+			on_del_db(message_box->data[0]);
+			num_db--;
+			break;
+		default:
+			elog(LOG, "[diskquota]:unsupported message cmd=%d", message_box->cmd);
+			*code = ERR_UNKNOWN;
+			break;
+	}
+}
+
+/*
+ * this function is called by launcher process to handle message from other backend 
+ * processes which call CREATE/DROP EXTENSION diskquota; It must be able to catch errors,
+ * and return an error code back to the backend process.
+ */
+static void
+process_message_box()
+{
+	MessageResult code = ERR_UNKNOWN;
+	int old_num_db = num_db;
+	if (message_box->req_pid == 0)
+		return;
+	elog(LOG, "[launcher]: received message");
+	PG_TRY();
+	{
+		StartTransactionCommand();
+		process_message_box_internal(&code);
+		CommitTransactionCommand();
+		code = ERR_OK;
+	}
+	PG_CATCH();
+	{
+		error_context_stack = NULL;
+		HOLD_INTERRUPTS();
+		AbortCurrentTransaction();
+		FlushErrorState();
+		RESUME_INTERRUPTS();
+		num_db = old_num_db;
+	}
+	PG_END_TRY();
+
+	message_box->result = (int)code;
+}
+
+/*
+ * This hook is used to handle drop extension diskquota event
+ * It will send CMD_DROP_EXTENSION message to diskquota laucher.
+ * Laucher will terminate the corresponding worker process and
+ * remove the dbOid from the database_list table.
+ */
+static void
+dq_object_access_hook(ObjectAccessType access, Oid classId,
+			Oid objectId, int subId, void *arg)
+{
+	Oid oid;
+	int rc;
+	if (access != OAT_DROP || classId != ExtensionRelationId)
+		goto out;
+	oid = get_extension_oid("diskquota", true);
+	if (oid != objectId)
+		goto out;
+	/*
+	 * invoke drop extension diskquota
+	 * 1. stop bgworker for MyDatabaseId
+	 * 2. remove dbid from diskquota_namespace.database_list in postgres
+	 */
+	LWLockAcquire(diskquota_locks.message_box_lock, LW_EXCLUSIVE);
+	message_box->req_pid = MyProcPid;
+	message_box->cmd = CMD_DROP_EXTENSION;
+	message_box->result = ERR_PENDING;
+	message_box->data[0] = MyDatabaseId;
+	rc = kill(message_box->launcher_pid, SIGUSR1);
+	if (rc == 0)
+	{
+		int count = 120; /* wait time 12 secs*/
+		while(count-- >0)
+		{
+			rc = WaitLatch(&MyProc->procLatch,
+						   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+						   100L, PG_WAIT_EXTENSION);
+			if (rc & WL_POSTMASTER_DEATH)
+				break;
+			ResetLatch(&MyProc->procLatch);
+			if (message_box->result != ERR_PENDING)
+				break;
+		}
+	}
+	message_box->req_pid = 0;
+	LWLockRelease(diskquota_locks.message_box_lock);
+	if (message_box->result != ERR_OK)
+		elog(ERROR, "[diskquota] %s", err_code_to_err_message((MessageResult)message_box->result));
+	elog(LOG, "[diskquota] DROP EXTENTION diskquota; OK");
+
+out:
+	if (next_object_access_hook)
+		(*next_object_access_hook)(access, classId, objectId,
+				subId, arg);
+}
+
+static const char *err_code_to_err_message(MessageResult code)
+{
+	switch (code)
+	{
+		case ERR_PENDING: return "ERR_PENDING";
+		case ERR_OK: return "NO ERROR";
+		case ERR_EXCEED: return "too many database to monitor";
+		case ERR_ADD_TO_DB: return "add dbid to database_list failed";
+		case ERR_START_WORKER: return "start worker failed";
+		case ERR_INVALID_DBID: return "invalid dbid";
+		default: return "unknown error";
+	}
 }

--- a/diskquota.c
+++ b/diskquota.c
@@ -163,8 +163,6 @@ _PG_init(void)
 	snprintf(worker.bgw_name, BGW_MAXLEN, "[diskquota] - launcher");
 
 	RegisterBackgroundWorker(&worker);
-
-	elog(LOG, "INIT FINISH");
 }
 
 void
@@ -527,7 +525,6 @@ disk_quota_launcher_main(Datum main_arg)
 	hash_ctl.keysize = sizeof(Oid);
 	hash_ctl.entrysize = sizeof(DiskQuotaWorkerEntry);
 	hash_ctl.hash = oid_hash;
-	elog(LOG,"diskquota launcher starting");
 
 	disk_quota_worker_map = hash_create("disk quota worker map",
 						  1024,

--- a/diskquota.h
+++ b/diskquota.h
@@ -9,13 +9,64 @@ typedef enum
 	ROLE_QUOTA
 } QuotaType;
 
-typedef struct
+struct DiskQuotaLocks
 {
-	LWLock	   *lock;		/* protects shared memory of blackMap */
-} disk_quota_shared_state;
+	LWLock *active_table_lock;
+	LWLock *black_map_lock;
+	LWLock *message_box_lock;
+};
+typedef struct DiskQuotaLocks DiskQuotaLocks;
+
+/*
+ * MessageBox is used to store a message for communication between
+ * the diskquota launcher process and backends.
+ * When backend create an extension, it send a message to launcher
+ * to start the diskquota worker process and write the corresponding
+ * dbOid into diskquota database_list table in postgres database.
+ * When backend drop an extension, it will send a message to launcher
+ * to stop the diskquota worker process and remove the dbOid from diskquota
+ * database_list table as well.
+ */
+struct MessageBox
+{
+	int launcher_pid;
+	int req_pid;		/* pid of the request process */
+	int cmd;			/* message command type, see MessageCommand */
+	int result;			/* message result writen by launcher, see MessageResult */
+	int data[4];		/* for create/drop extension diskquota, data[0] is dbid */
+};
+
+enum MessageCommand
+{
+	CMD_CREATE_EXTENSION = 1,
+	CMD_DROP_EXTENSION,
+};
+
+enum MessageResult
+{
+	ERR_PENDING = 0,
+	ERR_OK,
+	/* the number of database exceeds the maximum */
+	ERR_EXCEED,
+	/* add the dbid to diskquota_namespace.database_list failed */
+	ERR_ADD_TO_DB,
+	/* cann't start worker process */
+	ERR_START_WORKER,
+	/* invalid dbid */
+	ERR_INVALID_DBID,
+	ERR_UNKNOWN,
+};
+
+typedef struct MessageBox MessageBox;
+typedef enum MessageCommand MessageCommand;
+typedef enum MessageResult MessageResult;
+
+extern DiskQuotaLocks diskquota_locks;
+extern volatile MessageBox *message_box;
 
 /* enforcement interface*/
 extern void init_disk_quota_enforcement(void);
+extern void diskquota_invalidate_db(Oid dbid);
 
 /* quota model interface*/
 extern void init_disk_quota_shmem(void);
@@ -27,7 +78,6 @@ extern bool quota_check_common(Oid reloid);
 extern void init_disk_quota_hook(void);
 
 extern int   diskquota_naptime;
-extern char *diskquota_monitored_database_list;
 extern int   diskquota_max_active_tables;
 
 #endif

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -2,5 +2,6 @@ test: prepare
 test: test_role test_schema test_drop_table test_column test_copy test_update test_toast test_truncate test_reschema test_temp_role test_rename
 test: test_partition
 test: test_vacuum
+test: test_extension
 test: clean
 

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -2,6 +2,7 @@ test: prepare
 test: test_role test_schema test_drop_table test_column test_copy test_update test_toast test_truncate test_reschema test_temp_role test_rename
 test: test_partition
 test: test_vacuum
+test: test_transaction
 test: test_extension
 test: clean
 

--- a/expected/test_extension.out
+++ b/expected/test_extension.out
@@ -1,0 +1,272 @@
+CREATE DATABASE dbx0 ;
+CREATE DATABASE dbx1 ;
+CREATE DATABASE dbx2 ;
+CREATE DATABASE dbx3 ;
+CREATE DATABASE dbx4 ;
+CREATE DATABASE dbx5 ;
+CREATE DATABASE dbx6 ;
+CREATE DATABASE dbx7 ;
+CREATE DATABASE dbx8 ;
+CREATE DATABASE dbx9 ;
+CREATE DATABASE dbx10 ;
+show max_worker_processes;
+ max_worker_processes 
+----------------------
+ 12
+(1 row)
+
+\! sleep 4
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+2
+\c dbx0
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+3
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx1
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+4
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx2
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+5
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx3
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+6
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx4
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+7
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx5
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+8
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx6
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+9
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx7
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+10
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx8
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+11
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx9
+CREATE EXTENSION diskquota;
+ERROR:  too many database to monitor
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+11
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ERROR:  schema "diskquota" does not exist
+LINE 1: SELECT diskquota.set_schema_quota('SX', '1MB');
+               ^
+INSERT INTO SX.a values(generate_series(0, 10000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+\c dbx10
+CREATE EXTENSION diskquota;
+ERROR:  too many database to monitor
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+11
+\c dbx0
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+10
+\c dbx1
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+9
+\c dbx2
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+8
+\c dbx3
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+7
+\c dbx4
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+6
+\c dbx5
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+5
+\c dbx6
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+4
+\c dbx7
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+3
+\c dbx8
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+2
+\c dbx9
+DROP EXTENSION diskquota;
+ERROR:  extension "diskquota" does not exist
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+2
+\c dbx10
+DROP EXTENSION diskquota;
+ERROR:  extension "diskquota" does not exist
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+2
+\c postgres
+DROP DATABASE dbx0 ;
+DROP DATABASE dbx1 ;
+DROP DATABASE dbx2 ;
+DROP DATABASE dbx3 ;
+DROP DATABASE dbx4 ;
+DROP DATABASE dbx5 ;
+DROP DATABASE dbx6 ;
+DROP DATABASE dbx7 ;
+DROP DATABASE dbx8 ;
+DROP DATABASE dbx9 ;
+DROP DATABASE dbx10 ;

--- a/expected/test_transaction.out
+++ b/expected/test_transaction.out
@@ -1,0 +1,97 @@
+-- Test schema
+create schema ts1;
+select diskquota.set_schema_quota('ts1', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+BEGIN;
+create table ts1.a(i int);
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+ERROR:  schema's disk space quota exceeded with name:ts1
+END;
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+BEGIN;
+create table ts1.a(i int);
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+create table ts1.a2(i int);
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+END;
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+ERROR:  schema's disk space quota exceeded with name:ts1
+BEGIN;
+-- expect insert fail
+insert into ts1.a2 select generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:ts1
+END;
+BEGIN;
+drop table ts1.a;
+ABORT;
+select pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+BEGIN;
+-- expect insert fail
+insert into ts1.a2 select generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:ts1
+END;
+BEGIN;
+drop table ts1.a;
+END;
+select pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+BEGIN;
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+END;
+BEGIN;
+create table ts1.a(i int);
+END;
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+ERROR:  schema's disk space quota exceeded with name:ts1
+BEGIN;
+truncate table ts1.a;
+truncate table ts1.a2;
+savepoint p1;
+drop table ts1.a;
+rollback to p1;
+END;
+select pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+BEGIN;
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+ERROR:  schema's disk space quota exceeded with name:ts1
+END;
+drop schema ts1 CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table ts1.a2
+drop cascades to table ts1.a

--- a/pg_utils.c
+++ b/pg_utils.c
@@ -1,0 +1,96 @@
+/* -------------------------------------------------------------------------
+ *
+ * pg_utils.c
+ *
+ * This code is utils for detecting active table for databases
+ *
+ * Copyright (C) 2013, PostgreSQL Global Development Group
+ *
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "miscadmin.h"
+#include "fmgr.h"
+#include "utils/fmgrprotos.h"
+
+#include "pg_utils.h"
+
+#include <sys/stat.h>
+
+int64 diskquota_get_table_size_by_oid(Oid oid);
+int64 diskquota_get_table_size_by_relfilenode(RelFileNode *rfh);
+/*
+ * calculate size of (one fork of) a table in transaction
+ * This function is following calculate_relation_size()
+ */
+int64
+diskquota_get_table_size_by_relfilenode(RelFileNode *rfn)
+{
+    int64       totalsize = 0;
+    ForkNumber  forkNum;
+    int64       size = 0;
+    char       *relationpath;
+    char        pathname[MAXPGPATH];
+    unsigned int segcount = 0;
+
+    for (forkNum = 0; forkNum <= MAX_FORKNUM; forkNum++)
+    {
+        relationpath = relpathperm(*rfn, forkNum);
+        size = 0;
+
+        for (segcount = 0;; segcount++)
+        {
+            struct stat fst;
+
+            CHECK_FOR_INTERRUPTS();
+
+            if (segcount == 0)
+                snprintf(pathname, MAXPGPATH, "%s",
+                         relationpath);
+            else
+                snprintf(pathname, MAXPGPATH, "%s.%u",
+                         relationpath, segcount);
+
+            if (stat(pathname, &fst) < 0)
+            {
+                if (errno == ENOENT)
+                    break;
+                else
+                    ereport(ERROR,
+                            (errcode_for_file_access(),
+                                errmsg("could not stat file \"%s\": %m", pathname)));
+            }
+            size += fst.st_size;
+        }
+
+        totalsize += size;
+    }
+
+    return totalsize;
+}
+
+/*
+ * Function to calculate the total relation size
+ */
+int64
+diskquota_get_table_size_by_oid(Oid oid)
+{
+    FunctionCallInfoData fcinfo;
+    Datum       result;
+
+    InitFunctionCallInfoData(fcinfo, NULL, 1, InvalidOid, NULL, NULL);
+
+    fcinfo.arg[0] = ObjectIdGetDatum(oid);
+    fcinfo.argnull[0] = false;
+
+    result = pg_total_relation_size(&fcinfo);
+
+    /* Check for null result, since caller is clearly not expecting one */
+    if (fcinfo.isnull)
+        return 0;
+
+    return DatumGetInt64(result);
+}

--- a/pg_utils.h
+++ b/pg_utils.h
@@ -1,0 +1,20 @@
+/* -------------------------------------------------------------------------
+ *
+ * pg_utils.h
+ *
+ * This code is utils for detecting active table for databases
+ *
+ * Copyright (C) 2013, PostgreSQL Global Development Group
+ *
+ *
+ * -------------------------------------------------------------------------
+ */
+#ifndef DISKQUOTA_PG_UTILS_H
+#define DISKQUOTA_PG_UTILS_H
+
+#include "storage/relfilenode.h"
+
+extern int64 diskquota_get_table_size_by_oid(Oid oid);
+extern int64 diskquota_get_table_size_by_relfilenode(RelFileNode *rfh);
+
+#endif //DISKQUOTA_PG_UTILS_H

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -111,9 +111,6 @@ static HTAB *role_quota_limit_map = NULL;
 static HTAB *disk_quota_black_map = NULL;
 static HTAB *local_disk_quota_black_map = NULL;
 
-static disk_quota_shared_state *black_map_shm_lock;
-disk_quota_shared_state *active_table_shm_lock = NULL;
-
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 /* functions to refresh disk quota model*/
@@ -141,13 +138,21 @@ DiskQuotaShmemSize(void)
 {
 	Size		size;
 
-	size = MAXALIGN(sizeof(disk_quota_shared_state));
-	size = add_size(size, size); // two locks
+	size = sizeof(MessageBox);
 	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_BLACK_ENTRIES, sizeof(BlackMapEntry)));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableEntry)));
 	return size;
 }
 
+static void
+init_lwlocks(void)
+{
+	LWLockPadded *base;
+	base = GetNamedLWLockTranche("diskquota_locks");
+	diskquota_locks.active_table_lock = &base[0].lock;
+	diskquota_locks.black_map_lock = &base[1].lock;
+	diskquota_locks.message_box_lock = &base[2].lock;
+}
 /*
  * DiskQuotaShmemInit
  *		Allocate and initialize diskquota-related shared memory
@@ -161,21 +166,16 @@ disk_quota_shmem_startup(void)
 	if (prev_shmem_startup_hook)
 		(*prev_shmem_startup_hook)();
 
-	black_map_shm_lock = NULL;
 	disk_quota_black_map = NULL;
 
 	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
 
-	black_map_shm_lock = ShmemInitStruct("disk_quota_black_map_shm_lock",
-								 sizeof(disk_quota_shared_state),
-								 &found);
-
+	init_lwlocks();
+	message_box = ShmemInitStruct("disk_quota_message_box",
+								sizeof(MessageBox),
+								&found);
 	if (!found)
-	{
-		black_map_shm_lock->lock = &(GetNamedLWLockTranche("disk_quota_black_map_shm_lock"))->lock;
-	}
-
-	init_lock_active_tables();
+		memset((void*)message_box, 0, sizeof(MessageBox));
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize = sizeof(BlackMapEntry);
@@ -202,8 +202,7 @@ init_disk_quota_shmem(void)
 	 * resources in pgss_shmem_startup().
 	 */
 	RequestAddinShmemSpace(DiskQuotaShmemSize());
-	RequestNamedLWLockTranche("disk_quota_black_map_shm_lock", 1);
-	RequestNamedLWLockTranche("disk_quota_active_table_shm_lock", 1);
+	RequestNamedLWLockTranche("diskquota_locks", 3);
 
 	/*
 	 * Install startup hook to initialize our shared memory.
@@ -333,7 +332,7 @@ flush_local_black_map(void)
 	BlackMapEntry* blackentry;
 	bool found;
 
-	LWLockAcquire(black_map_shm_lock->lock, LW_EXCLUSIVE);
+	LWLockAcquire(diskquota_locks.black_map_lock, LW_EXCLUSIVE);
 
 	hash_seq_init(&iter, local_disk_quota_black_map);
 	while ((localblackentry = hash_seq_search(&iter)) != NULL)
@@ -370,7 +369,7 @@ flush_local_black_map(void)
 							   HASH_REMOVE, NULL);
 		}
 	}
-	LWLockRelease(black_map_shm_lock->lock);
+	LWLockRelease(diskquota_locks.black_map_lock);
 }
 
 /*
@@ -805,7 +804,7 @@ quota_check_common(Oid reloid)
 	BlackMapEntry keyitem;
 	memset(&keyitem, 0, sizeof(BlackMapEntry));
 	get_rel_owner_schema(reloid, &ownerOid, &nsOid);
-	LWLockAcquire(black_map_shm_lock->lock, LW_SHARED);
+	LWLockAcquire(diskquota_locks.black_map_lock, LW_SHARED);
 
 	if ( nsOid != InvalidOid)
 	{
@@ -841,6 +840,26 @@ quota_check_common(Oid reloid)
 			return false;
 		}
 	}
-	LWLockRelease(black_map_shm_lock->lock);
+	LWLockRelease(diskquota_locks.black_map_lock);
 	return true;
+}
+
+/*
+ * invalidate all black entry with a specific dbid in SHM
+ */
+void
+diskquota_invalidate_db(Oid dbid)
+{
+	BlackMapEntry * entry;
+	HASH_SEQ_STATUS iter;
+	LWLockAcquire(diskquota_locks.black_map_lock, LW_EXCLUSIVE);
+	hash_seq_init(&iter, disk_quota_black_map);
+	while ((entry = hash_seq_search(&iter)) != NULL)
+	{
+		if (entry->databaseoid == dbid)
+		{
+			hash_search(disk_quota_black_map, entry, HASH_REMOVE, NULL);
+		}
+	}
+	LWLockRelease(diskquota_locks.black_map_lock);
 }

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -57,11 +57,12 @@ typedef struct LocalBlackMapEntry LocalBlackMapEntry;
 /* local cache of table disk size and corresponding schema and owner */
 struct TableSizeEntry
 {
+	RelFileNode node;       /* hash table key */
 	Oid			reloid;
 	Oid			namespaceoid;
 	Oid			owneroid;
 	int64		totalsize;
-	bool		is_exist; /* flag used to check whether table is already dropped */
+
 };
 
 /* local cache of namespace disk size */
@@ -221,10 +222,10 @@ init_disk_quota_model(void)
 
 	/* init hash table for table/schema/role etc.*/
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.keysize = sizeof(Oid);
+	hash_ctl.keysize = sizeof(RelFileNode);
 	hash_ctl.entrysize = sizeof(TableSizeEntry);
 	hash_ctl.hcxt = CurrentMemoryContext;
-	hash_ctl.hash = oid_hash;
+	hash_ctl.hash = tag_hash;
 
 	table_size_map = hash_create("TableSizeEntry map",
 								1024 * 8,
@@ -511,6 +512,7 @@ calculate_table_disk_usage(bool force)
 	Relation	classRel;
 	HeapTuple	tuple;
 	HeapScanDesc relScan;
+	RelFileNode node;
 	TableSizeEntry *tsentry = NULL;
 	Oid			relOid;
 	HASH_SEQ_STATUS iter;
@@ -520,14 +522,8 @@ calculate_table_disk_usage(bool force)
 	classRel = heap_open(RelationRelationId, AccessShareLock);
 	relScan = heap_beginscan_catalog(classRel, 0, NULL);
 
+	/* TODO: init process could be separated to speed up processing */
 	local_active_table_stat_map = pg_fetch_active_tables(force);
-
-	/* unset is_exist flag for tsentry in table_size_map*/
-	hash_seq_init(&iter, table_size_map);
-	while ((tsentry = hash_seq_search(&iter)) != NULL)
-	{
-		tsentry->is_exist = false;
-	}
 
 	/*
 	 * scan pg_class to detect table event: drop, reset schema, reset owenr.
@@ -538,6 +534,7 @@ calculate_table_disk_usage(bool force)
 	{
 		Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tuple);
 		found = false;
+
 		if (classForm->relkind != RELKIND_RELATION &&
 			classForm->relkind != RELKIND_MATVIEW)
 			continue;
@@ -547,35 +544,47 @@ calculate_table_disk_usage(bool force)
 		if(relOid < FirstNormalObjectId)
 			continue;
 
-		tsentry = (TableSizeEntry *)hash_search(table_size_map,
-							 &relOid,
-							 HASH_ENTER, &found);
-		/* mark tsentry is_exist */
-		if (tsentry)
-			tsentry->is_exist = true;
+		node.dbNode = MyDatabaseId;
+		node.spcNode = MyDatabaseTableSpace;
+		node.relNode = classForm->relfilenode;
 
-		active_table_entry = (DiskQuotaActiveTableEntry *) hash_search(local_active_table_stat_map, &relOid, HASH_FIND, &active_tbl_found);
+		tsentry = (TableSizeEntry *)hash_search(table_size_map,
+		                                        &node,
+		                                        HASH_ENTER, &found);
+
+
+		/* We need to check whether such table is in local cache yet. If not, we init the entry firstly. */
+		if(!found)
+		{
+			tsentry->node = node;
+			tsentry->reloid = relOid;
+			tsentry->namespaceoid = classForm->relnamespace;
+			tsentry->owneroid = classForm->relowner;
+			tsentry->totalsize = 0;
+
+		}
+
+		/* The worker is single thread, so it should be safe when using HASH_REMOVE as there is no other thread
+		 * on this hash table
+		 * */
+		active_table_entry = (DiskQuotaActiveTableEntry *) hash_search(local_active_table_stat_map, &node, HASH_REMOVE, &active_tbl_found);
 
 		/* skip to recalculate the tables which are not in active list and not at initializatio stage*/
 		if(active_tbl_found)
 		{
+			int64 oldtotalsize;
 
-			/* namespace and owner may be changed since last check*/
-			if (!found)
+			if (active_table_entry->type == AT_UNLINK)
 			{
-				/* if it's a new table*/
-				tsentry->reloid = relOid;
-				tsentry->namespaceoid = classForm->relnamespace;
-				tsentry->owneroid = classForm->relowner;
-				tsentry->totalsize = (int64) active_table_entry->tablesize;
-				update_namespace_map(tsentry->namespaceoid, tsentry->totalsize);
-				update_role_map(tsentry->owneroid, tsentry->totalsize);
+				/* in case of the relate file has been removed, but the relfilenode is still existing in catalog */
+				update_namespace_map(tsentry->namespaceoid, -1 * tsentry->totalsize);
+				update_role_map(tsentry->owneroid, -1 * tsentry->totalsize);
+				hash_search(table_size_map, &node, HASH_REMOVE, NULL);
 			}
 			else
 			{
-				/* if not new table in table_size_map, it must be in active table list */
-				int64 oldtotalsize = tsentry->totalsize;
-				tsentry->totalsize = (int64) active_table_entry->tablesize;
+				oldtotalsize = tsentry->totalsize;
+				tsentry->totalsize = active_table_entry->tablesize;
 				update_namespace_map(tsentry->namespaceoid, tsentry->totalsize - oldtotalsize);
 				update_role_map(tsentry->owneroid, tsentry->totalsize - oldtotalsize);
 			}
@@ -599,23 +608,60 @@ calculate_table_disk_usage(bool force)
 
 	heap_endscan(relScan);
 	heap_close(classRel, AccessShareLock);
-	hash_destroy(local_active_table_stat_map);
 
-	/* process removed tables */
-	hash_seq_init(&iter, table_size_map);
-	while ((tsentry = hash_seq_search(&iter)) != NULL)
+	/* process table objects that are not (visible) in catalog yet */
+	hash_seq_init(&iter, local_active_table_stat_map);
+	while ((active_table_entry = (DiskQuotaActiveTableEntry *) hash_seq_search(&iter)) != NULL)
 	{
-		if (tsentry->is_exist == false)
+
+		tsentry = (TableSizeEntry *)hash_search(table_size_map,
+		                                        &active_table_entry->node,
+		                                        HASH_ENTER, &found);
+
+
+
+		/* A new invisible table object found, we need to init it firstly and then do update */
+		if(!found && active_table_entry->type != AT_UNLINK)
+		{
+			tsentry->node = active_table_entry->node;
+			tsentry->reloid = InvalidOid;
+			tsentry->namespaceoid = active_table_entry->namespace;
+			tsentry->owneroid = active_table_entry->owner;
+			tsentry->totalsize = active_table_entry->tablesize;
+
+			update_namespace_map(tsentry->namespaceoid, tsentry->totalsize);
+			update_role_map(tsentry->reloid, tsentry->totalsize);
+
+			ereport(DEBUG1, (errmsg("An active relfilenode %d:%d is added into local cache",
+			                       active_table_entry->node.relNode, active_table_entry->node.spcNode)));
+
+		}
+		else if (found && active_table_entry->type != AT_UNLINK)
+		{
+			int64 oldtotalsize = tsentry->totalsize;
+			tsentry->totalsize = active_table_entry->tablesize;
+			update_namespace_map(tsentry->namespaceoid, tsentry->totalsize - oldtotalsize);
+			update_role_map(tsentry->owneroid, tsentry->totalsize - oldtotalsize);
+			ereport(DEBUG1, (errmsg("An active relfilenode %d:%d is updated into local cache",
+			                     active_table_entry->node.relNode, active_table_entry->node.spcNode)));
+		}
+		else if (found && active_table_entry->type == AT_UNLINK)
 		{
 			update_role_map(tsentry->owneroid, -1 * tsentry->totalsize);
 			update_namespace_map(tsentry->namespaceoid, -1 * tsentry->totalsize);
-
-			hash_search(table_size_map,
-					&tsentry->reloid,
-					HASH_REMOVE, NULL);
-			continue;
+			hash_search(table_size_map, &active_table_entry->node, HASH_REMOVE, NULL);
+			ereport(DEBUG1, (errmsg("An active relfilenode %d:%d is deleted into local cache",
+			                     active_table_entry->node.relNode, active_table_entry->node.spcNode)));
 		}
+		else
+		{
+			ereport(ERROR, (errmsg("An active relfilenode %d:%d is under incorrect status",
+			                     active_table_entry->node.relNode, active_table_entry->node.spcNode)));
+
+		}
+
 	}
+	hash_destroy(local_active_table_stat_map);
 }
 
 /*

--- a/sql/test_extension.sql
+++ b/sql/test_extension.sql
@@ -1,0 +1,200 @@
+CREATE DATABASE dbx0 ;
+CREATE DATABASE dbx1 ;
+CREATE DATABASE dbx2 ;
+CREATE DATABASE dbx3 ;
+CREATE DATABASE dbx4 ;
+CREATE DATABASE dbx5 ;
+CREATE DATABASE dbx6 ;
+CREATE DATABASE dbx7 ;
+CREATE DATABASE dbx8 ;
+CREATE DATABASE dbx9 ;
+CREATE DATABASE dbx10 ;
+
+show max_worker_processes;
+
+\! sleep 4
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx0
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx1
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx2
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx3
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx4
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx5
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx6
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx7
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx8
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx9
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 10000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx10
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx0
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx1
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx2
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx3
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx4
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx5
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx6
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx7
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx8
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx9
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx10
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c postgres
+
+DROP DATABASE dbx0 ;
+DROP DATABASE dbx1 ;
+DROP DATABASE dbx2 ;
+DROP DATABASE dbx3 ;
+DROP DATABASE dbx4 ;
+DROP DATABASE dbx5 ;
+DROP DATABASE dbx6 ;
+DROP DATABASE dbx7 ;
+DROP DATABASE dbx8 ;
+DROP DATABASE dbx9 ;
+DROP DATABASE dbx10 ;

--- a/sql/test_transaction.sql
+++ b/sql/test_transaction.sql
@@ -1,0 +1,81 @@
+-- Test schema
+create schema ts1;
+select diskquota.set_schema_quota('ts1', '1 MB');
+BEGIN;
+create table ts1.a(i int);
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+END;
+
+SELECT pg_sleep(5);
+
+BEGIN;
+create table ts1.a(i int);
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+create table ts1.a2(i int);
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+END;
+
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+
+BEGIN;
+-- expect insert fail
+insert into ts1.a2 select generate_series(1,100);
+END;
+
+
+BEGIN;
+drop table ts1.a;
+ABORT;
+
+select pg_sleep(5);
+
+BEGIN;
+-- expect insert fail
+insert into ts1.a2 select generate_series(1,100);
+END;
+
+BEGIN;
+drop table ts1.a;
+END;
+
+select pg_sleep(5);
+
+BEGIN;
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+END;
+
+BEGIN;
+create table ts1.a(i int);
+END;
+
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+
+BEGIN;
+truncate table ts1.a;
+truncate table ts1.a2;
+savepoint p1;
+drop table ts1.a;
+rollback to p1;
+END;
+
+select pg_sleep(5);
+
+BEGIN;
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+END;
+
+drop schema ts1 CASCADE;
+

--- a/test_diskquota.conf
+++ b/test_diskquota.conf
@@ -1,5 +1,5 @@
 autovacuum = off
 fsync = on
 shared_preload_libraries = 'diskquota'
-diskquota.monitor_databases = 'contrib_regression'
 diskquota.naptime = 2
+max_worker_processes = 12

--- a/test_diskquota.conf
+++ b/test_diskquota.conf
@@ -3,3 +3,4 @@ fsync = on
 shared_preload_libraries = 'diskquota'
 diskquota.naptime = 2
 max_worker_processes = 12
+diskquota.monitor_databases = 'contrib_regression'


### PR DESCRIPTION
1. Disk quota now support the in-transaction disk
quota usage monitor and enforcement. For example,

```
BEGIN;
CREATE TABLE tbl (i int);
insert into tbl select generate_series(1,100000000);
ABORT;
```

2. Optimized active checker logic to avoid unexpected behavior
3. Update test cases