### PR TITLE
Add fast table size check feature.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,9 @@ FILES = diskquota.c enforcement.c quotamodel.c gp_activetable.c
 OBJS = diskquota.o enforcement.o quotamodel.o gp_activetable.o 
 PG_CPPFLAGS = -I$(libpq_srcdir)
 SHLIB_LINK = $(libpq)
-SHLIB_PREREQS = submake-libpq
 
 REGRESS = dummy
-REGRESS_OPTS = --schedule=diskquota_schedule
+REGRESS_OPTS = --schedule=diskquota_schedule --init-file=init_file
 
-ifdef USE_PGXS
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
-else
-subdir = gpcontrib/gp_diskquota
-top_builddir = ../..
-include $(top_builddir)/src/Makefile.global
-include $(top_srcdir)/contrib/contrib-global.mk
-endif

--- a/diskquota.h
+++ b/diskquota.h
@@ -16,11 +16,17 @@ typedef enum
 	FETCH_ACTIVE_SIZE			/* fetch size for active tables */
 }			FetchTableStatType;
 
+typedef enum
+{
+	DISKQUOTA_UNKNOWN_STATE,
+	DISKQUOTA_READY_STATE
+}			DiskQuotaState;
+
 struct DiskQuotaLocks
 {
-	LWLock *active_table_lock;
-	LWLock *black_map_lock;
-	LWLock *message_box_lock;
+	LWLock	   *active_table_lock;
+	LWLock	   *black_map_lock;
+	LWLock	   *message_box_lock;
 };
 typedef struct DiskQuotaLocks DiskQuotaLocks;
 
@@ -36,11 +42,13 @@ typedef struct DiskQuotaLocks DiskQuotaLocks;
  */
 struct MessageBox
 {
-	int launcher_pid;
-	int req_pid;		/* pid of the request process */
-	int cmd;			/* message command type, see MessageCommand */
-	int result;			/* message result writen by launcher, see MessageResult */
-	int data[4];		/* for create/drop extension diskquota, data[0] is dbid */
+	int			launcher_pid;
+	int			req_pid;		/* pid of the request process */
+	int			cmd;			/* message command type, see MessageCommand */
+	int			result;			/* message result writen by launcher, see
+								 * MessageResult */
+	int			data[4];		/* for create/drop extension diskquota,
+								 * data[0] is dbid */
 };
 
 enum MessageCommand
@@ -79,13 +87,14 @@ extern void diskquota_invalidate_db(Oid dbid);
 extern void init_disk_quota_shmem(void);
 extern void init_disk_quota_model(void);
 extern void refresh_disk_quota_model(bool force);
+extern bool check_diskquota_state_is_ready(void);
 extern bool quota_check_common(Oid reloid);
 
 /* quotaspi interface */
 extern void init_disk_quota_hook(void);
 
 extern Datum diskquota_fetch_table_stat(PG_FUNCTION_ARGS);
-extern int   diskquota_naptime;
-extern int   diskquota_max_active_tables;
+extern int	diskquota_naptime;
+extern int	diskquota_max_active_tables;
 
 #endif

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -4,5 +4,6 @@ test: test_role test_schema test_drop_table test_column test_copy test_update te
 test: test_partition
 test: test_vacuum
 test: test_extension
+test: test_fast_disk_check
 test: clean
 test: test_insert_after_drop

--- a/expected/test_extension.out
+++ b/expected/test_extension.out
@@ -42,22 +42,27 @@ INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx1
-CREATE EXTENSION diskquota;
-\! sleep 2
-\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
-4
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO SX.a values(generate_series(0, 100000));
+CREATE EXTENSION diskquota;
+SELECT diskquota.init_table_size_table();
+ init_table_size_table 
+-----------------------
+ 
+(1 row)
+
 SELECT diskquota.set_schema_quota('SX', '1MB');
  set_schema_quota 
 ------------------
  
 (1 row)
 
-INSERT INTO SX.a values(generate_series(0, 100000000));
-ERROR:  schema's disk space quota exceeded with name:sx
+\! sleep 5
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+4
 INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
@@ -203,22 +208,13 @@ ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx9
 CREATE EXTENSION diskquota;
-ERROR:  too many database to monitor (diskquota.c:975)
+ERROR:  too many database to monitor (diskquota.c:1056)
 \! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 11
-CREATE SCHEMA SX;
-CREATE TABLE SX.a(i int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-SELECT diskquota.set_schema_quota('SX', '1MB');
-ERROR:  schema "diskquota" does not exist
-INSERT INTO SX.a values(generate_series(0, 10000000));
-INSERT INTO SX.a values(generate_series(0, 10));
-DROP TABLE SX.a;
 \c dbx10
 CREATE EXTENSION diskquota;
-ERROR:  too many database to monitor (diskquota.c:975)
+ERROR:  too many database to monitor (diskquota.c:1056)
 \! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 11

--- a/expected/test_fast_disk_check.out
+++ b/expected/test_fast_disk_check.out
@@ -1,0 +1,22 @@
+-- Test SCHEMA
+CREATE SCHEMA s1;
+SET search_path to s1;
+CREATE TABLE a(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO a SELECT generate_series(1,2000000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT (pg_database_size(oid)-dbsize)/dbsize < 0.1  FROM pg_database, diskquota.database_size_view WHERE datname='contrib_regression';
+ ?column? 
+----------
+ t
+(1 row)
+
+RESET search_path;
+DROP TABLE s1.a;
+DROP SCHEMA s1;

--- a/init_file
+++ b/init_file
@@ -1,0 +1,10 @@
+-- This file contains global patterns of messages that should be ignored or
+-- masked out, when comparing test results with the expected output.
+-- Individual tests can contain additional patterns specific to the test.
+
+-- start_matchignore
+-- end_matchignore
+-- start_matchsubs
+m/diskquota.c:\d+\)/
+s/diskquota.c:\d+\)/diskquota.c:xxx/
+-- end_matchsubs

--- a/sql/prepare.sql
+++ b/sql/prepare.sql
@@ -1,6 +1,7 @@
 CREATE EXTENSION diskquota;
 -- start_ignore
 \! gpstop -u
+SELECT diskquota.init_table_size_table();
 -- end_ignore
 SELECT pg_sleep(1);
 \! cp data/csmall.txt /tmp/csmall.txt

--- a/sql/test_extension.sql
+++ b/sql/test_extension.sql
@@ -30,13 +30,14 @@ INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 
 \c dbx1
-CREATE EXTENSION diskquota;
-\! sleep 2
-\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
+INSERT INTO SX.a values(generate_series(0, 100000));
+CREATE EXTENSION diskquota;
+SELECT diskquota.init_table_size_table();
 SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 100000000));
+\! sleep 5
+\! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 
@@ -121,12 +122,6 @@ DROP TABLE SX.a;
 CREATE EXTENSION diskquota;
 \! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
-CREATE SCHEMA SX;
-CREATE TABLE SX.a(i int);
-SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 10000000));
-INSERT INTO SX.a values(generate_series(0, 10));
-DROP TABLE SX.a;
 
 \c dbx10
 CREATE EXTENSION diskquota;

--- a/sql/test_fast_disk_check.sql
+++ b/sql/test_fast_disk_check.sql
@@ -1,0 +1,12 @@
+-- Test SCHEMA
+CREATE SCHEMA s1;
+SET search_path to s1;
+
+CREATE TABLE a(i int);
+INSERT INTO a SELECT generate_series(1,2000000);
+SELECT pg_sleep(5);
+SELECT (pg_database_size(oid)-dbsize)/dbsize < 0.1  FROM pg_database, diskquota.database_size_view WHERE datname='contrib_regression';
+RESET search_path;
+DROP TABLE s1.a;
+DROP SCHEMA s1;
+


### PR DESCRIPTION
table_size info are stored in the local memory of diskquota worker.
It cannot be accessed from other backend directly. This patch
stores the table_size info into user table diskquota.table_size for
fast table size check.

Diskquota worker initialization logic also changed to read table table_size
instead of calculate all the table's size by UDF pg_total_relation_size.

Detail design please refer to the Quota Status Checker part of wiki:
https://github.com/greenplum-db/gpdb/wiki/Greenplum-Diskquota-Design#design-of-diskquota