### PR TITLE
Update hook interface and remove hook in dispatcher.

### DIFF
--- a/enforcement.c
+++ b/enforcement.c
@@ -24,15 +24,8 @@
 #define CHECKED_OID_LIST_NUM 64
 
 static bool quota_check_ExecCheckRTPerms(List *rangeTable, bool ereport_on_violation);
-static bool quota_check_DispatcherCheckPerms(void);
 
 static ExecutorCheckPerms_hook_type prev_ExecutorCheckPerms_hook;
-static DispatcherCheckPerms_hook_type prev_DispatcherCheckPerms_hook;
-static void diskquota_free_callback(ResourceReleasePhase phase, bool isCommit, bool isTopLevel, void *arg);
-
-/* result relation need to be checked in dispatcher */
-static Oid	checked_reloid_list[CHECKED_OID_LIST_NUM];
-static int	checked_reloid_list_count = 0;
 
 /*
  * Initialize enforcement hooks.
@@ -43,30 +36,6 @@ init_disk_quota_enforcement(void)
 	/* enforcement hook before query is loading data */
 	prev_ExecutorCheckPerms_hook = ExecutorCheckPerms_hook;
 	ExecutorCheckPerms_hook = quota_check_ExecCheckRTPerms;
-
-	/* enforcement hook during query is loading data */
-	prev_DispatcherCheckPerms_hook = DispatcherCheckPerms_hook;
-	DispatcherCheckPerms_hook = quota_check_DispatcherCheckPerms;
-
-	/* setup and reset the result relaiton checked list */
-	memset(checked_reloid_list, 0, sizeof(Oid) * CHECKED_OID_LIST_NUM);
-	RegisterResourceReleaseCallback(diskquota_free_callback, NULL);
-}
-
-/*
- * Reset checked reloid list
- * This may be called multiple times at different resource relase
- * phase, but it's safe to reset the checked_reloid_list.
- */
-static void
-diskquota_free_callback(ResourceReleasePhase phase,
-						bool isCommit,
-						bool isTopLevel,
-						void *arg)
-{
-
-	checked_reloid_list_count = 0;
-	return;
 }
 
 /*
@@ -99,32 +68,6 @@ quota_check_ExecCheckRTPerms(List *rangeTable, bool ereport_on_violation)
 		 * quota limit exceeded.
 		 */
 		quota_check_common(rte->relid);
-		checked_reloid_list[checked_reloid_list_count++] = rte->relid;
-
-	}
-	return true;
-}
-
-/*
- * Enformcent hook function when query is loading data. Throws an error if
- * the quota has been exceeded.
- */
-static bool
-quota_check_DispatcherCheckPerms(void)
-{
-	int			i;
-
-	/* Perform the check as the relation's owner and namespace */
-	for (i = 0; i < checked_reloid_list_count; i++)
-	{
-		Oid			relid = checked_reloid_list[i];
-
-		/*
-		 * Given table oid, check whether the quota limit of table's schema or
-		 * table's owner are reached. This function will ereport(ERROR) when
-		 * quota limit exceeded.
-		 */
-		quota_check_common(relid);
 	}
 	return true;
 }


### PR DESCRIPTION
GPDB hook for diskquota is merged. Some interface changed:
1 use unified name file_xxx_hook for both AO and heap tables.
2 parameter of hook function changed to RelFileNodeBackend.
3 remove hook in dispatcher.