### PR TITLE
Add try catch for diskquota workers accessing DB.

### DIFF
--- a/diskquota.h
+++ b/diskquota.h
@@ -44,11 +44,13 @@ typedef struct DiskQuotaLocks DiskQuotaLocks;
 struct MessageBox
 {
 	int			launcher_pid;	/* diskquota launcher pid */
-	int			req_pid;		/* pid of the QD process which create/drop diskquota extension */
+	int			req_pid;		/* pid of the QD process which create/drop
+								 * diskquota extension */
 	int			cmd;			/* message command type, see MessageCommand */
 	int			result;			/* message result writen by launcher, see
 								 * MessageResult */
-	int			dbid;		/* dbid of create/drop diskquota extensionstatement */
+	int			dbid;			/* dbid of create/drop diskquota
+								 * extensionstatement */
 };
 
 enum MessageCommand

--- a/enforcement.c
+++ b/enforcement.c
@@ -71,4 +71,3 @@ quota_check_ExecCheckRTPerms(List *rangeTable, bool ereport_on_violation)
 	}
 	return true;
 }
-

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -530,11 +530,16 @@ get_active_tables(void)
 			hash_search(local_active_table_file_map, active_table_file_entry, HASH_REMOVE, NULL);
 		}
 	}
-	/* If cannot convert relfilenode to relOid, put them back and wait for the next check. */
+
+	/*
+	 * If cannot convert relfilenode to relOid, put them back and wait for the
+	 * next check.
+	 */
 	if (hash_get_num_entries(local_active_table_file_map) > 0)
 	{
-		bool  found;
+		bool		found;
 		DiskQuotaActiveTableFileEntry *entry;
+
 		hash_seq_init(&iter, local_active_table_file_map);
 		LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
 		while ((active_table_file_entry = (DiskQuotaActiveTableFileEntry *) hash_seq_search(&iter)) != NULL)


### PR DESCRIPTION
diskquota workers may encounter error when sending SPI
queries to DB, these errors should be catched and workers
process could refetch database in the next loop instead of
exiting the worker processes directly.

Co-authored-by: Haozhou Wang <hawang@pivotal.io>