### PR TITLE
Refactor gp_activetable

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -123,7 +123,7 @@ _PG_init(void)
 
 	/* diskquota.so must be in shared_preload_libraries to init SHM. */
 	if (!process_shared_preload_libraries_in_progress)
-		elog(ERROR, "diskquota.so not in shared_preload_libraries.");
+		ereport(ERROR, (errmsg("diskquota.so not in shared_preload_libraries.")));
 
 	init_disk_quota_shmem();
 	init_disk_quota_enforcement();
@@ -517,7 +517,7 @@ create_monitor_db_table(void)
 
 		if (SPI_execute(sql, false, 0) != SPI_OK_UTILITY)
 		{
-			elog(ERROR, "[diskquota launcher] SPI_execute error, sql:'%s', errno:%d", sql, errno);
+			ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute error, sql:'%s', errno:%d", sql, errno)));
 		}
 	}
 	PG_CATCH();
@@ -564,13 +564,13 @@ start_workers_from_dblist(void)
 	PushActiveSnapshot(GetTransactionSnapshot());
 	ret = SPI_connect();
 	if (ret != SPI_OK_CONNECT)
-		elog(ERROR, "[diskquota launcher] SPI connect error, errno:%d", errno);
+		ereport(ERROR, (errmsg("[diskquota launcher] SPI connect error, errno:%d", errno)));
 	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
-		elog(ERROR, "select diskquota_namespace.database_list");
+		ereport(ERROR, (errmsg("select diskquota_namespace.database_list")));
 	tupdesc = SPI_tuptable->tupdesc;
 	if (tupdesc->natts != 1 || tupdesc->attrs[0]->atttypid != OIDOID)
-		elog(ERROR, "[diskquota launcher] table database_list corrupt, laucher will exit");
+		ereport(ERROR, (errmsg("[diskquota launcher] table database_list corrupt, laucher will exit")));
 
 	for (i = 0; num < SPI_processed; i++)
 	{
@@ -582,15 +582,15 @@ start_workers_from_dblist(void)
 		tup = SPI_tuptable->vals[i];
 		dat = SPI_getbinval(tup, tupdesc, 1, &isnull);
 		if (isnull)
-			elog(ERROR, "[diskquota launcher] dbid cann't be null in table database_list");
+			ereport(ERROR, (errmsg("[diskquota launcher] dbid cann't be null in table database_list")));
 		dbid = DatumGetObjectId(dat);
 		if (!is_valid_dbid(dbid))
 		{
-			elog(LOG, "[diskquota launcher] database(oid:%u) in table database_list is not a valid database", dbid);
+			ereport(LOG, (errmsg("[diskquota launcher] database(oid:%u) in table database_list is not a valid database", dbid)));
 			continue;
 		}
 		if (!start_worker_by_dboid(dbid))
-			elog(ERROR, "[diskquota launcher] start worker process of database(oid:%u) failed", dbid);
+			ereport(ERROR, (errmsg("[diskquota launcher] start worker process of database(oid:%u) failed", dbid)));
 		num++;
 
 		/*
@@ -599,7 +599,7 @@ start_workers_from_dblist(void)
 		 */
 		if (num >= MAX_NUM_MONITORED_DB)
 		{
-			elog(LOG, "[diskquota launcher] diskquota monitored database limit is reached, database(oid:%u) will not enable diskquota", dbid);
+			ereport(LOG, (errmsg("[diskquota launcher] diskquota monitored database limit is reached, database(oid:%u) will not enable diskquota", dbid)));
 			break;
 		}
 	}
@@ -630,7 +630,7 @@ process_extension_ddl_message()
 	if (local_extension_ddl_message.req_pid == 0 || local_extension_ddl_message.launcher_pid != MyProcPid)
 		return;
 
-	elog(LOG, "[diskquota launcher]: received create/drop extension diskquota message");
+	ereport(LOG, (errmsg("[diskquota launcher]: received create/drop extension diskquota message")));
 
 	do_process_extension_ddl_message(&code, local_extension_ddl_message);
 
@@ -690,7 +690,7 @@ do_process_extension_ddl_message(MessageResult * code, ExtensionDDLMessage local
 				*code = ERR_OK;
 				break;
 			default:
-				elog(LOG, "[diskquota launcher]:received unsupported message cmd=%d", local_extension_ddl_message.cmd);
+				ereport(LOG, (errmsg("[diskquota launcher]:received unsupported message cmd=%d", local_extension_ddl_message.cmd)));
 				*code = ERR_UNKNOWN;
 				break;
 		}
@@ -728,12 +728,12 @@ on_add_db(Oid dbid, MessageResult * code)
 	if (num_db >= MAX_NUM_MONITORED_DB)
 	{
 		*code = ERR_EXCEED;
-		elog(ERROR, "[diskquota launcher] too many databases to monitor");
+		ereport(ERROR, (errmsg("[diskquota launcher] too many databases to monitor")));
 	}
 	if (!is_valid_dbid(dbid))
 	{
 		*code = ERR_INVALID_DBID;
-		elog(ERROR, "[diskquota launcher] invalid database oid");
+		ereport(ERROR, (errmsg("[diskquota launcher] invalid database oid")));
 	}
 
 	/*
@@ -754,7 +754,7 @@ on_add_db(Oid dbid, MessageResult * code)
 	if (!start_worker_by_dboid(dbid))
 	{
 		*code = ERR_START_WORKER;
-		elog(ERROR, "[diskquota launcher] failed to start worker - dbid=%u", dbid);
+		ereport(ERROR, (errmsg("[diskquota launcher] failed to start worker - dbid=%u", dbid)));
 	}
 }
 
@@ -771,7 +771,7 @@ on_del_db(Oid dbid, MessageResult * code)
 	if (!is_valid_dbid(dbid))
 	{
 		*code = ERR_INVALID_DBID;
-		elog(ERROR, "[diskquota launcher] invalid database oid");
+		ereport(ERROR, (errmsg("[diskquota launcher] invalid database oid")));
 	}
 
 	/* tell postmaster to stop this bgworker */
@@ -812,7 +812,7 @@ add_dbid_to_database_list(Oid dbid)
 	ret = SPI_execute(str.data, false, 0);
 	if (ret != SPI_OK_INSERT)
 	{
-		elog(ERROR, "[diskquota launcher] SPI_execute sql:'%s', errno:%d", str.data, errno);
+		ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute sql:'%s', errno:%d", str.data, errno)));
 	}
 	return;
 }
@@ -834,7 +834,7 @@ del_dbid_from_database_list(Oid dbid)
 	ret = SPI_execute(str.data, false, 0);
 	if (ret != SPI_OK_DELETE)
 	{
-		elog(ERROR, "[diskquota launcher] SPI_execute sql:'%s', errno:%d", str.data, errno);
+		ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute sql:'%s', errno:%d", str.data, errno)));
 	}
 }
 

--- a/diskquota.h
+++ b/diskquota.h
@@ -11,7 +11,6 @@ typedef enum
 
 typedef enum
 {
-	FETCH_ALL_SIZE,				/* fetch size for all the tables */
 	FETCH_ACTIVE_OID,			/* fetch active table list */
 	FETCH_ACTIVE_SIZE			/* fetch size for active tables */
 }			FetchTableStatType;

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -1,8 +1,10 @@
 /* -------------------------------------------------------------------------
  *
- * activetable.c
+ * gp_activetable.c
  *
  * This code is responsible for detecting active table for databases
+ * quotamodel will call gp_fetch_active_tables() to fetch the active tables
+ * and their size information in each loop.
  *
  * Copyright (c) 2018-Present Pivotal Software, Inc.
  *
@@ -39,6 +41,7 @@
 #include "gp_activetable.h"
 #include "diskquota.h"
 
+PG_FUNCTION_INFO_V1(diskquota_fetch_table_stat);
 
 /* The results set cache for SRF call*/
 typedef struct DiskQuotaSetOFCache
@@ -49,7 +52,7 @@ typedef struct DiskQuotaSetOFCache
 
 HTAB	   *active_tables_map = NULL;
 
-/* active table hooks*/
+/* active table hooks which detect the disk file size change. */
 static file_create_hook_type prev_file_create_hook = NULL;
 static file_extend_hook_type prev_file_extend_hook = NULL;
 static file_truncate_hook_type prev_file_truncate_hook = NULL;
@@ -58,13 +61,11 @@ static void active_table_hook_smgrcreate(RelFileNodeBackend rnode);
 static void active_table_hook_smgrextend(RelFileNodeBackend rnode);
 static void active_table_hook_smgrtruncate(RelFileNodeBackend rnode);
 
-PG_FUNCTION_INFO_V1(diskquota_fetch_table_stat);
-
 static HTAB *get_active_tables_stats(ArrayType *array);
-static HTAB *get_all_tables_size(void);
-static HTAB *get_active_tables(void);
-static StringInfoData convert_map_to_string(HTAB *active_list);
+static HTAB *get_active_tables_oid(void);
 static HTAB *pull_active_list_from_seg(void);
+static void pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_array);
+static StringInfoData convert_map_to_string(HTAB *active_list);
 static void load_table_size(HTAB *local_table_stats_map);
 static void report_active_table_helper(const RelFileNodeBackend *relFileNode);
 
@@ -72,49 +73,6 @@ void		init_active_table_hook(void);
 void		init_shm_worker_active_tables(void);
 void		init_lock_active_tables(void);
 HTAB	   *gp_fetch_active_tables(bool is_init);
-
-/*
- * Register smgr hook to detect active table.
- */
-void
-init_active_table_hook(void)
-{
-	prev_file_create_hook = file_create_hook;
-	file_create_hook = active_table_hook_smgrcreate;
-
-	prev_file_extend_hook = file_extend_hook;
-	file_extend_hook = active_table_hook_smgrextend;
-
-	prev_file_truncate_hook = file_truncate_hook;
-	file_truncate_hook = active_table_hook_smgrtruncate;
-}
-
-static void
-active_table_hook_smgrcreate(RelFileNodeBackend rnode)
-{
-	if (prev_file_create_hook)
-		(*prev_file_create_hook) (rnode);
-
-	report_active_table_helper(&rnode);
-}
-
-static void
-active_table_hook_smgrextend(RelFileNodeBackend rnode)
-{
-	if (prev_file_extend_hook)
-		(*prev_file_extend_hook) (rnode);
-
-	report_active_table_helper(&rnode);
-}
-
-static void
-active_table_hook_smgrtruncate(RelFileNodeBackend rnode)
-{
-	if (prev_file_truncate_hook)
-		(*prev_file_truncate_hook) (rnode);
-
-	report_active_table_helper(&rnode);
-}
 
 /*
  * Init active_tables_map shared memory
@@ -138,9 +96,65 @@ init_shm_worker_active_tables(void)
 }
 
 /*
- * Common function for reporting active tables, used by smgr and ao
+ * Register disk file size change hook to detect active table.
  */
+void
+init_active_table_hook(void)
+{
+	prev_file_create_hook = file_create_hook;
+	file_create_hook = active_table_hook_smgrcreate;
 
+	prev_file_extend_hook = file_extend_hook;
+	file_extend_hook = active_table_hook_smgrextend;
+
+	prev_file_truncate_hook = file_truncate_hook;
+	file_truncate_hook = active_table_hook_smgrtruncate;
+}
+
+/*
+ * File create hook is used to monitor a new file create event
+ */
+static void
+active_table_hook_smgrcreate(RelFileNodeBackend rnode)
+{
+	if (prev_file_create_hook)
+		(*prev_file_create_hook) (rnode);
+
+	report_active_table_helper(&rnode);
+}
+
+/*
+ * File extend hook is used to monitor file size extend event
+ * it could be extending a page for heap table or just monitoring
+ * file write for an append-optimize table.
+ */
+static void
+active_table_hook_smgrextend(RelFileNodeBackend rnode)
+{
+	if (prev_file_extend_hook)
+		(*prev_file_extend_hook) (rnode);
+
+	report_active_table_helper(&rnode);
+}
+
+/*
+ * File truncate hook is used to monitor a new file truncate event
+ */
+static void
+active_table_hook_smgrtruncate(RelFileNodeBackend rnode)
+{
+	if (prev_file_truncate_hook)
+		(*prev_file_truncate_hook) (rnode);
+
+	report_active_table_helper(&rnode);
+}
+
+/*
+ * Common function for reporting active tables
+ * Currently, any file events(create, extend. truncate) are
+ * treated the same and report_active_table_helper just put
+ * the corresponding relFileNode into the active_tables_map
+ */
 static void
 report_active_table_helper(const RelFileNodeBackend *relFileNode)
 {
@@ -157,7 +171,6 @@ report_active_table_helper(const RelFileNodeBackend *relFileNode)
 	entry = hash_search(active_tables_map, &item, HASH_ENTER_NULL, &found);
 	if (entry && !found)
 		*entry = item;
-	LWLockRelease(diskquota_locks.active_table_lock);
 
 	if (!found && entry == NULL)
 	{
@@ -167,20 +180,70 @@ report_active_table_helper(const RelFileNodeBackend *relFileNode)
 		 */
 		ereport(WARNING, (errmsg("Share memory is not enough for active tables.")));
 	}
+	LWLockRelease(diskquota_locks.active_table_lock);
+}
+
+/*
+ * Interface of activetable module
+ * This function is called by quotamodel module.
+ * Disk quota worker process need to collect
+ * active table disk usage from all the segments.
+ * And aggregate the table size on each segment
+ * to get the real table size at cluster level.
+ */
+HTAB *
+gp_fetch_active_tables(bool is_init)
+{
+	HTAB	   *local_table_stats_map = NULL;
+	HASHCTL		ctl;
+	HTAB	   *local_active_table_oid_maps;
+	StringInfoData active_oid_list;
+
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+
+	memset(&ctl, 0, sizeof(ctl));
+	ctl.keysize = sizeof(Oid);
+	ctl.entrysize = sizeof(DiskQuotaActiveTableEntry);
+	ctl.hcxt = CurrentMemoryContext;
+	ctl.hash = oid_hash;
+
+	local_table_stats_map = hash_create("local active table map with relfilenode info",
+										1024,
+										&ctl,
+										HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
+
+	if (is_init)
+	{
+		load_table_size(local_table_stats_map);
+	}
+	else
+	{
+		/* step 1: fetch active oids from all the segments */
+		local_active_table_oid_maps = pull_active_list_from_seg();
+		active_oid_list = convert_map_to_string(local_active_table_oid_maps);
+
+		/* step 2: fetch active table sizes based on active oids */
+		pull_active_table_size_from_seg(local_table_stats_map, active_oid_list.data);
+
+		hash_destroy(local_active_table_oid_maps);
+		pfree(active_oid_list.data);
+	}
+	return local_table_stats_map;
 }
 
 /*
  * Function to get the table size from each segments
- * There are two mode: 1. calcualte disk usage for all
- * the tables, which is called when init the disk quota model.
- * 2. calculate the active table size when refreshing the
- * disk quota model.
+ * There are three mode:
+ * 1. gather active table oid from all the segments, since table may only
+ * be modified on a subset of the segments, we need to firstly gather the
+ * active table oid list from all the segments.
+ * 2. calculate the active table size based on the active table oid list.
  */
 Datum
 diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 {
 	FuncCallContext *funcctx;
-	int32		model = PG_GETARG_INT32(0);
+	int32		mode = PG_GETARG_INT32(0);
 	AttInMetadata *attinmeta;
 	bool		isFirstCall = true;
 
@@ -205,19 +268,16 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 			ereport(ERROR, (errmsg("This function must not be called on master or by user")));
 		}
 
-		switch (model)
+		switch (mode)
 		{
-			case FETCH_ALL_SIZE:
-				localCacheTable = get_all_tables_size();
-				break;
 			case FETCH_ACTIVE_OID:
-				localCacheTable = get_active_tables();
+				localCacheTable = get_active_tables_oid();
 				break;
 			case FETCH_ACTIVE_SIZE:
 				localCacheTable = get_active_tables_stats(PG_GETARG_ARRAYTYPE_P(1));
 				break;
 			default:
-				ereport(ERROR, (errmsg("Unused model number, transaction will be aborted")));
+				ereport(ERROR, (errmsg("Unused mode number, transaction will be aborted")));
 				break;
 
 		}
@@ -338,6 +398,10 @@ get_active_tables_stats(ArrayType *array)
 
 	for (i = 0; i < nitems; i++)
 	{
+		/*
+		 * handle array containing NULL case for general inupt, but the active
+		 * table oid array would not contain NULL in fact
+		 */
 		if (bitmap && (*bitmap & bitmask) == 0)
 		{
 			continue;
@@ -355,6 +419,7 @@ get_active_tables_stats(ArrayType *array)
 			 */
 			PG_TRY();
 			{
+				/* call pg_total_relation_size to get the active table size */
 				entry->tablesize = (Size) DatumGetInt64(DirectFunctionCall1(pg_total_relation_size,
 																			ObjectIdGetDatum(relOid)));
 			}
@@ -385,73 +450,15 @@ get_active_tables_stats(ArrayType *array)
 	return local_table;
 }
 
-
-HTAB *
-get_all_tables_size(void)
-{
-	HTAB	   *local_table_stats_map = NULL;
-	HASHCTL		ctl;
-	HeapTuple	tuple;
-	Relation	classRel;
-	HeapScanDesc relScan;
-
-
-	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(Oid);
-	ctl.entrysize = sizeof(DiskQuotaActiveTableEntry);
-	ctl.hcxt = CurrentMemoryContext;
-	ctl.hash = oid_hash;
-
-	local_table_stats_map = hash_create("local active table map with relfilenode info",
-										1024,
-										&ctl,
-										HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
-
-
-	classRel = heap_open(RelationRelationId, AccessShareLock);
-	relScan = heap_beginscan_catalog(classRel, 0, NULL);
-
-
-	while ((tuple = heap_getnext(relScan, ForwardScanDirection)) != NULL)
-	{
-		Oid			relOid;
-		DiskQuotaActiveTableEntry *entry;
-
-		Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tuple);
-
-		if (classForm->relkind != RELKIND_RELATION &&
-			classForm->relkind != RELKIND_MATVIEW)
-			continue;
-		relOid = HeapTupleGetOid(tuple);
-
-		/* ignore system table */
-		if (relOid < FirstNormalObjectId)
-			continue;
-
-		entry = (DiskQuotaActiveTableEntry *) hash_search(local_table_stats_map, &relOid, HASH_ENTER, NULL);
-
-		entry->tableoid = relOid;
-		entry->tablesize = (Size) DatumGetInt64(DirectFunctionCall1(pg_total_relation_size,
-																	ObjectIdGetDatum(relOid)));
-
-	}
-
-	heap_endscan(relScan);
-	heap_close(classRel, AccessShareLock);
-
-	return local_table_stats_map;
-}
-
-
 /*
  * Get local active table with table oid and table size info.
  * This function first copies active table map from shared memory
  * to local active table map with refilenode info. Then traverses
  * the local map and find corresponding table oid and table file
- * size. Finnaly stores them into local active table map and return.
+ * size. Finally stores them into local active table map and return.
  */
-HTAB *
-get_active_tables(void)
+static HTAB *
+get_active_tables_oid(void)
 {
 	HASHCTL		ctl;
 	HTAB	   *local_active_table_file_map = NULL;
@@ -478,6 +485,7 @@ get_active_tables(void)
 
 	hash_seq_init(&iter, active_tables_map);
 
+	/* copy active table from shared memory into local memory */
 	while ((active_table_file_entry = (DiskQuotaActiveTableFileEntry *) hash_seq_search(&iter)) != NULL)
 	{
 		bool		found;
@@ -507,13 +515,12 @@ get_active_tables(void)
 											   &ctl,
 											   HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
 
-	/* traverse local active table map and calculate their file size. */
-	hash_seq_init(&iter, local_active_table_file_map);
-
 	/*
 	 * scan whole local map, get the oid of each table and calculate the size
 	 * of them
 	 */
+	hash_seq_init(&iter, local_active_table_file_map);
+
 	while ((active_table_file_entry = (DiskQuotaActiveTableFileEntry *) hash_seq_search(&iter)) != NULL)
 	{
 		bool		found;
@@ -532,8 +539,8 @@ get_active_tables(void)
 	}
 
 	/*
-	 * If cannot convert relfilenode to relOid, put them back and wait for the
-	 * next check.
+	 * If cannot convert relfilenode to relOid, put them back to shared memory
+	 * and wait for the next check.
 	 */
 	if (hash_get_num_entries(local_active_table_file_map) > 0)
 	{
@@ -556,6 +563,8 @@ get_active_tables(void)
 
 /*
  * Load table size info from diskquota.table_size table.
+ * This is called when system startup, disk quota black list
+ * and other shared memory will be warmed up by table_size table.
 */
 static void
 load_table_size(HTAB *local_table_stats_map)
@@ -566,23 +575,9 @@ load_table_size(HTAB *local_table_stats_map)
 	bool		found;
 	DiskQuotaActiveTableEntry *quota_entry;
 
-	RangeVar   *rv;
-	Relation	rel;
-
-	rv = makeRangeVar("diskquota", "table_size", -1);
-	rel = heap_openrv_extended(rv, AccessShareLock, true);
-	if (!rel)
-	{
-		/* configuration table is missing. */
-		elog(ERROR, "[diskquota] table \"table_size\" is missing in database \"%s\","
-			 " please recreate diskquota extension",
-			 get_database_name(MyDatabaseId));
-	}
-	heap_close(rel, AccessShareLock);
-
 	ret = SPI_execute("select tableid, size from diskquota.table_size", true, 0);
 	if (ret != SPI_OK_SELECT)
-		elog(ERROR, "[diskquota] load_table_size SPI_execute failed: error code %d", ret);
+		elog(ERROR, "[diskquota] load_table_size SPI_execute failed: error code %d", errno);
 
 	tupdesc = SPI_tuptable->tupdesc;
 	if (tupdesc->natts != 2 ||
@@ -594,6 +589,7 @@ load_table_size(HTAB *local_table_stats_map)
 			 get_database_name(MyDatabaseId));
 	}
 
+	/* push the table oid and size into local_table_stats_map */
 	for (i = 0; i < SPI_processed; i++)
 	{
 		HeapTuple	tup = SPI_tuptable->vals[i];
@@ -624,115 +620,23 @@ load_table_size(HTAB *local_table_stats_map)
 }
 
 /*
- * Worker process at master need to collect
- * active table disk usage from all the segments.
- * And aggregate the table size on each segment
- * to obtainer the real table size at cluster level.
- */
-HTAB *
-gp_fetch_active_tables(bool is_init)
-{
-	CdbPgResults cdb_pgresults = {NULL, 0};
-	int			i,
-				j;
-	char	   *sql;
-	HTAB	   *local_table_stats_map = NULL;
-	HASHCTL		ctl;
-	HTAB	   *local_active_table_maps;
-	StringInfoData buffer;
-	StringInfoData map_string;
-
-	Assert(Gp_role == GP_ROLE_DISPATCH);
-
-	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(Oid);
-	ctl.entrysize = sizeof(DiskQuotaActiveTableEntry);
-	ctl.hcxt = CurrentMemoryContext;
-	ctl.hash = oid_hash;
-
-	local_table_stats_map = hash_create("local active table map with relfilenode info",
-										1024,
-										&ctl,
-										HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
-
-	if (is_init)
-	{
-		load_table_size(local_table_stats_map);
-	}
-	else
-	{
-		local_active_table_maps = pull_active_list_from_seg();
-		map_string = convert_map_to_string(local_active_table_maps);
-		initStringInfo(&buffer);
-		appendStringInfo(&buffer, "select * from diskquota.diskquota_fetch_table_stat(2, '%s'::oid[])",
-						 map_string.data);
-		sql = buffer.data;
-
-		CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
-
-		/* collect data from each segment */
-		for (i = 0; i < cdb_pgresults.numResults; i++)
-		{
-
-			Size		tableSize;
-			bool		found;
-			Oid			tableOid;
-			DiskQuotaActiveTableEntry *entry;
-
-			struct pg_result *pgresult = cdb_pgresults.pg_results[i];
-
-			if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
-			{
-				cdbdisp_clearCdbPgResults(&cdb_pgresults);
-				ereport(ERROR,
-						(errmsg("unexpected result from segment: %d",
-								PQresultStatus(pgresult))));
-			}
-
-			for (j = 0; j < PQntuples(pgresult); j++)
-			{
-				tableOid = atooid(PQgetvalue(pgresult, j, 0));
-				tableSize = (Size) atoll(PQgetvalue(pgresult, j, 1));
-
-				entry = (DiskQuotaActiveTableEntry *) hash_search(
-																  local_table_stats_map, &tableOid, HASH_ENTER, &found);
-
-				if (!found)
-				{
-					entry->tableoid = tableOid;
-					entry->tablesize = tableSize;
-				}
-				else
-				{
-					entry->tablesize = entry->tablesize + tableSize;
-				}
-
-			}
-		}
-		cdbdisp_clearCdbPgResults(&cdb_pgresults);
-	}
-	return local_table_stats_map;
-}
-
-
-/*
  * Convert a hash map with oids into a string array
  * This function is used to prepare the second array parameter
  * of function diskquota_fetch_table_stat.
  */
 static StringInfoData
-convert_map_to_string(HTAB *active_list)
+convert_map_to_string(HTAB *local_active_table_oid_maps)
 {
 	HASH_SEQ_STATUS iter;
 	StringInfoData buffer;
 	DiskQuotaActiveTableEntry *entry;
 	uint32		count = 0;
-	uint32		nitems = hash_get_num_entries(active_list);
+	uint32		nitems = hash_get_num_entries(local_active_table_oid_maps);
 
 	initStringInfo(&buffer);
 	appendStringInfo(&buffer, "{");
 
-	hash_seq_init(&iter, active_list);
+	hash_seq_init(&iter, local_active_table_oid_maps);
 
 	while ((entry = (DiskQuotaActiveTableEntry *) hash_seq_search(&iter)) != NULL)
 	{
@@ -753,13 +657,10 @@ convert_map_to_string(HTAB *active_list)
 
 
 /*
- * Get active table list from all the segments.
- * Since when loading data, there is case where only subset for
- * segment doing the real loading. As a result, the same table
- * maybe active on some segemnts while not active on others. We
- * haven't store the table size for each segment on master(to save
- * memory), so when re-calcualte the table size, we need to sum the
- * table size on all of the segments.
+ * Get active table size from all the segments based on
+ * active table oid list.
+ * Function diskquota_fetch_table_stat is called to calculate
+ * the table size on the fly.
  */
 static HTAB *
 pull_active_list_from_seg(void)
@@ -767,8 +668,8 @@ pull_active_list_from_seg(void)
 	CdbPgResults cdb_pgresults = {NULL, 0};
 	int			i,
 				j;
-	char	   *sql;
-	HTAB	   *local_table_stats_map = NULL;
+	char	   *sql = NULL;
+	HTAB	   *local_active_table_oid_map = NULL;
 	HASHCTL		ctl;
 	DiskQuotaActiveTableEntry *entry;
 
@@ -778,19 +679,20 @@ pull_active_list_from_seg(void)
 	ctl.hcxt = CurrentMemoryContext;
 	ctl.hash = oid_hash;
 
-	local_table_stats_map = hash_create("local active table map with relfilenode info",
-										1024,
-										&ctl,
-										HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
+	local_active_table_oid_map = hash_create("local active table map with relfilenode info",
+											 1024,
+											 &ctl,
+											 HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
 
 
-	sql = "select * from diskquota.diskquota_fetch_table_stat(1, '{}'::oid[])";
+	/* first get all oid of tables which are active table on any segment */
+	sql = "select * from diskquota.diskquota_fetch_table_stat(0, '{}'::oid[])";
 
+	/* any errors will be catch in upper level */
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
 
 	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{
-
 		Oid			tableOid;
 		bool		found;
 
@@ -800,25 +702,93 @@ pull_active_list_from_seg(void)
 		{
 			cdbdisp_clearCdbPgResults(&cdb_pgresults);
 			ereport(ERROR,
-					(errmsg("unexpected result from segment: %d",
+					(errmsg("[diskquota] fetching active tables, encounter unexpected result from segment: %d",
 							PQresultStatus(pgresult))));
 		}
 
+		/* push the active table oid into local_active_table_oid_map */
 		for (j = 0; j < PQntuples(pgresult); j++)
 		{
 			tableOid = atooid(PQgetvalue(pgresult, j, 0));
 
-			entry = (DiskQuotaActiveTableEntry *) hash_search(local_table_stats_map, &tableOid, HASH_ENTER, &found);
+			entry = (DiskQuotaActiveTableEntry *) hash_search(local_active_table_oid_map, &tableOid, HASH_ENTER, &found);
 
 			if (!found)
 			{
 				entry->tableoid = tableOid;
 				entry->tablesize = 0;
 			}
-
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
-	return local_table_stats_map;
+	return local_active_table_oid_map;
+}
+
+/*
+ * Get active table list from all the segments.
+ * Since when loading data, there is case where only subset for
+ * segment doing the real loading. As a result, the same table
+ * maybe active on some segments while not active on others. We
+ * haven't store the table size for each segment on master(to save
+ * memory), so when re-calculate the table size, we need to sum the
+ * table size on all of the segments.
+ */
+static void
+pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_array)
+{
+	CdbPgResults cdb_pgresults = {NULL, 0};
+	StringInfoData sql_command;
+	int			i;
+	int			j;
+
+	initStringInfo(&sql_command);
+	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, '%s'::oid[])",
+					 active_oid_array);
+	CdbDispatchCommand(sql_command.data, DF_NONE, &cdb_pgresults);
+	pfree(sql_command.data);
+
+	/* sum table size from each segment into local_table_stats_map */
+	for (i = 0; i < cdb_pgresults.numResults; i++)
+	{
+
+		Size		tableSize;
+		bool		found;
+		Oid			tableOid;
+		DiskQuotaActiveTableEntry *entry;
+
+		struct pg_result *pgresult = cdb_pgresults.pg_results[i];
+
+		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
+		{
+			cdbdisp_clearCdbPgResults(&cdb_pgresults);
+			ereport(ERROR,
+					(errmsg("[diskquota] fetching active tables, encounter unexpected result from segment: %d",
+							PQresultStatus(pgresult))));
+		}
+
+		for (j = 0; j < PQntuples(pgresult); j++)
+		{
+			tableOid = atooid(PQgetvalue(pgresult, j, 0));
+			tableSize = (Size) atoll(PQgetvalue(pgresult, j, 1));
+
+			entry = (DiskQuotaActiveTableEntry *) hash_search(
+															  local_table_stats_map, &tableOid, HASH_ENTER, &found);
+
+			if (!found)
+			{
+				/* receive table size info from the first segment */
+				entry->tableoid = tableOid;
+				entry->tablesize = tableSize;
+			}
+			else
+			{
+				/* sum table size from all the segments */
+				entry->tablesize = entry->tablesize + tableSize;
+			}
+
+		}
+	}
+	cdbdisp_clearCdbPgResults(&cdb_pgresults);
+	return;
 }

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -577,16 +577,16 @@ load_table_size(HTAB *local_table_stats_map)
 
 	ret = SPI_execute("select tableid, size from diskquota.table_size", true, 0);
 	if (ret != SPI_OK_SELECT)
-		elog(ERROR, "[diskquota] load_table_size SPI_execute failed: error code %d", errno);
+		ereport(ERROR, (errmsg("[diskquota] load_table_size SPI_execute failed: error code %d", errno)));
 
 	tupdesc = SPI_tuptable->tupdesc;
 	if (tupdesc->natts != 2 ||
 		((tupdesc)->attrs[0])->atttypid != OIDOID ||
 		((tupdesc)->attrs[1])->atttypid != INT8OID)
 	{
-		elog(ERROR, "[diskquota] table \"table_size\" is corrupted in database \"%s\","
-			 " please recreate diskquota extension",
-			 get_database_name(MyDatabaseId));
+		ereport(ERROR, (errmsg("[diskquota] table \"table_size\" is corrupted in database \"%s\","
+							   " please recreate diskquota extension",
+							   get_database_name(MyDatabaseId))));
 	}
 
 	/* push the table oid and size into local_table_stats_map */


### PR DESCRIPTION
remove unused function get_all_tables_size.
we now get table size info from table_size table when
rebooting.
add new function pull_active_table_size_from_seg to make
gp_fetch_active_tables interface clear.
add some comments