### PR TITLE
Support in-transaction disk quota management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EXTENSION = diskquota
 DATA = diskquota--1.0.sql
 SRCDIR = ./
 FILES = $(shell find $(SRCDIR) -type f -name "*.c")
-OBJS = diskquota.o enforcement.o quotamodel.o activetable.o
+OBJS = diskquota.o enforcement.o quotamodel.o activetable.o pg_utils.o
 
 REGRESS = dummy
 REGRESS_OPTS = --temp-config=test_diskquota.conf --temp-instance=/tmp/pg_diskquota_test  --schedule=diskquota_schedule

--- a/activetable.c
+++ b/activetable.c
@@ -23,13 +23,16 @@
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/relfilenodemap.h"
+#include "utils/syscache.h"
 
 #include "activetable.h"
+#include "pg_utils.h"
 
 HTAB *active_tables_map = NULL;
 static smgrcreate_hook_type prev_smgrcreate_hook = NULL;
 static smgrextend_hook_type prev_smgrextend_hook = NULL;
 static smgrtruncate_hook_type prev_smgrtruncate_hook = NULL;
+static smgrdounlinkall_hook_type prev_smgrdounlinkall_hook = NULL;
 static void active_table_hook_smgrcreate(SMgrRelation reln,
 							  ForkNumber forknum,
 							  bool isRedo);
@@ -41,8 +44,11 @@ static void active_table_hook_smgrextend(SMgrRelation reln,
 static void active_table_hook_smgrtruncate(SMgrRelation reln,
 							  ForkNumber forknum,
 							  BlockNumber blocknum);
+static void active_table_hook_smgrunlink(SMgrRelation *reln,
+                              int nrels,
+                              bool isRedo);
 
-static void report_active_table_SmgrStat(SMgrRelation reln);
+static void report_active_table_SmgrStat(SMgrRelation reln, ActiveType at);
 static HTAB* get_active_tables_stats(void);
 static HTAB* get_all_tables_stats(void);
 
@@ -65,6 +71,9 @@ init_active_table_hook(void)
 
 	prev_smgrtruncate_hook = smgrtruncate_hook;
 	smgrtruncate_hook = active_table_hook_smgrtruncate;
+
+	prev_smgrdounlinkall_hook = smgrdounlinkall_hook;
+	smgrdounlinkall_hook = active_table_hook_smgrunlink;
 }
 
 static void
@@ -72,7 +81,7 @@ active_table_hook_smgrcreate(SMgrRelation reln,
 							  pg_attribute_unused() ForkNumber forknum,
 							  pg_attribute_unused() bool isRedo)
 {
-	report_active_table_SmgrStat(reln);
+	report_active_table_SmgrStat(reln, AT_CREATE);
 }
 
 static void
@@ -82,7 +91,7 @@ active_table_hook_smgrextend(SMgrRelation reln,
 							  pg_attribute_unused() char *buffer,
 							  pg_attribute_unused() bool skipFsync)
 {
-	report_active_table_SmgrStat(reln);
+	report_active_table_SmgrStat(reln, AT_EXTEND);
 }
 
 static void
@@ -90,7 +99,18 @@ active_table_hook_smgrtruncate(SMgrRelation reln,
 							  pg_attribute_unused() ForkNumber forknum,
 							  pg_attribute_unused() BlockNumber blocknum)
 {
-	report_active_table_SmgrStat(reln);
+	report_active_table_SmgrStat(reln, AT_TRUNCATE);
+}
+
+static void active_table_hook_smgrunlink(SMgrRelation *reln,
+                                         pg_attribute_unused() int nrels,
+                                         pg_attribute_unused() bool isRedo)
+{
+	int i;
+	for (i = 0; i < nrels; i++)
+	{
+		report_active_table_SmgrStat(reln[i], AT_UNLINK);
+	}
 }
 
 /*
@@ -102,7 +122,7 @@ init_shm_worker_active_tables(void)
 	HASHCTL ctl;
 	memset(&ctl, 0, sizeof(ctl));
 
-	ctl.keysize = sizeof(DiskQuotaActiveTableEntry);
+	ctl.keysize = sizeof(RelFileNode);
 	ctl.entrysize = sizeof(DiskQuotaActiveTableEntry);
 	ctl.hash = tag_hash;
 
@@ -142,10 +162,10 @@ get_all_tables_stats()
 	HeapScanDesc relScan;
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(Oid);
+	ctl.keysize = sizeof(RelFileNode);
 	ctl.entrysize = sizeof(DiskQuotaActiveTableEntry);
 	ctl.hcxt = CurrentMemoryContext;
-	ctl.hash = oid_hash;
+	ctl.hash = tag_hash;
 
 	local_table_stats_map = hash_create("local table map with table size info",
 								1024,
@@ -159,6 +179,7 @@ get_all_tables_stats()
 	{
 		Oid relOid;
 		DiskQuotaActiveTableEntry *entry;
+		RelFileNode node;
 
 		Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tuple);
 		if (classForm->relkind != RELKIND_RELATION &&
@@ -170,11 +191,15 @@ get_all_tables_stats()
 		if (relOid < FirstNormalObjectId)
 			continue;
 
-		entry = (DiskQuotaActiveTableEntry *) hash_search(local_table_stats_map, &relOid, HASH_ENTER, NULL);
+		node.spcNode = MyDatabaseTableSpace;
+		node.dbNode = MyDatabaseId;
+		node.relNode = classForm->relfilenode;
 
-		entry->tableoid = relOid;
-		entry->tablesize = (Size) DatumGetInt64(DirectFunctionCall1(pg_total_relation_size,
-					ObjectIdGetDatum(relOid)));
+		entry = (DiskQuotaActiveTableEntry *) hash_search(local_table_stats_map, &node, HASH_ENTER, NULL);
+
+		entry->node = node;
+		entry->type = AT_EXTEND;
+		entry->tablesize = diskquota_get_table_size_by_oid(relOid);
 
 	}
 
@@ -183,7 +208,7 @@ get_all_tables_stats()
 
     return local_table_stats_map;	
 }
-/*
+/**
  * Get local active table with table oid and table size info.
  * This function first copies active table map from shared memory 
  * to local active table map with refilenode info. Then traverses
@@ -203,7 +228,7 @@ get_active_tables_stats()
 	Oid relOid;
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(DiskQuotaActiveTableFileEntry);
+	ctl.keysize = sizeof(RelFileNode);
 	ctl.entrysize = sizeof(DiskQuotaActiveTableFileEntry);
 	ctl.hcxt = CurrentMemoryContext;
 	ctl.hash = tag_hash;
@@ -223,25 +248,24 @@ get_active_tables_stats()
 		bool  found;
 		DiskQuotaActiveTableFileEntry *entry;
 
-		if (active_table_file_entry->dbid != MyDatabaseId)
+		if (active_table_file_entry->node.dbNode != MyDatabaseId)
 		{
 			continue;
 		}
 
 		/* Add the active table entry into local hash table*/
-		entry = hash_search(local_active_table_file_map, active_table_file_entry, HASH_ENTER, &found);
-		if (entry)
-			*entry = *active_table_file_entry;
-		hash_search(active_tables_map, active_table_file_entry, HASH_REMOVE, NULL);
+		entry = hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_ENTER, &found);
+		*entry = *active_table_file_entry;
+		hash_search(active_tables_map, &active_table_file_entry->node, HASH_REMOVE, &found);
 	}
 
 	LWLockRelease(diskquota_locks.active_table_lock);
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(Oid);
+	ctl.keysize = sizeof(RelFileNode);
 	ctl.entrysize = sizeof(DiskQuotaActiveTableEntry);
 	ctl.hcxt = CurrentMemoryContext;
-	ctl.hash = oid_hash;
+	ctl.hash = tag_hash;
 
 	local_active_table_stats_map = hash_create("local active table map with relfilenode info",
 								1024,
@@ -253,59 +277,184 @@ get_active_tables_stats()
 	/* scan whole local map, get the oid of each table and calculate the size of them */
 	while ((active_table_file_entry = (DiskQuotaActiveTableFileEntry *) hash_seq_search(&iter)) != NULL)
 	{
-		Size tablesize;
 		bool found;
-		
-		relOid = RelidByRelfilenode(active_table_file_entry->tablespaceoid, active_table_file_entry->relfilenode);
 
-		//TODO replace DirectFunctionCall1 by a new total relation size function, which could handle Invalid relOid
-		/* avoid to generate ERROR if relOid is not existed (i.e. table has been droped) */
-		PG_TRY();
+		switch (active_table_file_entry->tablestatus)
 		{
-			tablesize = (Size) DatumGetInt64(DirectFunctionCall1(pg_total_relation_size,
-						ObjectIdGetDatum(relOid)));
+			case TABLE_COMMIT_CREATE:
+			case TABLE_COMMIT_CHANGE:
+				relOid = RelidByRelfilenode(active_table_file_entry->node.spcNode,
+				                            active_table_file_entry->node.relNode);
+				if (relOid != InvalidOid) {
+					active_table_entry = hash_search(local_active_table_stats_map, &active_table_file_entry->node,
+					                                 HASH_ENTER, &found);
+					active_table_entry->node = active_table_file_entry->node;
+					active_table_entry->tablesize = diskquota_get_table_size_by_oid(relOid);
+					active_table_entry->type = AT_EXTEND;
+					hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_REMOVE, NULL);
+				} else {
+					active_table_file_entry->ispushedback = true;
+				}
+				break;
+			case TABLE_IN_TRANSX_CHANGE:
+			case TABLE_IN_TRANSX_CREATE:
+				active_table_entry = hash_search(local_active_table_stats_map, &active_table_file_entry->node,
+				                                 HASH_ENTER, &found);
+				active_table_entry->node = active_table_file_entry->node;
+				active_table_entry->tablesize = diskquota_get_table_size_by_relfilenode(&active_table_entry->node);
+				active_table_entry->namespace = active_table_file_entry->inXnamespace;
+				active_table_entry->owner = active_table_file_entry->inXowner;
+				active_table_entry->type = AT_EXTEND;
+				hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_REMOVE, NULL);
+				break;
+			case TABLE_COMMIT_DELETE:
+			case TABLE_IN_TRANSX_DELETE:
+				active_table_entry = hash_search(local_active_table_stats_map, &active_table_file_entry->node,
+				                                 HASH_ENTER, &found);
+				active_table_entry->node = active_table_file_entry->node;
+				active_table_entry->type = AT_UNLINK;
+				hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_REMOVE, NULL);
+				break;
+			default:
+				/* Unknown status of entry, ignore it*/
+				ereport(LOG, (errmsg("found an entry in unexpected status, table status is %d, relnode is %d", active_table_file_entry->tablestatus,
+					 active_table_file_entry->node.relNode)));
+				hash_search(local_active_table_file_map, &active_table_file_entry->node, HASH_REMOVE, NULL);
+				break;
+
 		}
-		PG_CATCH();
-		{
-			FlushErrorState();
-			tablesize = 0;
-		}
-		PG_END_TRY();
-		active_table_entry = hash_search(local_active_table_stats_map, &relOid, HASH_ENTER, &found);
-		active_table_entry->tableoid = relOid;
-		active_table_entry->tablesize = tablesize;
 	}
-	elog(DEBUG1, "active table number is:%ld", hash_get_num_entries(local_active_table_file_map));
+
+	/* If table is not found, it could be in transaction, so push back to share memory */
+
+	if (hash_get_num_entries(local_active_table_file_map) > 0)
+	{
+		bool  found;
+		DiskQuotaActiveTableFileEntry *entry;
+
+		/* traverse local active table map and rewrite them into share memory */
+		hash_seq_init(&iter, local_active_table_file_map);
+		LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
+
+		while ((active_table_file_entry = (DiskQuotaActiveTableFileEntry *) hash_seq_search(&iter)) != NULL)
+		{
+			entry = hash_search(active_tables_map, &active_table_file_entry->node, HASH_ENTER_NULL, &found);
+			if (entry)
+			{
+				*entry = *active_table_file_entry;
+			}
+		}
+		LWLockRelease(diskquota_locks.active_table_lock);
+	}
+
 	hash_destroy(local_active_table_file_map);
 	return local_active_table_stats_map;
 }
 
-/*
+/**
  *  Hook function in smgr to report the active table
  *  information and stroe them in active table shared memory
  *  diskquota worker will consuming these active tables and
  *  recalculate their file size to update diskquota model.
  */
 static void
-report_active_table_SmgrStat(SMgrRelation reln)
+report_active_table_SmgrStat(SMgrRelation reln, ActiveType at)
 {
-	DiskQuotaActiveTableFileEntry *entry;
-	DiskQuotaActiveTableFileEntry item;
+	DiskQuotaActiveTableFileEntry *entry = NULL;
 	bool found = false;
 
-	MemSet(&item, 0, sizeof(DiskQuotaActiveTableFileEntry));
-	item.dbid = reln->smgr_rnode.node.dbNode;
-	item.relfilenode = reln->smgr_rnode.node.relNode;
-	item.tablespaceoid = reln->smgr_rnode.node.spcNode;
+	/* ignore the system table relfilenode */
+	if (reln->smgr_rnode.node.relNode < FirstNormalObjectId)
+		return;
 
 	LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
-	entry = hash_search(active_tables_map, &item, HASH_ENTER_NULL, &found);
-	if (entry && !found)
-		*entry = item;
-	LWLockRelease(diskquota_locks.active_table_lock);
+	entry = hash_search(active_tables_map, &reln->smgr_rnode.node, HASH_ENTER_NULL, &found);
+	if (entry && !entry->ispushedback)
+	{
+		entry->node = reln->smgr_rnode.node;
+		switch (at)
+		{
+			case AT_EXTEND :
+			case AT_TRUNCATE :
+				entry->tablestatus = TABLE_COMMIT_CHANGE;
+				entry->inXnamespace = InvalidOid;
+				entry->inXowner = InvalidOid;
+				break;
+			case AT_CREATE:
+				entry->tablestatus = TABLE_COMMIT_CREATE;
+				entry->inXnamespace = InvalidOid;
+				entry->inXowner = InvalidOid; 
+				break;
+			case AT_UNLINK:
+				entry->tablestatus = TABLE_COMMIT_DELETE;
+				entry->inXnamespace = InvalidOid;
+				entry->inXowner = InvalidOid; 
+				break;
+			default:
+				entry->tablestatus = TABLE_UNKNOWN;
+				break;
+		}
 
-	if (!found && entry == NULL) {
+	}
+	/*
+	 * if the entry is still in active list and marked as un-committed,
+	 * this means the entry is only visible in transaction, and need to process here
+	 * TODO: this is time consuming, may need to let user to choose enable or disable
+	 */
+	else if (entry && found && entry->ispushedback)
+	{
+		Oid relOid;
+		HeapTuple tuple;
+		Form_pg_class rel;
+	
+		/* 
+		 * If the entry status is TABLE_NOT_FOUND, but its action type is AT_UNLINK. This means
+		 * the transaction is under committing or aborting, hence we just need ignore this active
+		 * entry and send its unlink status back to worker.
+		 */
+		if (at == AT_UNLINK)
+		{
+			entry->tablestatus = TABLE_IN_TRANSX_DELETE;
+		}
+		else
+		{
+			relOid = RelidByRelfilenode(entry->node.spcNode, entry->node.relNode);
+			tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relOid));
+			if (HeapTupleIsValid(tuple))
+			{
+				rel = (Form_pg_class) GETSTRUCT(tuple);
+				entry->inXnamespace = rel->relnamespace;
+				entry->inXowner = rel->relowner;
+				switch (at)
+				{
+				case AT_EXTEND :
+				case AT_TRUNCATE :
+					entry->tablestatus = TABLE_IN_TRANSX_CHANGE;
+					break;
+				case AT_CREATE:
+					entry->tablestatus = TABLE_IN_TRANSX_CREATE;
+					break;
+				default:
+					entry->tablestatus = TABLE_UNKNOWN;
+					break;
+				}
+				ReleaseSysCache(tuple);
+			}
+			else
+			{
+				ereport(LOG, (errmsg("Unknown database file with tablespace:relfilenode is %d:%d"
+									 ,entry->node.spcNode, entry->node.relNode)));
+				entry->tablestatus = TABLE_UNKNOWN;
+
+			}
+		}
+
+	}
+	else if (entry == NULL)
+	{
 		/* We may miss the file size change of this relation at current refresh interval.*/
 		ereport(WARNING, (errmsg("Share memory is not enough for active tables.")));
+
 	}
+	LWLockRelease(diskquota_locks.active_table_lock);
 }

--- a/activetable.h
+++ b/activetable.h
@@ -3,18 +3,45 @@
 
 #include "diskquota.h"
 
+/* Type of status of returned active table objects*/
+typedef enum
+{
+	TABLE_COMMIT_CHANGE = 0,
+	TABLE_COMMIT_CREATE = 1,
+	TABLE_COMMIT_DELETE = 2,
+	TABLE_IN_TRANSX_CHANGE = 3,
+	TABLE_IN_TRANSX_CREATE = 4,
+	TABLE_IN_TRANSX_DELETE = 5,
+	TABLE_NOT_FOUND = 6,
+	TABLE_UNKNOWN = 99,
+} ATStatus;
+
+typedef enum
+{
+	AT_CREATE = 1,
+	AT_EXTEND = 2,
+	AT_TRUNCATE = 3,
+	AT_UNLINK = 4,
+} ActiveType;
+
 /* Cache to detect the active table list */
 typedef struct DiskQuotaActiveTableFileEntry
 {
-	Oid         dbid;
-	Oid         relfilenode;
-	Oid         tablespaceoid;
+	RelFileNode     node;
+	Oid             inXnamespace;
+	Oid             inXowner;
+	ATStatus        tablestatus;
+	bool			ispushedback;
+
 } DiskQuotaActiveTableFileEntry;
 
 typedef struct DiskQuotaActiveTableEntry
 {
-	Oid     tableoid;
-	Size    tablesize;
+	RelFileNode     node;
+	int64           tablesize;
+	Oid             namespace;
+	Oid             owner;
+	ActiveType      type;
 } DiskQuotaActiveTableEntry;
 
 

--- a/diskquota.c
+++ b/diskquota.c
@@ -57,9 +57,12 @@ static volatile sig_atomic_t got_sighup = false;
 static volatile sig_atomic_t got_sigterm = false;
 static volatile sig_atomic_t got_sigusr1 = false;
 
+ #define MAX_DISK_QUOTA_ACTIVE_ENTRIES (1 * 1024 * 1024)
+
 /* GUC variables */
 int	diskquota_naptime = 0;
-int diskquota_max_active_tables = 0;
+char *diskquota_monitored_database_list = NULL;
+int diskquota_max_active_tables = MAX_DISK_QUOTA_ACTIVE_ENTRIES;
 
 typedef struct DiskQuotaWorkerEntry DiskQuotaWorkerEntry;
 

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -3,6 +3,7 @@ test: prepare
 test: test_role test_schema test_drop_table test_column test_copy test_update test_toast test_truncate test_reschema test_temp_role test_rename
 test: test_partition
 test: test_vacuum
+test: test_transaction
 test: test_extension
 test: clean
 

--- a/expected/test_transaction.out
+++ b/expected/test_transaction.out
@@ -1,0 +1,97 @@
+-- Test schema
+create schema ts1;
+select diskquota.set_schema_quota('ts1', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+BEGIN;
+create table ts1.a(i int);
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+ERROR:  schema's disk space quota exceeded with name:ts1
+END;
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+BEGIN;
+create table ts1.a(i int);
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+create table ts1.a2(i int);
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+END;
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+ERROR:  schema's disk space quota exceeded with name:ts1
+BEGIN;
+-- expect insert fail
+insert into ts1.a2 select generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:ts1
+END;
+BEGIN;
+drop table ts1.a;
+ABORT;
+select pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+BEGIN;
+-- expect insert fail
+insert into ts1.a2 select generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:ts1
+END;
+BEGIN;
+drop table ts1.a;
+END;
+select pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+BEGIN;
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+END;
+BEGIN;
+create table ts1.a(i int);
+END;
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+ERROR:  schema's disk space quota exceeded with name:ts1
+BEGIN;
+truncate table ts1.a;
+truncate table ts1.a2;
+savepoint p1;
+drop table ts1.a;
+rollback to p1;
+END;
+select pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+BEGIN;
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+ERROR:  schema's disk space quota exceeded with name:ts1
+END;
+drop schema ts1 CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table ts1.a2
+drop cascades to table ts1.a

--- a/pg_utils.c
+++ b/pg_utils.c
@@ -1,0 +1,96 @@
+/* -------------------------------------------------------------------------
+ *
+ * pg_utils.c
+ *
+ * This code is utils for detecting active table for databases
+ *
+ * Copyright (C) 2013, PostgreSQL Global Development Group
+ *
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "miscadmin.h"
+#include "fmgr.h"
+#include "utils/fmgrprotos.h"
+
+#include "pg_utils.h"
+
+#include <sys/stat.h>
+
+int64 diskquota_get_table_size_by_oid(Oid oid);
+int64 diskquota_get_table_size_by_relfilenode(RelFileNode *rfh);
+/*
+ * calculate size of (one fork of) a table in transaction
+ * This function is following calculate_relation_size()
+ */
+int64
+diskquota_get_table_size_by_relfilenode(RelFileNode *rfn)
+{
+    int64       totalsize = 0;
+    ForkNumber  forkNum;
+    int64       size = 0;
+    char       *relationpath;
+    char        pathname[MAXPGPATH];
+    unsigned int segcount = 0;
+
+    for (forkNum = 0; forkNum <= MAX_FORKNUM; forkNum++)
+    {
+        relationpath = relpathperm(*rfn, forkNum);
+        size = 0;
+
+        for (segcount = 0;; segcount++)
+        {
+            struct stat fst;
+
+            CHECK_FOR_INTERRUPTS();
+
+            if (segcount == 0)
+                snprintf(pathname, MAXPGPATH, "%s",
+                         relationpath);
+            else
+                snprintf(pathname, MAXPGPATH, "%s.%u",
+                         relationpath, segcount);
+
+            if (stat(pathname, &fst) < 0)
+            {
+                if (errno == ENOENT)
+                    break;
+                else
+                    ereport(ERROR,
+                            (errcode_for_file_access(),
+                                errmsg("could not stat file \"%s\": %m", pathname)));
+            }
+            size += fst.st_size;
+        }
+
+        totalsize += size;
+    }
+
+    return totalsize;
+}
+
+/*
+ * Function to calculate the total relation size
+ */
+int64
+diskquota_get_table_size_by_oid(Oid oid)
+{
+    FunctionCallInfoData fcinfo;
+    Datum       result;
+
+    InitFunctionCallInfoData(fcinfo, NULL, 1, InvalidOid, NULL, NULL);
+
+    fcinfo.arg[0] = ObjectIdGetDatum(oid);
+    fcinfo.argnull[0] = false;
+
+    result = pg_total_relation_size(&fcinfo);
+
+    /* Check for null result, since caller is clearly not expecting one */
+    if (fcinfo.isnull)
+        return 0;
+
+    return DatumGetInt64(result);
+}

--- a/pg_utils.h
+++ b/pg_utils.h
@@ -1,0 +1,20 @@
+/* -------------------------------------------------------------------------
+ *
+ * pg_utils.h
+ *
+ * This code is utils for detecting active table for databases
+ *
+ * Copyright (C) 2013, PostgreSQL Global Development Group
+ *
+ *
+ * -------------------------------------------------------------------------
+ */
+#ifndef DISKQUOTA_PG_UTILS_H
+#define DISKQUOTA_PG_UTILS_H
+
+#include "storage/relfilenode.h"
+
+extern int64 diskquota_get_table_size_by_oid(Oid oid);
+extern int64 diskquota_get_table_size_by_relfilenode(RelFileNode *rfh);
+
+#endif //DISKQUOTA_PG_UTILS_H

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -57,11 +57,12 @@ typedef struct LocalBlackMapEntry LocalBlackMapEntry;
 /* local cache of table disk size and corresponding schema and owner */
 struct TableSizeEntry
 {
+	RelFileNode node;       /* hash table key */
 	Oid			reloid;
 	Oid			namespaceoid;
 	Oid			owneroid;
 	int64		totalsize;
-	bool		is_exist; /* flag used to check whether table is already dropped */
+
 };
 
 /* local cache of namespace disk size */
@@ -221,10 +222,10 @@ init_disk_quota_model(void)
 
 	/* init hash table for table/schema/role etc.*/
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.keysize = sizeof(Oid);
+	hash_ctl.keysize = sizeof(RelFileNode);
 	hash_ctl.entrysize = sizeof(TableSizeEntry);
 	hash_ctl.hcxt = CurrentMemoryContext;
-	hash_ctl.hash = oid_hash;
+	hash_ctl.hash = tag_hash;
 
 	table_size_map = hash_create("TableSizeEntry map",
 								1024 * 8,
@@ -511,6 +512,7 @@ calculate_table_disk_usage(bool force)
 	Relation	classRel;
 	HeapTuple	tuple;
 	HeapScanDesc relScan;
+	RelFileNode node;
 	TableSizeEntry *tsentry = NULL;
 	Oid			relOid;
 	HASH_SEQ_STATUS iter;
@@ -520,14 +522,8 @@ calculate_table_disk_usage(bool force)
 	classRel = heap_open(RelationRelationId, AccessShareLock);
 	relScan = heap_beginscan_catalog(classRel, 0, NULL);
 
+	/* TODO: init process could be separated to speed up processing */
 	local_active_table_stat_map = pg_fetch_active_tables(force);
-
-	/* unset is_exist flag for tsentry in table_size_map*/
-	hash_seq_init(&iter, table_size_map);
-	while ((tsentry = hash_seq_search(&iter)) != NULL)
-	{
-		tsentry->is_exist = false;
-	}
 
 	/*
 	 * scan pg_class to detect table event: drop, reset schema, reset owenr.
@@ -538,6 +534,7 @@ calculate_table_disk_usage(bool force)
 	{
 		Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tuple);
 		found = false;
+
 		if (classForm->relkind != RELKIND_RELATION &&
 			classForm->relkind != RELKIND_MATVIEW)
 			continue;
@@ -547,35 +544,47 @@ calculate_table_disk_usage(bool force)
 		if(relOid < FirstNormalObjectId)
 			continue;
 
-		tsentry = (TableSizeEntry *)hash_search(table_size_map,
-							 &relOid,
-							 HASH_ENTER, &found);
-		/* mark tsentry is_exist */
-		if (tsentry)
-			tsentry->is_exist = true;
+		node.dbNode = MyDatabaseId;
+		node.spcNode = MyDatabaseTableSpace;
+		node.relNode = classForm->relfilenode;
 
-		active_table_entry = (DiskQuotaActiveTableEntry *) hash_search(local_active_table_stat_map, &relOid, HASH_FIND, &active_tbl_found);
+		tsentry = (TableSizeEntry *)hash_search(table_size_map,
+		                                        &node,
+		                                        HASH_ENTER, &found);
+
+
+		/* We need to check whether such table is in local cache yet. If not, we init the entry firstly. */
+		if(!found)
+		{
+			tsentry->node = node;
+			tsentry->reloid = relOid;
+			tsentry->namespaceoid = classForm->relnamespace;
+			tsentry->owneroid = classForm->relowner;
+			tsentry->totalsize = 0;
+
+		}
+
+		/* The worker is single thread, so it should be safe when using HASH_REMOVE as there is no other thread
+		 * on this hash table
+		 * */
+		active_table_entry = (DiskQuotaActiveTableEntry *) hash_search(local_active_table_stat_map, &node, HASH_REMOVE, &active_tbl_found);
 
 		/* skip to recalculate the tables which are not in active list and not at initializatio stage*/
 		if(active_tbl_found)
 		{
+			int64 oldtotalsize;
 
-			/* namespace and owner may be changed since last check*/
-			if (!found)
+			if (active_table_entry->type == AT_UNLINK)
 			{
-				/* if it's a new table*/
-				tsentry->reloid = relOid;
-				tsentry->namespaceoid = classForm->relnamespace;
-				tsentry->owneroid = classForm->relowner;
-				tsentry->totalsize = (int64) active_table_entry->tablesize;
-				update_namespace_map(tsentry->namespaceoid, tsentry->totalsize);
-				update_role_map(tsentry->owneroid, tsentry->totalsize);
+				/* in case of the relate file has been removed, but the relfilenode is still existing in catalog */
+				update_namespace_map(tsentry->namespaceoid, -1 * tsentry->totalsize);
+				update_role_map(tsentry->owneroid, -1 * tsentry->totalsize);
+				hash_search(table_size_map, &node, HASH_REMOVE, NULL);
 			}
 			else
 			{
-				/* if not new table in table_size_map, it must be in active table list */
-				int64 oldtotalsize = tsentry->totalsize;
-				tsentry->totalsize = (int64) active_table_entry->tablesize;
+				oldtotalsize = tsentry->totalsize;
+				tsentry->totalsize = active_table_entry->tablesize;
 				update_namespace_map(tsentry->namespaceoid, tsentry->totalsize - oldtotalsize);
 				update_role_map(tsentry->owneroid, tsentry->totalsize - oldtotalsize);
 			}
@@ -599,23 +608,60 @@ calculate_table_disk_usage(bool force)
 
 	heap_endscan(relScan);
 	heap_close(classRel, AccessShareLock);
-	hash_destroy(local_active_table_stat_map);
 
-	/* process removed tables */
-	hash_seq_init(&iter, table_size_map);
-	while ((tsentry = hash_seq_search(&iter)) != NULL)
+	/* process table objects that are not (visible) in catalog yet */
+	hash_seq_init(&iter, local_active_table_stat_map);
+	while ((active_table_entry = (DiskQuotaActiveTableEntry *) hash_seq_search(&iter)) != NULL)
 	{
-		if (tsentry->is_exist == false)
+
+		tsentry = (TableSizeEntry *)hash_search(table_size_map,
+		                                        &active_table_entry->node,
+		                                        HASH_ENTER, &found);
+
+
+
+		/* A new invisible table object found, we need to init it firstly and then do update */
+		if(!found && active_table_entry->type != AT_UNLINK)
+		{
+			tsentry->node = active_table_entry->node;
+			tsentry->reloid = InvalidOid;
+			tsentry->namespaceoid = active_table_entry->namespace;
+			tsentry->owneroid = active_table_entry->owner;
+			tsentry->totalsize = active_table_entry->tablesize;
+
+			update_namespace_map(tsentry->namespaceoid, tsentry->totalsize);
+			update_role_map(tsentry->reloid, tsentry->totalsize);
+
+			ereport(DEBUG1, (errmsg("An active relfilenode %d:%d is added into local cache",
+			                       active_table_entry->node.relNode, active_table_entry->node.spcNode)));
+
+		}
+		else if (found && active_table_entry->type != AT_UNLINK)
+		{
+			int64 oldtotalsize = tsentry->totalsize;
+			tsentry->totalsize = active_table_entry->tablesize;
+			update_namespace_map(tsentry->namespaceoid, tsentry->totalsize - oldtotalsize);
+			update_role_map(tsentry->owneroid, tsentry->totalsize - oldtotalsize);
+			ereport(DEBUG1, (errmsg("An active relfilenode %d:%d is updated into local cache",
+			                     active_table_entry->node.relNode, active_table_entry->node.spcNode)));
+		}
+		else if (found && active_table_entry->type == AT_UNLINK)
 		{
 			update_role_map(tsentry->owneroid, -1 * tsentry->totalsize);
 			update_namespace_map(tsentry->namespaceoid, -1 * tsentry->totalsize);
-
-			hash_search(table_size_map,
-					&tsentry->reloid,
-					HASH_REMOVE, NULL);
-			continue;
+			hash_search(table_size_map, &active_table_entry->node, HASH_REMOVE, NULL);
+			ereport(DEBUG1, (errmsg("An active relfilenode %d:%d is deleted into local cache",
+			                     active_table_entry->node.relNode, active_table_entry->node.spcNode)));
 		}
+		else
+		{
+			ereport(ERROR, (errmsg("An active relfilenode %d:%d is under incorrect status",
+			                     active_table_entry->node.relNode, active_table_entry->node.spcNode)));
+
+		}
+
 	}
+	hash_destroy(local_active_table_stat_map);
 }
 
 /*

--- a/sql/test_transaction.sql
+++ b/sql/test_transaction.sql
@@ -1,0 +1,81 @@
+-- Test schema
+create schema ts1;
+select diskquota.set_schema_quota('ts1', '1 MB');
+BEGIN;
+create table ts1.a(i int);
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+END;
+
+SELECT pg_sleep(5);
+
+BEGIN;
+create table ts1.a(i int);
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+create table ts1.a2(i int);
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+END;
+
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+
+BEGIN;
+-- expect insert fail
+insert into ts1.a2 select generate_series(1,100);
+END;
+
+
+BEGIN;
+drop table ts1.a;
+ABORT;
+
+select pg_sleep(5);
+
+BEGIN;
+-- expect insert fail
+insert into ts1.a2 select generate_series(1,100);
+END;
+
+BEGIN;
+drop table ts1.a;
+END;
+
+select pg_sleep(5);
+
+BEGIN;
+-- expect insert succeed
+insert into ts1.a2 select generate_series(1,100);
+END;
+
+BEGIN;
+create table ts1.a(i int);
+END;
+
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+
+BEGIN;
+truncate table ts1.a;
+truncate table ts1.a2;
+savepoint p1;
+drop table ts1.a;
+rollback to p1;
+END;
+
+select pg_sleep(5);
+
+BEGIN;
+-- expect insert succeed
+insert into ts1.a select generate_series(1,100);
+-- expect insert fail
+insert into ts1.a select generate_series(1,100000000);
+END;
+
+drop schema ts1 CASCADE;
+

--- a/test_diskquota.conf
+++ b/test_diskquota.conf
@@ -3,3 +3,4 @@ fsync = on
 shared_preload_libraries = 'diskquota'
 diskquota.naptime = 2
 max_worker_processes = 12
+diskquota.monitor_databases = 'contrib_regression'


### PR DESCRIPTION
1. Disk quota now support the in-transaction disk
quota usage monitor and enforcement. For example,

```
BEGIN;
CREATE TABLE tbl (i int);
-- will fail if the quota is exceeded during inserting
insert into tbl select generate_series(1,100000000);
ABORT;
```

2. Optimized active checker logic to avoid unexpected behavior
3. Update test cases