### PR TITLE
enable/disable diskquota dynamically

### DIFF
--- a/activetable.c
+++ b/activetable.c
@@ -114,22 +114,6 @@ init_shm_worker_active_tables(void)
 }
 
 /*
- * Init lock of active table map 
- */
-void init_lock_active_tables(void)
-{
-	bool found = false;
-	active_table_shm_lock = ShmemInitStruct("disk_quota_active_table_shm_lock",
-											sizeof(disk_quota_shared_state),
-											&found);
-
-	if (!found)
-	{
-		active_table_shm_lock->lock = &(GetNamedLWLockTranche("disk_quota_active_table_shm_lock"))->lock;
-	}
-}
-
-/*
  * Fetch active table file size statistics.
  * If force is true, then fetch all the tables.
  */
@@ -230,7 +214,7 @@ get_active_tables_stats()
 								HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
 
 	/* Move active table from shared memory to local active table map */
-	LWLockAcquire(active_table_shm_lock->lock, LW_EXCLUSIVE);
+	LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
 
 	hash_seq_init(&iter, active_tables_map);
 
@@ -251,7 +235,7 @@ get_active_tables_stats()
 		hash_search(active_tables_map, active_table_file_entry, HASH_REMOVE, NULL);
 	}
 
-	LWLockRelease(active_table_shm_lock->lock);
+	LWLockRelease(diskquota_locks.active_table_lock);
 
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize = sizeof(Oid);
@@ -314,11 +298,11 @@ report_active_table_SmgrStat(SMgrRelation reln)
 	item.relfilenode = reln->smgr_rnode.node.relNode;
 	item.tablespaceoid = reln->smgr_rnode.node.spcNode;
 
-	LWLockAcquire(active_table_shm_lock->lock, LW_EXCLUSIVE);
+	LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
 	entry = hash_search(active_tables_map, &item, HASH_ENTER_NULL, &found);
 	if (entry && !found)
 		*entry = item;
-	LWLockRelease(active_table_shm_lock->lock);
+	LWLockRelease(diskquota_locks.active_table_lock);
 
 	if (!found && entry == NULL) {
 		/* We may miss the file size change of this relation at current refresh interval.*/

--- a/activetable.h
+++ b/activetable.h
@@ -24,5 +24,4 @@ extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
 
 extern HTAB *active_tables_map;
-extern disk_quota_shared_state *active_table_shm_lock;
 #endif

--- a/diskquota--1.0.sql
+++ b/diskquota--1.0.sql
@@ -5,33 +5,37 @@
 
 CREATE SCHEMA diskquota;
 
-set search_path='diskquota';
-
 -- Configuration table
 create table diskquota.quota_config (targetOid oid, quotatype int, quotalimitMB int8, PRIMARY KEY(targetOid, quotatype));
 
 SELECT pg_catalog.pg_extension_config_dump('diskquota.quota_config', '');
 
-CREATE FUNCTION set_schema_quota(text, text)
+CREATE FUNCTION diskquota.set_schema_quota(text, text)
 RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE FUNCTION set_role_quota(text, text)
+CREATE FUNCTION diskquota.set_role_quota(text, text)
 RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE VIEW show_schema_quota_view AS
+CREATE FUNCTION diskquota.diskquota_start_worker()
+RETURNS void STRICT
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+CREATE VIEW diskquota.show_schema_quota_view AS
 SELECT pg_namespace.nspname as schema_name, pg_class.relnamespace as schema_oid, quota.quotalimitMB as quota_in_mb, sum(pg_total_relation_size(pg_class.oid)) as nspsize_in_bytes
 FROM pg_namespace, pg_class, diskquota.quota_config as quota
 WHERE pg_class.relnamespace = quota.targetoid and pg_class.relnamespace = pg_namespace.oid and quota.quotatype=0
 GROUP BY pg_class.relnamespace, pg_namespace.nspname, quota.quotalimitMB;
 
-CREATE VIEW show_role_quota_view AS
+CREATE VIEW diskquota.show_role_quota_view AS
 SELECT pg_roles.rolname as role_name, pg_class.relowner as role_oid, quota.quotalimitMB as quota_in_mb, sum(pg_total_relation_size(pg_class.oid)) as rolsize_in_bytes
 FROM pg_roles, pg_class, diskquota.quota_config as quota
 WHERE pg_class.relowner = quota.targetoid and pg_class.relowner = pg_roles.oid and quota.quotatype=1
 GROUP BY pg_class.relowner, pg_roles.rolname, quota.quotalimitMB;
 
-reset search_path;
+SELECT diskquota.diskquota_start_worker();
+DROP FUNCTION diskquota.diskquota_start_worker();

--- a/diskquota.c
+++ b/diskquota.c
@@ -14,18 +14,31 @@
  */
 #include "postgres.h"
 
+#include "access/tupdesc.h"
+#include "access/xact.h"
+#include "catalog/indexing.h"
 #include "catalog/namespace.h"
+#include "catalog/objectaccess.h"
 #include "catalog/pg_collation.h"
+#include "catalog/pg_database.h"
+#include "catalog/pg_extension.h"
+#include "catalog/pg_type.h"
+#include "commands/dbcommands.h"
+#include "commands/extension.h"
 #include "executor/spi.h"
 #include "miscadmin.h"
+#include "nodes/makefuncs.h"
 #include "pgstat.h"
 #include "postmaster/bgworker.h"
 #include "storage/ipc.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
+#include "utils/fmgroids.h"
 #include "utils/formatting.h"
+#include "utils/memutils.h"
 #include "utils/numeric.h"
-#include "utils/varlena.h"
+#include "utils/snapmgr.h"
+#include "utils/syscache.h"
 
 #include "activetable.h"
 #include "diskquota.h"
@@ -34,14 +47,15 @@ PG_MODULE_MAGIC;
 /* disk quota helper function */
 PG_FUNCTION_INFO_V1(set_schema_quota);
 PG_FUNCTION_INFO_V1(set_role_quota);
+PG_FUNCTION_INFO_V1(diskquota_start_worker);
 
 /* flags set by signal handlers */
 static volatile sig_atomic_t got_sighup = false;
 static volatile sig_atomic_t got_sigterm = false;
+static volatile sig_atomic_t got_sigusr1 = false;
 
 /* GUC variables */
 int	diskquota_naptime = 0;
-char *diskquota_monitored_database_list = NULL;
 int diskquota_max_active_tables = 0;
 
 typedef struct DiskQuotaWorkerEntry DiskQuotaWorkerEntry;
@@ -49,12 +63,17 @@ typedef struct DiskQuotaWorkerEntry DiskQuotaWorkerEntry;
 /* disk quota worker info used by launcher to manage the worker processes. */
 struct DiskQuotaWorkerEntry
 {
-	char dbname[NAMEDATALEN];
+	Oid dbid;
+	int pid; /* worker pid */
 	BackgroundWorkerHandle *handle;
 };
 
+DiskQuotaLocks diskquota_locks;
+volatile MessageBox * message_box = NULL;
 /* using hash table to support incremental update the table size entry.*/
 static HTAB *disk_quota_worker_map = NULL;
+static object_access_hook_type next_object_access_hook;
+static int num_db = 0;
 
 /* functions of disk quota*/
 void _PG_init(void);
@@ -64,11 +83,20 @@ void disk_quota_launcher_main(Datum);
 
 static void disk_quota_sigterm(SIGNAL_ARGS);
 static void disk_quota_sighup(SIGNAL_ARGS);
-static List *get_database_list(void);
 static int64 get_size_in_mb(char *str);
-static void refresh_worker_list(void);
 static void set_quota_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type);
-static int start_worker(char* dbname);
+static int start_worker_by_dboid(Oid dbid);
+static void create_monitor_db_table();
+static inline void exec_simple_utility(const char *sql);
+static void exec_simple_spi(const char *sql, int expected_code);
+static bool add_db_to_config(Oid dbid);
+static void del_db_from_config(Oid dbid);
+static void process_message_box();
+static void process_message_box_internal(MessageResult *code);
+static void dq_object_access_hook(ObjectAccessType access, Oid classId,
+				Oid objectId, int subId, void *arg);
+static const char *err_code_to_err_message(MessageResult code);
+extern void diskquota_invalidate_db(Oid dbid);
 
 /*
  * Entrypoint of diskquota module.
@@ -81,6 +109,9 @@ void
 _PG_init(void)
 {
 	BackgroundWorker worker;
+	if (!process_shared_preload_libraries_in_progress)
+		elog(ERROR, "It is too late to load diskquota.so :"
+			   " please put diskquota into 'shared_preload_libraries' in GUC");
 
 	init_disk_quota_shmem();
 	init_disk_quota_enforcement();
@@ -100,19 +131,6 @@ _PG_init(void)
 							NULL,
 							NULL);
 
-	if (!process_shared_preload_libraries_in_progress)
-		return;
-
-	DefineCustomStringVariable("diskquota.monitor_databases",
-								gettext_noop("database list with disk quota monitored."),
-								NULL,
-								&diskquota_monitored_database_list,
-								"",
-								PGC_SIGHUP, GUC_LIST_INPUT,
-								NULL,
-								NULL,
-								NULL);
-
 	DefineCustomIntVariable("diskquota.max_active_tables",
 							"max number of active tables monitored by disk-quota",
 							NULL,
@@ -126,6 +144,10 @@ _PG_init(void)
 							NULL,
 							NULL);
 
+	/* Add dq_object_access_hook to handle drop extension event.*/
+	next_object_access_hook = object_access_hook;
+	object_access_hook = dq_object_access_hook;
+
 	/* set up common data for diskquota launcher worker */
 	worker.bgw_flags = BGWORKER_SHMEM_ACCESS |
 		BGWORKER_BACKEND_DATABASE_CONNECTION;
@@ -135,7 +157,7 @@ _PG_init(void)
 	sprintf(worker.bgw_function_name, "disk_quota_launcher_main");
 	worker.bgw_notify_pid = 0;
 
-	snprintf(worker.bgw_name, BGW_MAXLEN, "disk quota launcher");
+	snprintf(worker.bgw_name, BGW_MAXLEN, "[diskquota] - launcher");
 
 	RegisterBackgroundWorker(&worker);
 }
@@ -179,6 +201,21 @@ disk_quota_sighup(SIGNAL_ARGS)
 	errno = save_errno;
 }
 
+/*
+ * Signal handler for SIGUSR1
+ * 		Set a flag to tell the launcher to handle message box
+ */
+static void
+disk_quota_sigusr1(SIGNAL_ARGS)
+{
+	int save_errno = errno;
+	got_sigusr1 = true;
+
+	if (MyProc)
+		SetLatch(&MyProc->procLatch);
+
+	errno = save_errno;
+}
 
 /* ---- Functions for disk quota worker process ---- */
 
@@ -189,12 +226,13 @@ disk_quota_sighup(SIGNAL_ARGS)
 void
 disk_quota_worker_main(Datum main_arg)
 {
-	char *dbname=MyBgworkerEntry->bgw_name;
-	elog(LOG,"start disk quota worker process to monitor database:%s", dbname);
+	char *dbname = MyBgworkerEntry->bgw_extra;
+	elog(LOG,"[diskquota]:start disk quota worker process to monitor database:%s", dbname);
 
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, disk_quota_sighup);
 	pqsignal(SIGTERM, disk_quota_sigterm);
+	pqsignal(SIGUSR1, disk_quota_sigusr1);
 
 	/* We're now ready to receive signals */
 	BackgroundWorkerUnblockSignals();
@@ -241,7 +279,220 @@ disk_quota_worker_main(Datum main_arg)
 		}
 	}
 
-	proc_exit(1);
+	diskquota_invalidate_db(MyDatabaseId);
+	proc_exit(0);
+}
+
+/**
+ * create table to record the list of monitored databases
+ * we need a place to store the database with diskquota enabled
+ * (via CREATE EXTENSION diskquota). Currently, we store them into
+ * heap table in diskquota_namespace schema of postgres database.
+ * When database restarted, diskquota laucher will start worker processes
+ * for these databases.
+ */
+static void
+create_monitor_db_table()
+{
+	const char *sql;
+	sql = "create schema if not exists diskquota_namespace;"
+		"create table if not exists diskquota_namespace.database_list(dbid oid not null unique);";
+	exec_simple_utility(sql);
+}
+
+static inline void
+exec_simple_utility(const char *sql)
+{
+	StartTransactionCommand();
+	exec_simple_spi(sql, SPI_OK_UTILITY);
+	CommitTransactionCommand();
+}
+
+static void
+exec_simple_spi(const char *sql, int expected_code)
+{
+	int ret;
+
+	ret = SPI_connect();
+	if (ret != SPI_OK_CONNECT)
+		elog(ERROR, "connect error, code=%d", ret);
+	PushActiveSnapshot(GetTransactionSnapshot());
+	ret = SPI_execute(sql, false, 0);
+	if (ret != expected_code)
+		elog(ERROR, "sql:'%s', code %d", sql, ret);
+	SPI_finish();
+	PopActiveSnapshot();
+}
+
+static bool
+is_valid_dbid(Oid dbid)
+{
+    HeapTuple       tuple;
+
+    if (dbid == InvalidOid)
+            return false;
+    tuple = SearchSysCache1(DATABASEOID, ObjectIdGetDatum(dbid));
+    if (!HeapTupleIsValid(tuple))
+            return false;
+    ReleaseSysCache(tuple);
+    return true;
+}
+/*
+ * in early stage, start all worker processes of diskquota-enabled databases
+ * from diskquota_namespace.database_list
+ */
+static void
+start_workers_from_dblist()
+{
+	TupleDesc tupdesc;
+	Oid fake_dbid[128];
+	int fake_count = 0;
+	int num = 0;
+	int ret;
+	int i;
+	StartTransactionCommand();
+	PushActiveSnapshot(GetTransactionSnapshot());
+	ret = SPI_connect();
+	if (ret != SPI_OK_CONNECT)
+		elog(ERROR, "connect error, code=%d", ret);
+	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", false, 0);
+	if (ret != SPI_OK_SELECT)
+		elog(ERROR, "select diskquota_namespace.database_list");
+	tupdesc = SPI_tuptable->tupdesc;
+	if (tupdesc->natts != 1 || tupdesc->attrs[0].atttypid != OIDOID)
+		elog(ERROR, "[diskquota] table database_list corrupt, laucher will exit");
+
+	for (i = 0; num < SPI_processed; i++)
+	{
+		HeapTuple tup;
+		Oid dbid;
+		Datum dat;
+		bool isnull;
+
+	    tup	= SPI_tuptable->vals[i];
+		dat = SPI_getbinval(tup, tupdesc, 1, &isnull);
+		if (isnull)
+		{
+			elog(ERROR, "dbid cann't be null");
+		}
+		dbid = DatumGetObjectId(dat);
+		if (!is_valid_dbid(dbid))
+		{
+			fake_dbid[fake_count++] = dbid;
+			continue;
+		}
+		if (start_worker_by_dboid(dbid) < 1)
+		{
+			elog(WARNING, "[diskquota]: start worker process of database(%d) failed", dbid);
+		}
+		num++;
+	}
+	num_db = num;
+	SPI_finish();
+	PopActiveSnapshot();
+	CommitTransactionCommand();
+
+	/*  TODO: clean invalid database */
+
+}
+
+static bool
+add_db_to_config(Oid dbid)
+{
+	StringInfoData str;
+
+	initStringInfo(&str);
+	appendStringInfo(&str, "insert into diskquota_namespace.database_list values(%d);", dbid);
+	exec_simple_spi(str.data, SPI_OK_INSERT);
+	return true;
+}
+
+static void
+del_db_from_config(Oid dbid)
+{
+	StringInfoData str;
+
+	initStringInfo(&str);
+	appendStringInfo(&str, "delete from diskquota_namespace.database_list where dbid=%d;", dbid);
+	exec_simple_spi(str.data, SPI_OK_DELETE);
+}
+
+/*
+ * When drop exention database, diskquota laucher will receive a message
+ * to kill the diskquota worker process which monitoring the target database. 
+ */
+static void
+try_kill_db_worker(Oid dbid)
+{
+	DiskQuotaWorkerEntry *hash_entry;
+	bool found;
+	hash_entry = (DiskQuotaWorkerEntry *)hash_search(disk_quota_worker_map,
+											(void *)&dbid,
+											HASH_REMOVE, &found);
+	if (found)
+	{
+		BackgroundWorkerHandle *handle;
+		handle = hash_entry->handle;
+		TerminateBackgroundWorker(handle);
+		pfree(handle);
+	}
+}
+
+/*
+ * handle create extension diskquota
+ * if we know the exact error which caused failure,
+ * we set it, and error out
+ */
+static void
+on_add_db(Oid dbid, MessageResult *code)
+{
+	if (num_db >= 10)
+	{
+		*code = ERR_EXCEED;
+		elog(ERROR, "[diskquota] too database to monitor");
+	}
+	if (!is_valid_dbid(dbid))
+	{
+		*code = ERR_INVALID_DBID;
+		elog(ERROR, "[diskquota] invalid database oid");
+	}
+
+	/*
+	 * add dbid to diskquota_namespace.database_list
+	 * set *code to ERR_ADD_TO_DB if any error occurs
+	 */
+	PG_TRY();
+	{
+		add_db_to_config(dbid);
+	}
+	PG_CATCH();
+	{
+		*code = ERR_ADD_TO_DB;
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	if (start_worker_by_dboid(dbid) < 1)
+	{
+		*code = ERR_START_WORKER;
+		elog(ERROR, "[diskquota] failed to start worker - dbid=%d", dbid);
+	}
+}
+
+/*
+ * handle message: drop extension diskquota
+ * do our best to:
+ * 1. kill the associated worker process
+ * 2. delete dbid from diskquota_namespace.database_list
+ * 3. invalidate black-map entries from shared memory
+ */
+static void
+on_del_db(Oid dbid)
+{
+	if (dbid == InvalidOid)
+		return;
+	try_kill_db_worker(dbid);
+	del_db_from_config(dbid);
 }
 
 /* ---- Functions for lancher process ---- */
@@ -252,44 +503,32 @@ disk_quota_worker_main(Datum main_arg)
 void
 disk_quota_launcher_main(Datum main_arg)
 {
-	List *dblist;
-	ListCell *cell;
 	HASHCTL		hash_ctl;
-	int db_count = 0;
 
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, disk_quota_sighup);
 	pqsignal(SIGTERM, disk_quota_sigterm);
+	pqsignal(SIGUSR1, disk_quota_sigusr1);
 
 	/* We're now ready to receive signals */
 	BackgroundWorkerUnblockSignals();
 
+	message_box->launcher_pid = MyProcPid;
+	/* Connect to our database */
+	BackgroundWorkerInitializeConnection("postgres", NULL, 0);
+	create_monitor_db_table();
+
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.keysize = NAMEDATALEN;
+	hash_ctl.keysize = sizeof(Oid);
 	hash_ctl.entrysize = sizeof(DiskQuotaWorkerEntry);
+	hash_ctl.hash = oid_hash;
 
 	disk_quota_worker_map = hash_create("disk quota worker map",
-										  1024,
-										  &hash_ctl,
-										  HASH_ELEM);
+						  1024,
+						  &hash_ctl,
+						  HASH_ELEM | HASH_FUNCTION);
 
-	dblist = get_database_list();
-	elog(LOG,"diskquota launcher started");
-	foreach(cell, dblist)
-	{
-		char *db_name;
-
-		if (db_count >= 10)
-			break;
-		db_name = (char *)lfirst(cell);
-		if (db_name == NULL || *db_name == '\0')
-		{
-			elog(LOG, "invalid db name='%s' in diskquota.monitor_databases", db_name);
-			continue;
-		}
-		start_worker(db_name);
-		db_count++;
-	}
+	start_workers_from_dblist();
 	/*
 	 * Main loop: do this until the SIGTERM handler tells us to terminate
 	 */
@@ -311,7 +550,12 @@ disk_quota_launcher_main(Datum main_arg)
 		/* emergency bailout if postmaster has died */
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);
-
+		/* process message box, now someone is holding message_box_lock */
+		if (got_sigusr1)
+		{
+			got_sigusr1 = false;
+			process_message_box();
+		}
 		/*
 		 * In case of a SIGHUP, just reload the configuration.
 		 */
@@ -319,8 +563,6 @@ disk_quota_launcher_main(Datum main_arg)
 		{
 			got_sighup = false;
 			ProcessConfigFile(PGC_SIGHUP);
-			/* terminate not monitored worker process and start new worker process */
-			refresh_worker_list();
 		}
 
 	}
@@ -329,138 +571,19 @@ disk_quota_launcher_main(Datum main_arg)
 }
 
 /*
- * database list found in GUC diskquota.monitored_database_list
- */
-static List *
-get_database_list(void)
-{
-	List	   *dblist = NULL;
-	char       *dbstr;
-
-	dbstr = pstrdup(diskquota_monitored_database_list);
-
-	if (!SplitIdentifierString(dbstr, ',', &dblist))
-	{
-		elog(WARNING, "cann't get database list from guc:'%s'", diskquota_monitored_database_list);
-		return NULL;
-	}
-	return dblist;
-}
-
-/*
- * When launcher receive SIGHUP, it will call refresh_worker_list()
- * to terminate worker processes whose connected database no longer need
- * to be monitored, and start new worker processes to watch new database.
- */
-static void
-refresh_worker_list(void)
-{
-	List *monitor_dblist;
-	List *removed_workerlist;
-	ListCell *cell;
-	ListCell *removed_workercell;
-	bool flag = false;
-	bool found;
-	DiskQuotaWorkerEntry *hash_entry;
-	HASH_SEQ_STATUS status;
-	int db_count = 0;
-
-	removed_workerlist = NIL;
-	monitor_dblist = get_database_list();
-	/*
-	 * refresh the worker process based on the configuration file change.
-	 * step 1 is to terminate worker processes whose connected database
-	 * not in monitor database list.
-	 */
-	elog(LOG,"Refresh monitored database list.");
-	hash_seq_init(&status, disk_quota_worker_map);
-
-	while ((hash_entry = (DiskQuotaWorkerEntry*) hash_seq_search(&status)) != NULL)
-	{
-		flag = false;
-		foreach(cell, monitor_dblist)
-		{
-			char *db_name;
-
-			if (db_count >= 10)
-				break;
-			db_name = (char *)lfirst(cell);
-			if (db_name == NULL || *db_name == '\0')
-			{
-				continue;
-			}
-			if (strcmp(db_name, hash_entry->dbname) == 0 )
-			{
-				flag = true;
-				break;
-			}
-		}
-		if (!flag)
-		{
-			removed_workerlist = lappend(removed_workerlist, hash_entry->dbname);
-		}
-	}
-
-	foreach(removed_workercell, removed_workerlist)
-	{
-		DiskQuotaWorkerEntry* workerentry;
-		char *db_name;
-		BackgroundWorkerHandle *handle;
-
-		db_name = (char *)lfirst(removed_workercell);
-
-		workerentry = (DiskQuotaWorkerEntry *)hash_search(disk_quota_worker_map,
-															(void *)db_name,
-															HASH_REMOVE, &found);
-		if(found)
-		{
-			handle = workerentry->handle;
-			TerminateBackgroundWorker(handle);
-		}
-	}
-
-	/* step 2: start new worker which first appears in monitor database list. */
-	db_count = 0;
-	foreach(cell, monitor_dblist)
-	{
-		DiskQuotaWorkerEntry* workerentry;
-		char *db_name;
-		pid_t pid;
-
-		if (db_count >= 10)
-			break;
-		db_name = (char *)lfirst(cell);
-		if (db_name == NULL || *db_name == '\0')
-		{
-			continue;
-		}
-		workerentry = (DiskQuotaWorkerEntry *)hash_search(disk_quota_worker_map,
-															(void *)db_name,
-															HASH_FIND, &found);
-		if (found)
-		{
-			/* in case worker is not in BGWH_STARTED mode, restart it. */
-			if (GetBackgroundWorkerPid(workerentry->handle, &pid) != BGWH_STARTED)
-				start_worker(db_name);
-		}
-		else
-		{
-			start_worker(db_name);
-		}
-	}
-}
-
-/*
  * Dynamically launch an disk quota worker process.
  */
 static int
-start_worker(char* dbname)
+start_worker_by_dboid(Oid dbid)
 {
 	BackgroundWorker worker;
 	BackgroundWorkerHandle *handle;
 	BgwHandleStatus status;
-	pid_t		pid;
+	MemoryContext old_ctx;
+	char *dbname;
+	pid_t pid;
 	bool found;
+	bool ok;
 	DiskQuotaWorkerEntry* workerentry;
 
 	memset(&worker, 0, sizeof(BackgroundWorker));
@@ -470,16 +593,22 @@ start_worker(char* dbname)
 	worker.bgw_restart_time = BGW_NEVER_RESTART;
 	sprintf(worker.bgw_library_name, "diskquota");
 	sprintf(worker.bgw_function_name, "disk_quota_worker_main");
-	snprintf(worker.bgw_name, BGW_MAXLEN, "%s", dbname);
+
+	dbname = get_database_name(dbid);
+	Assert(dbname != NULL);
+	snprintf(worker.bgw_name, sizeof(worker.bgw_name), "[diskquota] %s", dbname);
+	snprintf(worker.bgw_extra, sizeof(worker.bgw_extra), "%s", dbname);
+	pfree(dbname);
 	/* set bgw_notify_pid so that we can use WaitForBackgroundWorkerStartup */
 	worker.bgw_notify_pid = MyProcPid;
 	worker.bgw_main_arg = (Datum) 0;
 
-	if (!RegisterDynamicBackgroundWorker(&worker, &handle))
+	old_ctx = MemoryContextSwitchTo(TopMemoryContext);
+	ok = RegisterDynamicBackgroundWorker(&worker, &handle);
+	MemoryContextSwitchTo(old_ctx);
+	if (!ok)
 		return -1;
-
 	status = WaitForBackgroundWorkerStartup(handle, &pid);
-
 	if (status == BGWH_STOPPED)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
@@ -490,15 +619,17 @@ start_worker(char* dbname)
 				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
 			  errmsg("cannot start background processes without postmaster"),
 				 errhint("Kill all remaining database processes and restart the database.")));
+
 	Assert(status == BGWH_STARTED);
 
 	/* put the worker handle into the worker map */
 	workerentry = (DiskQuotaWorkerEntry *)hash_search(disk_quota_worker_map,
-														(void *)dbname,
+														(void *)&dbid,
 														HASH_ENTER, &found);
 	if (!found)
 	{
 		workerentry->handle = handle;
+		workerentry->pid = pid;
 	}
 
 	return pid;
@@ -765,4 +896,168 @@ get_size_in_mb(char *str)
 											   NumericGetDatum(num)));
 
 	return result;
+}
+
+/*
+ * trigger start diskquota worker when create extension diskquota
+ * This function is called at backend side, and will send message to 
+ * diskquota launcher. Luacher process is responsible for starting the real
+ * diskquota worker process.
+ */
+Datum
+diskquota_start_worker(PG_FUNCTION_ARGS)
+{
+	int rc;
+	elog(LOG, "[diskquota]:DB = %d, MyProc=%p launcher pid=%d", MyDatabaseId, MyProc, message_box->launcher_pid);
+	LWLockAcquire(diskquota_locks.message_box_lock, LW_EXCLUSIVE);
+	message_box->req_pid = MyProcPid;
+	message_box->cmd = CMD_CREATE_EXTENSION;
+	message_box->result = ERR_PENDING;
+	message_box->data[0] = MyDatabaseId;
+	/* setup sig handler to receive message */
+	rc = kill(message_box->launcher_pid, SIGUSR1);
+	if (rc == 0)
+	{
+		int count = 120; /* wait time 12 secs */
+		while(count-- > 0)
+		{
+			rc = WaitLatch(&MyProc->procLatch,
+						   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+						   100L, PG_WAIT_EXTENSION);
+			if (rc & WL_POSTMASTER_DEATH)
+				break;
+			ResetLatch(&MyProc->procLatch);
+			if (message_box->result != ERR_PENDING)
+				break;
+		}
+	}
+	message_box->req_pid = 0;
+	LWLockRelease(diskquota_locks.message_box_lock);
+	if (message_box->result != ERR_OK)
+		elog(ERROR, "%s", err_code_to_err_message((MessageResult)message_box->result));
+	PG_RETURN_VOID();
+}
+
+static void
+process_message_box_internal(MessageResult *code)
+{
+	Assert(message_box->launcher_pid == MyProcPid);
+	switch (message_box->cmd)
+	{
+		case CMD_CREATE_EXTENSION:
+			on_add_db(message_box->data[0], code);
+			num_db++;
+			break;
+		case CMD_DROP_EXTENSION:
+			on_del_db(message_box->data[0]);
+			num_db--;
+			break;
+		default:
+			elog(LOG, "[diskquota]:unsupported message cmd=%d", message_box->cmd);
+			*code = ERR_UNKNOWN;
+			break;
+	}
+}
+
+/*
+ * this function is called by launcher process to handle message from other backend 
+ * processes which call CREATE/DROP EXTENSION diskquota; It must be able to catch errors,
+ * and return an error code back to the backend process.
+ */
+static void
+process_message_box()
+{
+	MessageResult code = ERR_UNKNOWN;
+	int old_num_db = num_db;
+	if (message_box->req_pid == 0)
+		return;
+	elog(LOG, "[launcher]: received message");
+	PG_TRY();
+	{
+		StartTransactionCommand();
+		process_message_box_internal(&code);
+		CommitTransactionCommand();
+		code = ERR_OK;
+	}
+	PG_CATCH();
+	{
+		error_context_stack = NULL;
+		HOLD_INTERRUPTS();
+		AbortCurrentTransaction();
+		FlushErrorState();
+		RESUME_INTERRUPTS();
+		num_db = old_num_db;
+	}
+	PG_END_TRY();
+
+	message_box->result = (int)code;
+}
+
+/*
+ * This hook is used to handle drop extension diskquota event
+ * It will send CMD_DROP_EXTENSION message to diskquota laucher.
+ * Laucher will terminate the corresponding worker process and
+ * remove the dbOid from the database_list table.
+ */
+static void
+dq_object_access_hook(ObjectAccessType access, Oid classId,
+			Oid objectId, int subId, void *arg)
+{
+	Oid oid;
+	int rc;
+	if (access != OAT_DROP || classId != ExtensionRelationId)
+		goto out;
+	oid = get_extension_oid("diskquota", true);
+	if (oid != objectId)
+		goto out;
+	/*
+	 * invoke drop extension diskquota
+	 * 1. stop bgworker for MyDatabaseId
+	 * 2. remove dbid from diskquota_namespace.database_list in postgres
+	 */
+	LWLockAcquire(diskquota_locks.message_box_lock, LW_EXCLUSIVE);
+	message_box->req_pid = MyProcPid;
+	message_box->cmd = CMD_DROP_EXTENSION;
+	message_box->result = ERR_PENDING;
+	message_box->data[0] = MyDatabaseId;
+	rc = kill(message_box->launcher_pid, SIGUSR1);
+	if (rc == 0)
+	{
+		int count = 120; /* wait time 12 secs*/
+		while(count-- >0)
+		{
+			rc = WaitLatch(&MyProc->procLatch,
+						   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+						   100L, PG_WAIT_EXTENSION);
+			if (rc & WL_POSTMASTER_DEATH)
+				break;
+			ResetLatch(&MyProc->procLatch);
+			if (message_box->result != ERR_PENDING)
+				break;
+		}
+	}
+	message_box->req_pid = 0;
+	LWLockRelease(diskquota_locks.message_box_lock);
+	if (message_box->result != ERR_OK)
+		elog(ERROR, "[diskquota] %s", err_code_to_err_message((MessageResult)message_box->result));
+	elog(LOG, "[diskquota] DROP EXTENTION diskquota; OK");
+
+out:
+	if (next_object_access_hook)
+		(*next_object_access_hook)(access, classId, objectId,
+				subId, arg);
+}
+
+static const char *err_code_to_err_message(MessageResult code)
+{
+	switch (code)
+	{
+		case ERR_PENDING: return "ERR_PENDING";
+		case ERR_OK: return "NO ERROR";
+		case ERR_EXCEED: return "too many database to monitor";
+		case ERR_ADD_TO_DB: return "add dbid to database_list failed";
+		case ERR_START_WORKER: return "start worker failed";
+		case ERR_INVALID_DBID: return "invalid dbid";
+		default: return "unknown error";
+	}
 }

--- a/diskquota.c
+++ b/diskquota.c
@@ -515,7 +515,7 @@ disk_quota_launcher_main(Datum main_arg)
 
 	message_box->launcher_pid = MyProcPid;
 	/* Connect to our database */
-	BackgroundWorkerInitializeConnection("postgres", NULL, 0);
+	BackgroundWorkerInitializeConnection("diskquota", NULL, 0);
 	create_monitor_db_table();
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));

--- a/diskquota.h
+++ b/diskquota.h
@@ -9,13 +9,64 @@ typedef enum
 	ROLE_QUOTA
 } QuotaType;
 
-typedef struct
+struct DiskQuotaLocks
 {
-	LWLock	   *lock;		/* protects shared memory of blackMap */
-} disk_quota_shared_state;
+	LWLock *active_table_lock;
+	LWLock *black_map_lock;
+	LWLock *message_box_lock;
+};
+typedef struct DiskQuotaLocks DiskQuotaLocks;
+
+/*
+ * MessageBox is used to store a message for communication between
+ * the diskquota launcher process and backends.
+ * When backend create an extension, it send a message to launcher
+ * to start the diskquota worker process and write the corresponding
+ * dbOid into diskquota database_list table in postgres database.
+ * When backend drop an extension, it will send a message to launcher
+ * to stop the diskquota worker process and remove the dbOid from diskquota
+ * database_list table as well.
+ */
+struct MessageBox
+{
+	int launcher_pid;
+	int req_pid;		/* pid of the request process */
+	int cmd;			/* message command type, see MessageCommand */
+	int result;			/* message result writen by launcher, see MessageResult */
+	int data[4];		/* for create/drop extension diskquota, data[0] is dbid */
+};
+
+enum MessageCommand
+{
+	CMD_CREATE_EXTENSION = 1,
+	CMD_DROP_EXTENSION,
+};
+
+enum MessageResult
+{
+	ERR_PENDING = 0,
+	ERR_OK,
+	/* the number of database exceeds the maximum */
+	ERR_EXCEED,
+	/* add the dbid to diskquota_namespace.database_list failed */
+	ERR_ADD_TO_DB,
+	/* cann't start worker process */
+	ERR_START_WORKER,
+	/* invalid dbid */
+	ERR_INVALID_DBID,
+	ERR_UNKNOWN,
+};
+
+typedef struct MessageBox MessageBox;
+typedef enum MessageCommand MessageCommand;
+typedef enum MessageResult MessageResult;
+
+extern DiskQuotaLocks diskquota_locks;
+extern volatile MessageBox *message_box;
 
 /* enforcement interface*/
 extern void init_disk_quota_enforcement(void);
+extern void diskquota_invalidate_db(Oid dbid);
 
 /* quota model interface*/
 extern void init_disk_quota_shmem(void);
@@ -27,7 +78,6 @@ extern bool quota_check_common(Oid reloid);
 extern void init_disk_quota_hook(void);
 
 extern int   diskquota_naptime;
-extern char *diskquota_monitored_database_list;
 extern int   diskquota_max_active_tables;
 
 #endif

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -2,5 +2,6 @@ test: prepare
 test: test_role test_schema test_drop_table test_column test_copy test_update test_toast test_truncate test_reschema test_temp_role test_rename
 test: test_partition
 test: test_vacuum
+test: test_extension
 test: clean
 

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -1,3 +1,4 @@
+test: prepare0
 test: prepare
 test: test_role test_schema test_drop_table test_column test_copy test_update test_toast test_truncate test_reschema test_temp_role test_rename
 test: test_partition

--- a/expected/prepare.out
+++ b/expected/prepare.out
@@ -1,3 +1,10 @@
+-- wait for restart
+select pg_sleep(9);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 create extension diskquota;
 select pg_sleep(1);
  pg_sleep 

--- a/expected/prepare0.out
+++ b/expected/prepare0.out
@@ -1,0 +1,2 @@
+create database diskquota;
+\! pg_ctl -D /tmp/pg_diskquota_test/data restart -l /dev/null 2>/dev/null >/dev/null

--- a/expected/test_extension.out
+++ b/expected/test_extension.out
@@ -1,0 +1,272 @@
+CREATE DATABASE dbx0 ;
+CREATE DATABASE dbx1 ;
+CREATE DATABASE dbx2 ;
+CREATE DATABASE dbx3 ;
+CREATE DATABASE dbx4 ;
+CREATE DATABASE dbx5 ;
+CREATE DATABASE dbx6 ;
+CREATE DATABASE dbx7 ;
+CREATE DATABASE dbx8 ;
+CREATE DATABASE dbx9 ;
+CREATE DATABASE dbx10 ;
+show max_worker_processes;
+ max_worker_processes 
+----------------------
+ 12
+(1 row)
+
+\! sleep 4
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+2
+\c dbx0
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+3
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx1
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+4
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx2
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+5
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx3
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+6
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx4
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+7
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx5
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+8
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx6
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+9
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx7
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+10
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx8
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+11
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+INSERT INTO SX.a values(generate_series(0, 100000000));
+ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 10));
+ERROR:  schema's disk space quota exceeded with name:sx
+DROP TABLE SX.a;
+\c dbx9
+CREATE EXTENSION diskquota;
+ERROR:  too many database to monitor
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+11
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+ERROR:  schema "diskquota" does not exist
+LINE 1: SELECT diskquota.set_schema_quota('SX', '1MB');
+               ^
+INSERT INTO SX.a values(generate_series(0, 10000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+\c dbx10
+CREATE EXTENSION diskquota;
+ERROR:  too many database to monitor
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+11
+\c dbx0
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+10
+\c dbx1
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+9
+\c dbx2
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+8
+\c dbx3
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+7
+\c dbx4
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+6
+\c dbx5
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+5
+\c dbx6
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+4
+\c dbx7
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+3
+\c dbx8
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+2
+\c dbx9
+DROP EXTENSION diskquota;
+ERROR:  extension "diskquota" does not exist
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+2
+\c dbx10
+DROP EXTENSION diskquota;
+ERROR:  extension "diskquota" does not exist
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+2
+\c postgres
+DROP DATABASE dbx0 ;
+DROP DATABASE dbx1 ;
+DROP DATABASE dbx2 ;
+DROP DATABASE dbx3 ;
+DROP DATABASE dbx4 ;
+DROP DATABASE dbx5 ;
+DROP DATABASE dbx6 ;
+DROP DATABASE dbx7 ;
+DROP DATABASE dbx8 ;
+DROP DATABASE dbx9 ;
+DROP DATABASE dbx10 ;

--- a/expected/test_extension.out
+++ b/expected/test_extension.out
@@ -1,3 +1,6 @@
+-- NOTE: when test this script, you must make sure that there is no diskquota launcher
+-- process or diskquota worker process. i.e. `ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l`
+-- returns 0
 CREATE DATABASE dbx0 ;
 CREATE DATABASE dbx1 ;
 CREATE DATABASE dbx2 ;

--- a/expected/test_insert_after_drop.out
+++ b/expected/test_insert_after_drop.out
@@ -1,0 +1,31 @@
+create database db_insert_after_drop;
+\c db_insert_after_drop
+create extension diskquota;
+-- Test Drop Extension
+create schema sdrtbl;
+select diskquota.set_schema_quota('sdrtbl', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+set search_path to sdrtbl;
+create table a(i int);
+insert into a select generate_series(1,100);
+-- expect insert fail
+insert into a select generate_series(1,100000000);
+ERROR:  schema's disk space quota exceeded with name:sdrtbl
+select pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+insert into a select generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:sdrtbl
+drop extension diskquota;
+-- no sleep, it will take effect immediately
+insert into a select generate_series(1,100);
+drop table a;
+\c postgres
+drop database db_insert_after_drop;

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -111,9 +111,6 @@ static HTAB *role_quota_limit_map = NULL;
 static HTAB *disk_quota_black_map = NULL;
 static HTAB *local_disk_quota_black_map = NULL;
 
-static disk_quota_shared_state *black_map_shm_lock;
-disk_quota_shared_state *active_table_shm_lock = NULL;
-
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 /* functions to refresh disk quota model*/
@@ -141,13 +138,21 @@ DiskQuotaShmemSize(void)
 {
 	Size		size;
 
-	size = MAXALIGN(sizeof(disk_quota_shared_state));
-	size = add_size(size, size); // two locks
+	size = sizeof(MessageBox);
 	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_BLACK_ENTRIES, sizeof(BlackMapEntry)));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableEntry)));
 	return size;
 }
 
+static void
+init_lwlocks(void)
+{
+	LWLockPadded *base;
+	base = GetNamedLWLockTranche("diskquota_locks");
+	diskquota_locks.active_table_lock = &base[0].lock;
+	diskquota_locks.black_map_lock = &base[1].lock;
+	diskquota_locks.message_box_lock = &base[2].lock;
+}
 /*
  * DiskQuotaShmemInit
  *		Allocate and initialize diskquota-related shared memory
@@ -161,21 +166,16 @@ disk_quota_shmem_startup(void)
 	if (prev_shmem_startup_hook)
 		(*prev_shmem_startup_hook)();
 
-	black_map_shm_lock = NULL;
 	disk_quota_black_map = NULL;
 
 	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
 
-	black_map_shm_lock = ShmemInitStruct("disk_quota_black_map_shm_lock",
-								 sizeof(disk_quota_shared_state),
-								 &found);
-
+	init_lwlocks();
+	message_box = ShmemInitStruct("disk_quota_message_box",
+								sizeof(MessageBox),
+								&found);
 	if (!found)
-	{
-		black_map_shm_lock->lock = &(GetNamedLWLockTranche("disk_quota_black_map_shm_lock"))->lock;
-	}
-
-	init_lock_active_tables();
+		memset((void*)message_box, 0, sizeof(MessageBox));
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize = sizeof(BlackMapEntry);
@@ -202,8 +202,7 @@ init_disk_quota_shmem(void)
 	 * resources in pgss_shmem_startup().
 	 */
 	RequestAddinShmemSpace(DiskQuotaShmemSize());
-	RequestNamedLWLockTranche("disk_quota_black_map_shm_lock", 1);
-	RequestNamedLWLockTranche("disk_quota_active_table_shm_lock", 1);
+	RequestNamedLWLockTranche("diskquota_locks", 3);
 
 	/*
 	 * Install startup hook to initialize our shared memory.
@@ -333,7 +332,7 @@ flush_local_black_map(void)
 	BlackMapEntry* blackentry;
 	bool found;
 
-	LWLockAcquire(black_map_shm_lock->lock, LW_EXCLUSIVE);
+	LWLockAcquire(diskquota_locks.black_map_lock, LW_EXCLUSIVE);
 
 	hash_seq_init(&iter, local_disk_quota_black_map);
 	while ((localblackentry = hash_seq_search(&iter)) != NULL)
@@ -370,7 +369,7 @@ flush_local_black_map(void)
 							   HASH_REMOVE, NULL);
 		}
 	}
-	LWLockRelease(black_map_shm_lock->lock);
+	LWLockRelease(diskquota_locks.black_map_lock);
 }
 
 /*
@@ -805,7 +804,7 @@ quota_check_common(Oid reloid)
 	BlackMapEntry keyitem;
 	memset(&keyitem, 0, sizeof(BlackMapEntry));
 	get_rel_owner_schema(reloid, &ownerOid, &nsOid);
-	LWLockAcquire(black_map_shm_lock->lock, LW_SHARED);
+	LWLockAcquire(diskquota_locks.black_map_lock, LW_SHARED);
 
 	if ( nsOid != InvalidOid)
 	{
@@ -841,6 +840,26 @@ quota_check_common(Oid reloid)
 			return false;
 		}
 	}
-	LWLockRelease(black_map_shm_lock->lock);
+	LWLockRelease(diskquota_locks.black_map_lock);
 	return true;
+}
+
+/*
+ * invalidate all black entry with a specific dbid in SHM
+ */
+void
+diskquota_invalidate_db(Oid dbid)
+{
+	BlackMapEntry * entry;
+	HASH_SEQ_STATUS iter;
+	LWLockAcquire(diskquota_locks.black_map_lock, LW_EXCLUSIVE);
+	hash_seq_init(&iter, disk_quota_black_map);
+	while ((entry = hash_seq_search(&iter)) != NULL)
+	{
+		if (entry->databaseoid == dbid)
+		{
+			hash_search(disk_quota_black_map, entry, HASH_REMOVE, NULL);
+		}
+	}
+	LWLockRelease(diskquota_locks.black_map_lock);
 }

--- a/sql/prepare.sql
+++ b/sql/prepare.sql
@@ -1,3 +1,5 @@
+-- wait for restart
+select pg_sleep(9);
 create extension diskquota;
 select pg_sleep(1);
 \! pg_ctl -D /tmp/pg_diskquota_test/data reload

--- a/sql/prepare0.sql
+++ b/sql/prepare0.sql
@@ -1,0 +1,2 @@
+create database diskquota;
+\! pg_ctl -D /tmp/pg_diskquota_test/data restart -l /dev/null 2>/dev/null >/dev/null

--- a/sql/test_extension.sql
+++ b/sql/test_extension.sql
@@ -1,0 +1,200 @@
+CREATE DATABASE dbx0 ;
+CREATE DATABASE dbx1 ;
+CREATE DATABASE dbx2 ;
+CREATE DATABASE dbx3 ;
+CREATE DATABASE dbx4 ;
+CREATE DATABASE dbx5 ;
+CREATE DATABASE dbx6 ;
+CREATE DATABASE dbx7 ;
+CREATE DATABASE dbx8 ;
+CREATE DATABASE dbx9 ;
+CREATE DATABASE dbx10 ;
+
+show max_worker_processes;
+
+\! sleep 4
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx0
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx1
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx2
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx3
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx4
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx5
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx6
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx7
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx8
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx9
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+CREATE SCHEMA SX;
+CREATE TABLE SX.a(i int);
+SELECT diskquota.set_schema_quota('SX', '1MB');
+INSERT INTO SX.a values(generate_series(0, 10000000));
+INSERT INTO SX.a values(generate_series(0, 10));
+DROP TABLE SX.a;
+
+\c dbx10
+CREATE EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx0
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx1
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx2
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx3
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx4
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx5
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx6
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx7
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx8
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx9
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c dbx10
+DROP EXTENSION diskquota;
+\! sleep 2
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+
+\c postgres
+
+DROP DATABASE dbx0 ;
+DROP DATABASE dbx1 ;
+DROP DATABASE dbx2 ;
+DROP DATABASE dbx3 ;
+DROP DATABASE dbx4 ;
+DROP DATABASE dbx5 ;
+DROP DATABASE dbx6 ;
+DROP DATABASE dbx7 ;
+DROP DATABASE dbx8 ;
+DROP DATABASE dbx9 ;
+DROP DATABASE dbx10 ;

--- a/sql/test_extension.sql
+++ b/sql/test_extension.sql
@@ -1,3 +1,6 @@
+-- NOTE: when test this script, you must make sure that there is no diskquota launcher
+-- process or diskquota worker process. i.e. `ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l`
+-- returns 0
 CREATE DATABASE dbx0 ;
 CREATE DATABASE dbx1 ;
 CREATE DATABASE dbx2 ;

--- a/sql/test_insert_after_drop.sql
+++ b/sql/test_insert_after_drop.sql
@@ -1,0 +1,20 @@
+create database db_insert_after_drop;
+\c db_insert_after_drop
+create extension diskquota;
+-- Test Drop Extension
+create schema sdrtbl;
+select diskquota.set_schema_quota('sdrtbl', '1 MB');
+set search_path to sdrtbl;
+create table a(i int);
+insert into a select generate_series(1,100);
+-- expect insert fail
+insert into a select generate_series(1,100000000);
+select pg_sleep(5);
+insert into a select generate_series(1,100);
+drop extension diskquota;
+-- no sleep, it will take effect immediately
+insert into a select generate_series(1,100);
+
+drop table a;
+\c postgres
+drop database db_insert_after_drop;

--- a/test_diskquota.conf
+++ b/test_diskquota.conf
@@ -1,5 +1,5 @@
 autovacuum = off
 fsync = on
 shared_preload_libraries = 'diskquota'
-diskquota.monitor_databases = 'contrib_regression'
 diskquota.naptime = 2
+max_worker_processes = 12


### PR DESCRIPTION

    Design: In past, we use GUC diskquota_monitor_database to save the diskquota enabled databases. DBA has to reset the value in postgresql.conf each time and call pg_ctl reload to refresh the database list. To make this management process easy, we use a heap table (diskquota_name.database_list) in database `diskquota` to store the monitored database list instead.
    GUC diskquota_monitor_database is removed and the monitored database is loaded into table database_list by `create extension diskquota` and delete from table by `drop extension diskquota` automatically.
    When `create extension diskquota` is called, a UDF, diskquota_start_worker, is invoked, and the launcher will store the dboid into table diskquota_name.database_list, and start a bgworker for the corresponding database to control the disk usage of this database.
    When `drop extension diskquota` is called, a hook function, object_access_hook, is invoked, and the launcher will delete the dboid from table diskquota_name.database_list, and stop the corresponding bgworker.

    Protocol: The communication between the launcher process of diskquota and the backends uses a simple protocol, via a block of shared memory(MessageBox). When the backend wants to send a message to the launcher, it follows the steps:
    * acquires a lock
    * fills message data into the message_box
    * sends a signal SIGUSR1 to the launcher
    * waits for a response, in a loop with a timeout
    * consumes the response
    * releases the lock