### PR TITLE
Add test when primary segment is failed

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -450,7 +450,7 @@ start_workers_from_dblist()
 	ret = SPI_connect();
 	if (ret != SPI_OK_CONNECT)
 		elog(ERROR, "[diskquota launcher] SPI connect error, code=%d", ret);
-	ret = SPI_execute("[diskquota launcher] select dbid from diskquota_namespace.database_list;", true, 0);
+	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
 		elog(ERROR, "select diskquota_namespace.database_list");
 	tupdesc = SPI_tuptable->tupdesc;

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -6,6 +6,7 @@ test: test_truncate
 test: test_delete_quota
 test: test_partition
 test: test_vacuum
+test: test_primary_failure
 test: test_extension
 test: clean
 test: test_insert_after_drop

--- a/expected/test_insert_after_drop.out
+++ b/expected/test_insert_after_drop.out
@@ -25,7 +25,13 @@ SELECT pg_sleep(10);
 INSERT INTO a SELECT generate_series(1,100);
 ERROR:  schema's disk space quota exceeded with name:sdrtbl
 DROP EXTENSION diskquota;
--- no sleep, it will take effect immediately
+-- sleep 1 second in case of system slow
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 INSERT INTO a SELECT generate_series(1,100);
 DROP TABLE a;
 \c postgres

--- a/expected/test_primary_failure.out
+++ b/expected/test_primary_failure.out
@@ -1,0 +1,95 @@
+CREATE SCHEMA ftsr;
+SELECT diskquota.set_schema_quota('ftsr', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+SET search_path TO ftsr;
+create or replace language plpythonu;
+--
+-- pg_ctl:
+--   datadir: data directory of process to target with `pg_ctl`
+--   command: commands valid for `pg_ctl`
+--   command_mode: modes valid for `pg_ctl -m`  
+--
+create or replace function pg_ctl(datadir text, command text, command_mode text default 'immediate')
+returns text as $$
+    import subprocess
+    if command not in ('stop', 'restart'):
+        return 'Invalid command input'
+
+    cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir
+    cmd = cmd + '-W -m %s %s' % (command_mode, command)
+
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+$$ language plpythonu;
+CREATE TABLE a(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO a SELECT generate_series(1,100);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- expect insert fail
+INSERT INTO a SELECT generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:ftsr
+-- now one of primary is down
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+        pg_ctl        
+----------------------
+ server shutting down+
+ 
+(1 row)
+
+-- switch mirror to primary
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+-- check GPDB status
+select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+       0 | p              | m    | d      | n
+       0 | m              | p    | u      | n
+(2 rows)
+
+-- expect insert fail
+INSERT INTO a SELECT generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:ftsr
+-- increase quota
+SELECT diskquota.set_schema_quota('ftsr', '200 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+-- pull up failed primary
+-- start_ignore
+-- end_ignore
+-- check GPDB status
+select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+       0 | p              | p    | u      | s
+       0 | m              | m    | u      | s
+(2 rows)
+
+-- no sleep, it will take effect immediately
+SELECT quota_in_mb, nspsize_in_bytes from diskquota.show_schema_quota_view where schema_name='ftsr';
+ quota_in_mb | nspsize_in_bytes 
+-------------+------------------
+         200 |          1310720
+(1 row)
+
+INSERT INTO a SELECT generate_series(1,100);
+DROP TABLE a;
+DROP SCHEMA ftsr CASCADE;
+NOTICE:  drop cascades to function pg_ctl(text,text,text)

--- a/sql/test_insert_after_drop.sql
+++ b/sql/test_insert_after_drop.sql
@@ -12,7 +12,8 @@ INSERT INTO a SELECT generate_series(1,100000);
 SELECT pg_sleep(10);
 INSERT INTO a SELECT generate_series(1,100);
 DROP EXTENSION diskquota;
--- no sleep, it will take effect immediately
+-- sleep 1 second in case of system slow
+SELECT pg_sleep(1);
 INSERT INTO a SELECT generate_series(1,100);
 
 DROP TABLE a;

--- a/sql/test_primary_failure.sql
+++ b/sql/test_primary_failure.sql
@@ -1,0 +1,58 @@
+CREATE SCHEMA ftsr;
+SELECT diskquota.set_schema_quota('ftsr', '1 MB');
+SET search_path TO ftsr;
+create or replace language plpythonu;
+--
+-- pg_ctl:
+--   datadir: data directory of process to target with `pg_ctl`
+--   command: commands valid for `pg_ctl`
+--   command_mode: modes valid for `pg_ctl -m`  
+--
+create or replace function pg_ctl(datadir text, command text, command_mode text default 'immediate')
+returns text as $$
+    import subprocess
+    if command not in ('stop', 'restart'):
+        return 'Invalid command input'
+
+    cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir
+    cmd = cmd + '-W -m %s %s' % (command_mode, command)
+
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+$$ language plpythonu;
+
+CREATE TABLE a(i int);
+INSERT INTO a SELECT generate_series(1,100);
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT pg_sleep(5);
+-- expect insert fail
+INSERT INTO a SELECT generate_series(1,100);
+
+-- now one of primary is down
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
+
+-- switch mirror to primary
+select gp_request_fts_probe_scan();
+
+-- check GPDB status
+select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0;
+
+-- expect insert fail
+INSERT INTO a SELECT generate_series(1,100);
+
+-- increase quota
+SELECT diskquota.set_schema_quota('ftsr', '200 MB');
+
+-- pull up failed primary
+-- start_ignore
+\! gprecoverseg -a
+\! gprecoverseg -ar
+-- end_ignore
+
+-- check GPDB status
+select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0;
+-- no sleep, it will take effect immediately
+SELECT quota_in_mb, nspsize_in_bytes from diskquota.show_schema_quota_view where schema_name='ftsr';
+INSERT INTO a SELECT generate_series(1,100);
+
+DROP TABLE a;
+DROP SCHEMA ftsr CASCADE;


### PR DESCRIPTION
1. Add a new test suit to make sure diskqouta is still working
   when primary segment is failed, and mirror segment is swtich to
   primary