### PR TITLE
add diskquota soft limit

### DIFF
--- a/enforcement.c
+++ b/enforcement.c
@@ -71,3 +71,4 @@ quota_check_ExecCheckRTPerms(List *rangeTable, bool ereport_on_violation)
 	}
 	return true;
 }
+

--- a/expected/prepare.out
+++ b/expected/prepare.out
@@ -1,13 +1,18 @@
 CREATE EXTENSION diskquota;
 -- start_ignore
 \! gpstop -u
-20181119:10:38:22:019976 gpstop:instance-1:huanzhang-[INFO]:-Starting gpstop with args: -u
-20181119:10:38:22:019976 gpstop:instance-1:huanzhang-[INFO]:-Gathering information and validating the environment...
-20181119:10:38:22:019976 gpstop:instance-1:huanzhang-[INFO]:-Obtaining Greenplum Master catalog information
-20181119:10:38:22:019976 gpstop:instance-1:huanzhang-[INFO]:-Obtaining Segment details from master...
-20181119:10:38:23:019976 gpstop:instance-1:huanzhang-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.13149.g1ff3481 build dev-oss'
-20181119:10:38:23:019976 gpstop:instance-1:huanzhang-[INFO]:-Signalling all postmaster processes to reload
-. 
+20190319:07:07:05:020219 gpstop:df38f510da4b:gpadmin-[INFO]:-Starting gpstop with args: -u
+20190319:07:07:05:020219 gpstop:df38f510da4b:gpadmin-[INFO]:-Gathering information and validating the environment...
+20190319:07:07:05:020219 gpstop:df38f510da4b:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20190319:07:07:05:020219 gpstop:df38f510da4b:gpadmin-[INFO]:-Obtaining Segment details from master...
+20190319:07:07:05:020219 gpstop:df38f510da4b:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.16105.gdfbfc2b build dev'
+20190319:07:07:05:020219 gpstop:df38f510da4b:gpadmin-[INFO]:-Signalling all postmaster processes to reload
+SELECT diskquota.init_table_size_table();
+ init_table_size_table 
+-----------------------
+ 
+(1 row)
+
 -- end_ignore
 SELECT pg_sleep(1);
  pg_sleep 
@@ -36,9 +41,8 @@ CREATE TABLE badquota.t1(i INT);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE badquota.t1 OWNER TO testbody;
-INSERT INTO badquota.t1 SELECT generate_series(0, 100000000);
-ERROR:  schema's disk space quota exceeded with name:badquota
-SELECT pg_sleep(20);
+INSERT INTO badquota.t1 SELECT generate_series(0, 100000);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  

--- a/expected/test_column.out
+++ b/expected/test_column.out
@@ -17,8 +17,13 @@ CREATE TABLE a2(i INT);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- expect fail
-INSERT INTO a2 SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:scolumn
+INSERT INTO a2 SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- expect fail
 INSERT INTO a2 SELECT generate_series(1,10);
 ERROR:  schema's disk space quota exceeded with name:scolumn

--- a/expected/test_copy.out
+++ b/expected/test_copy.out
@@ -12,9 +12,8 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 COPY c FROM '/tmp/csmall.txt';
 -- expect failed 
-INSERT INTO c SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:s3
-SELECT pg_sleep(20);
+INSERT INTO c SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  

--- a/expected/test_delete_quota.out
+++ b/expected/test_delete_quota.out
@@ -11,9 +11,8 @@ CREATE TABLE c (i INT);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- expect failed 
-INSERT INTO c SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:deleteschema
-SELECT pg_sleep(20);
+INSERT INTO c SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  

--- a/expected/test_drop_table.out
+++ b/expected/test_drop_table.out
@@ -15,8 +15,13 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO a SELECT generate_series(1,100);
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:sdrtbl
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- expect insert fail
 INSERT INTO a2 SELECT generate_series(1,100);
 ERROR:  schema's disk space quota exceeded with name:sdrtbl

--- a/expected/test_extension.out
+++ b/expected/test_extension.out
@@ -36,8 +36,13 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
  
 (1 row)
 
-INSERT INTO SX.a values(generate_series(0, 100000000));
-ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
@@ -81,8 +86,13 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
  
 (1 row)
 
-INSERT INTO SX.a values(generate_series(0, 100000000));
-ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
@@ -101,8 +111,13 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
  
 (1 row)
 
-INSERT INTO SX.a values(generate_series(0, 100000000));
-ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
@@ -121,8 +136,13 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
  
 (1 row)
 
-INSERT INTO SX.a values(generate_series(0, 100000000));
-ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
@@ -141,8 +161,13 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
  
 (1 row)
 
-INSERT INTO SX.a values(generate_series(0, 100000000));
-ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
@@ -161,8 +186,13 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
  
 (1 row)
 
-INSERT INTO SX.a values(generate_series(0, 100000000));
-ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
@@ -181,8 +211,13 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
  
 (1 row)
 
-INSERT INTO SX.a values(generate_series(0, 100000000));
-ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
@@ -201,20 +236,25 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
  
 (1 row)
 
-INSERT INTO SX.a values(generate_series(0, 100000000));
-ERROR:  schema's disk space quota exceeded with name:sx
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 INSERT INTO SX.a values(generate_series(0, 10));
 ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx9
 CREATE EXTENSION diskquota;
-ERROR:  [diskquota] failed to create diskquota extension: too many database to monitor (diskquota.c:1056)
+ERROR:  [diskquota] failed to create diskquota extension: too many database to monitor (diskquota.c:1102)
 \! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 11
 \c dbx10
 CREATE EXTENSION diskquota;
-ERROR:  [diskquota] failed to create diskquota extension: too many database to monitor (diskquota.c:1056)
+ERROR:  [diskquota] failed to create diskquota extension: too many database to monitor (diskquota.c:1102)
 \! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 11

--- a/expected/test_fast_disk_check.out
+++ b/expected/test_fast_disk_check.out
@@ -4,8 +4,8 @@ SET search_path to s1;
 CREATE TABLE a(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO a SELECT generate_series(1,2000000);
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,200000);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  
@@ -14,7 +14,7 @@ SELECT pg_sleep(20);
 SELECT (pg_database_size(oid)-dbsize)/dbsize < 0.1  FROM pg_database, diskquota.database_size_view WHERE datname='contrib_regression';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 RESET search_path;

--- a/expected/test_insert_after_drop.out
+++ b/expected/test_insert_after_drop.out
@@ -15,9 +15,8 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO a SELECT generate_series(1,100);
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:sdrtbl
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  

--- a/expected/test_partition.out
+++ b/expected/test_partition.out
@@ -31,8 +31,13 @@ SELECT pg_sleep(20);
 
 INSERT INTO measurement SELECT 1, '2006-02-02' ,1,1;
 -- expect insert fail
-INSERT INTO measurement SELECT generate_series(1,100000000), '2006-03-02' ,1,1;
-ERROR:  schema's disk space quota exceeded with name:s8
+INSERT INTO measurement SELECT generate_series(1,100000), '2006-03-02' ,1,1;
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- expect insert fail
 INSERT INTO measurement SELECT 1, '2006-02-02' ,1,1;
 ERROR:  schema's disk space quota exceeded with name:s8

--- a/expected/test_rename.out
+++ b/expected/test_rename.out
@@ -11,8 +11,13 @@ CREATE TABLE a(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:srs1
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,10);
 ERROR:  schema's disk space quota exceeded with name:srs1
@@ -45,8 +50,13 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE a OWNER TO srerole;
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
-ERROR:  role's disk space quota exceeded with name:srerole
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,10);
 ERROR:  role's disk space quota exceeded with name:srerole

--- a/expected/test_reschema.out
+++ b/expected/test_reschema.out
@@ -11,8 +11,13 @@ CREATE TABLE a(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,1000000000);
-ERROR:  schema's disk space quota exceeded with name:sre
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- expect insert fail when exceed quota limit
 INSERT INTO a SELECT generate_series(1,1000);
 ERROR:  schema's disk space quota exceeded with name:sre

--- a/expected/test_role.out
+++ b/expected/test_role.out
@@ -21,8 +21,13 @@ SELECT diskquota.set_role_quota('u1', '1 MB');
 
 INSERT INTO b SELECT generate_series(1,100);
 -- expect insert fail
-INSERT INTO b SELECT generate_series(1,100000000);
-ERROR:  role's disk space quota exceeded with name:u1
+INSERT INTO b SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- expect insert fail
 INSERT INTO b SELECT generate_series(1,100);
 ERROR:  role's disk space quota exceeded with name:u1

--- a/expected/test_schema.out
+++ b/expected/test_schema.out
@@ -12,8 +12,13 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO a SELECT generate_series(1,100);
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:s1
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,100);
 ERROR:  schema's disk space quota exceeded with name:s1

--- a/expected/test_temp_role.out
+++ b/expected/test_temp_role.out
@@ -18,8 +18,13 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE ta OWNER TO u3temp;
 -- expected failed: fill temp table
-INSERT INTO ta SELECT generate_series(1,100000000);
-ERROR:  role's disk space quota exceeded with name:u3temp
+INSERT INTO ta SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- expected failed: 
 INSERT INTO a SELECT generate_series(1,100);
 ERROR:  role's disk space quota exceeded with name:u3temp

--- a/expected/test_toast.out
+++ b/expected/test_toast.out
@@ -14,7 +14,7 @@ INSERT INTO a5
 SELECT (SELECT 
         string_agg(chr(floor(random() * 26)::int + 65), '')
         FROM generate_series(1,10000)) 
-FROM generate_series(1,10);
+FROM generate_series(1,10000);
 SELECT pg_sleep(20);
  pg_sleep 
 ----------
@@ -25,8 +25,8 @@ SELECT pg_sleep(20);
 INSERT INTO a5
 SELECT (SELECT 
         string_agg(chr(floor(random() * 26)::int + 65), '')
-        FROM generate_series(1,100000)) 
-FROM generate_series(1,1000000);
+        FROM generate_series(1,1000)) 
+FROM generate_series(1,1000);
 ERROR:  schema's disk space quota exceeded with name:s5
 DROP TABLE a5;
 RESET search_path;

--- a/expected/test_truncate.out
+++ b/expected/test_truncate.out
@@ -13,9 +13,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE TABLE b (i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO a SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:s7
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  

--- a/expected/test_update.out
+++ b/expected/test_update.out
@@ -10,9 +10,8 @@ SET search_path TO s4;
 CREATE TABLE a(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO a SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:s4
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  

--- a/expected/test_vacuum.out
+++ b/expected/test_vacuum.out
@@ -13,9 +13,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE TABLE b (i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO a SELECT generate_series(1,100000000);
-ERROR:  schema's disk space quota exceeded with name:s6
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  

--- a/sql/prepare.sql
+++ b/sql/prepare.sql
@@ -13,7 +13,7 @@ SELECT diskquota.set_schema_quota('badquota', '1 MB');
 CREATE ROLE testbody;
 CREATE TABLE badquota.t1(i INT);
 ALTER TABLE badquota.t1 OWNER TO testbody;
-INSERT INTO badquota.t1 SELECT generate_series(0, 100000000);
-SELECT pg_sleep(20);
+INSERT INTO badquota.t1 SELECT generate_series(0, 100000);
+SELECT pg_sleep(10);
 -- expect fail
 INSERT INTO badquota.t1 SELECT generate_series(0, 10);

--- a/sql/test_column.sql
+++ b/sql/test_column.sql
@@ -6,7 +6,8 @@ SELECT pg_sleep(20);
 
 CREATE TABLE a2(i INT);
 -- expect fail
-INSERT INTO a2 SELECT generate_series(1,100000000);
+INSERT INTO a2 SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
 -- expect fail
 INSERT INTO a2 SELECT generate_series(1,10);
 ALTER TABLE a2 ADD COLUMN j VARCHAR(50);

--- a/sql/test_copy.sql
+++ b/sql/test_copy.sql
@@ -6,8 +6,8 @@ SET search_path TO s3;
 CREATE TABLE c (i int);
 COPY c FROM '/tmp/csmall.txt';
 -- expect failed 
-INSERT INTO c SELECT generate_series(1,100000000);
-SELECT pg_sleep(20);
+INSERT INTO c SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
 -- expect copy fail
 COPY c FROM '/tmp/csmall.txt';
 

--- a/sql/test_delete_quota.sql
+++ b/sql/test_delete_quota.sql
@@ -5,8 +5,8 @@ SET search_path TO deleteschema;
 
 CREATE TABLE c (i INT);
 -- expect failed 
-INSERT INTO c SELECT generate_series(1,100000000);
-SELECT pg_sleep(20);
+INSERT INTO c SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
 -- expect fail
 INSERT INTO c SELECT generate_series(1,100);
 SELECT diskquota.set_schema_quota('deleteschema', '-1 MB');

--- a/sql/test_drop_table.sql
+++ b/sql/test_drop_table.sql
@@ -6,7 +6,8 @@ CREATE TABLE a(i INT);
 CREATE TABLE a2(i INT);
 INSERT INTO a SELECT generate_series(1,100);
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
 -- expect insert fail
 INSERT INTO a2 SELECT generate_series(1,100);
 DROP TABLE a;

--- a/sql/test_extension.sql
+++ b/sql/test_extension.sql
@@ -25,7 +25,8 @@ CREATE EXTENSION diskquota;
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
 INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 
@@ -48,7 +49,8 @@ CREATE EXTENSION diskquota;
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
 INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 
@@ -59,7 +61,8 @@ CREATE EXTENSION diskquota;
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
 INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 
@@ -70,7 +73,8 @@ CREATE EXTENSION diskquota;
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
 INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 
@@ -81,7 +85,8 @@ CREATE EXTENSION diskquota;
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
 INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 
@@ -92,7 +97,8 @@ CREATE EXTENSION diskquota;
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
 INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 
@@ -103,7 +109,8 @@ CREATE EXTENSION diskquota;
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
 INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 
@@ -114,7 +121,8 @@ CREATE EXTENSION diskquota;
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 SELECT diskquota.set_schema_quota('SX', '1MB');
-INSERT INTO SX.a values(generate_series(0, 100000000));
+INSERT INTO SX.a values(generate_series(0, 100000));
+SELECT pg_sleep(5);
 INSERT INTO SX.a values(generate_series(0, 10));
 DROP TABLE SX.a;
 

--- a/sql/test_fast_disk_check.sql
+++ b/sql/test_fast_disk_check.sql
@@ -3,8 +3,8 @@ CREATE SCHEMA s1;
 SET search_path to s1;
 
 CREATE TABLE a(i int);
-INSERT INTO a SELECT generate_series(1,2000000);
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,200000);
+SELECT pg_sleep(10);
 SELECT (pg_database_size(oid)-dbsize)/dbsize < 0.1  FROM pg_database, diskquota.database_size_view WHERE datname='contrib_regression';
 RESET search_path;
 DROP TABLE s1.a;

--- a/sql/test_insert_after_drop.sql
+++ b/sql/test_insert_after_drop.sql
@@ -8,8 +8,8 @@ SET search_path TO sdrtbl;
 CREATE TABLE a(i int);
 INSERT INTO a SELECT generate_series(1,100);
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
 INSERT INTO a SELECT generate_series(1,100);
 DROP EXTENSION diskquota;
 -- no sleep, it will take effect immediately

--- a/sql/test_partition.sql
+++ b/sql/test_partition.sql
@@ -18,7 +18,8 @@ INSERT INTO measurement SELECT generate_series(1,100), '2006-02-02' ,1,1;
 SELECT pg_sleep(20);
 INSERT INTO measurement SELECT 1, '2006-02-02' ,1,1;
 -- expect insert fail
-INSERT INTO measurement SELECT generate_series(1,100000000), '2006-03-02' ,1,1;
+INSERT INTO measurement SELECT generate_series(1,100000), '2006-03-02' ,1,1;
+SELECT pg_sleep(5);
 -- expect insert fail
 INSERT INTO measurement SELECT 1, '2006-02-02' ,1,1;
 -- expect insert fail

--- a/sql/test_rename.sql
+++ b/sql/test_rename.sql
@@ -4,7 +4,8 @@ SELECT diskquota.set_schema_quota('srs1', '1 MB');
 set search_path to srs1;
 CREATE TABLE a(i int);
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,10);
 ALTER SCHEMA srs1 RENAME TO srs2;
@@ -30,7 +31,8 @@ CREATE TABLE a(i int);
 ALTER TABLE a OWNER TO srerole;
 
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,10);
 ALTER ROLE srerole RENAME TO srerole2;

--- a/sql/test_reschema.sql
+++ b/sql/test_reschema.sql
@@ -4,7 +4,8 @@ SELECT diskquota.set_schema_quota('srE', '1 MB');
 SET search_path TO srE;
 CREATE TABLE a(i int);
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,1000000000);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
 -- expect insert fail when exceed quota limit
 INSERT INTO a SELECT generate_series(1,1000);
 -- set schema quota larger

--- a/sql/test_role.sql
+++ b/sql/test_role.sql
@@ -14,7 +14,8 @@ SELECT diskquota.set_role_quota('u1', '1 MB');
 
 INSERT INTO b SELECT generate_series(1,100);
 -- expect insert fail
-INSERT INTO b SELECT generate_series(1,100000000);
+INSERT INTO b SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
 -- expect insert fail
 INSERT INTO b SELECT generate_series(1,100);
 -- expect insert fail

--- a/sql/test_schema.sql
+++ b/sql/test_schema.sql
@@ -6,7 +6,8 @@ SET search_path TO s1;
 CREATE TABLE a(i int);
 INSERT INTO a SELECT generate_series(1,100);
 -- expect insert fail
-INSERT INTO a SELECT generate_series(1,100000000);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,100);
 CREATE TABLE a2(i int);

--- a/sql/test_temp_role.sql
+++ b/sql/test_temp_role.sql
@@ -10,7 +10,8 @@ CREATE TEMP TABLE ta(i int);
 ALTER TABLE ta OWNER TO u3temp;
 
 -- expected failed: fill temp table
-INSERT INTO ta SELECT generate_series(1,100000000);
+INSERT INTO ta SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
 -- expected failed: 
 INSERT INTO a SELECT generate_series(1,100);
 DROP TABLE ta;

--- a/sql/test_toast.sql
+++ b/sql/test_toast.sql
@@ -7,15 +7,15 @@ INSERT INTO a5
 SELECT (SELECT 
         string_agg(chr(floor(random() * 26)::int + 65), '')
         FROM generate_series(1,10000)) 
-FROM generate_series(1,10);
+FROM generate_series(1,10000);
 
 SELECT pg_sleep(20);
 -- expect insert toast fail
 INSERT INTO a5
 SELECT (SELECT 
         string_agg(chr(floor(random() * 26)::int + 65), '')
-        FROM generate_series(1,100000)) 
-FROM generate_series(1,1000000);
+        FROM generate_series(1,1000)) 
+FROM generate_series(1,1000);
 
 DROP TABLE a5;
 RESET search_path;

--- a/sql/test_truncate.sql
+++ b/sql/test_truncate.sql
@@ -4,8 +4,8 @@ SELECT diskquota.set_schema_quota('s7', '1 MB');
 SET search_path TO s7;
 CREATE TABLE a (i int);
 CREATE TABLE b (i int);
-INSERT INTO a SELECT generate_series(1,100000000);
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,30);
 INSERT INTO b SELECT generate_series(1,30);

--- a/sql/test_update.sql
+++ b/sql/test_update.sql
@@ -3,8 +3,8 @@ CREATE SCHEMA s4;
 SELECT diskquota.set_schema_quota('s4', '1 MB');
 SET search_path TO s4;
 CREATE TABLE a(i int);
-INSERT INTO a SELECT generate_series(1,100000000);
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
 -- expect update fail.
 UPDATE a SET i = 100;
 DROP TABLE a;

--- a/sql/test_vacuum.sql
+++ b/sql/test_vacuum.sql
@@ -4,8 +4,8 @@ SELECT diskquota.set_schema_quota('s6', '1 MB');
 SET search_path TO s6;
 CREATE TABLE a (i int);
 CREATE TABLE b (i int);
-INSERT INTO a SELECT generate_series(1,100000000);
-SELECT pg_sleep(20);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(10);
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,10);
 -- expect insert fail


### PR DESCRIPTION
1. Add a new GUC diskquota.enable_hardlimit and default is false
2. Change diskquota enforcement to soft limit, therefore, the query
   will not be cancelled even if it aleady hits the diskquota
   limitation.