### PR TITLE
calculate table size including QD side file size

### DIFF
--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -1,5 +1,6 @@
 test: init
 test: prepare
+test: test_table_size
 test: test_fast_disk_check
 test: test_role test_schema test_drop_table test_column test_copy test_update test_toast test_truncate test_reschema test_temp_role test_rename test_delete_quota test_mistake
 test: test_truncate

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -128,8 +128,6 @@ init_table_size_table(PG_FUNCTION_ARGS)
 		oid = SPI_getbinval(tup,tupdesc, 1, &isnull);
 		sz = SPI_getbinval(tup,tupdesc, 2, &isnull);
 
-		elog(WARNING,"%u,%ld",oid,sz);
-
 		appendStringInfo(&buf, " ( %u, %ld)", oid, sz);
 		if(i + 1 < SPI_processed)
 			appendStringInfoChar(&buf, ',');

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -101,13 +101,41 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	if (ret != SPI_OK_DELETE)
 		elog(ERROR, "cannot delete table_size table: error code %d", ret);
 
+	/* fetch table size */
+	resetStringInfo(&buf);
+	appendStringInfo(&buf,
+					 "select oid, pg_total_relation_size(oid)"
+					 " from pg_class"
+					 " where oid >= %u and (relkind='r' or relkind='m')",
+					 FirstNormalObjectId);
+	ret = SPI_execute(buf.data, false, 0);
+	if (ret != SPI_OK_SELECT)
+		elog(ERROR, "cannot fetch in pg_total_relation_size. error code %d", ret);
+
 	/* fill table_size table with table oid and size info. */
 	resetStringInfo(&buf);
 	appendStringInfo(&buf,
-					 "insert into diskquota.table_size "
-					 "select oid, sum(pg_total_relation_size(oid)) from gp_dist_random('pg_class') "
-					 "where oid>= %u and (relkind='r' or relkind='m') group by oid;",
-					 FirstNormalObjectId);
+	                 "insert into diskquota.table_size values");
+	TupleDesc tupdesc = SPI_tuptable->tupdesc;
+	for(int i = 0; i < SPI_processed; i++)
+	{
+		HeapTuple   tup;
+		bool        isnull;
+		Oid         oid;
+		int64       sz;
+
+		tup = SPI_tuptable->vals[i];
+		oid = SPI_getbinval(tup,tupdesc, 1, &isnull);
+		sz = SPI_getbinval(tup,tupdesc, 2, &isnull);
+
+		elog(WARNING,"%u,%ld",oid,sz);
+
+		appendStringInfo(&buf, " ( %u, %ld)", oid, sz);
+		if(i + 1 < SPI_processed)
+			appendStringInfoChar(&buf, ',');
+	}
+	appendStringInfo(&buf, ";");
+
 	ret = SPI_execute(buf.data, false, 0);
 	if (ret != SPI_OK_INSERT)
 		elog(ERROR, "cannot insert table_size table: error code %d", ret);

--- a/expected/test_table_size.out
+++ b/expected/test_table_size.out
@@ -1,0 +1,22 @@
+-- Test tablesize table
+create table a(i text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into a select * from generate_series(1,10000);
+select pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+create table buffer(oid oid, relname name, size bigint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'oid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+with size as ( select oid,relname,pg_total_relation_size(oid) from pg_class) insert into buffer select size.oid, size.relname, size.pg_total_relation_size  from size, diskquota.table_size as dt where dt.tableid = size.oid and relname = 'a';
+insert into buffer select oid, relname, sum(pg_total_relation_size(oid)) from gp_dist_random('pg_class') where oid > 16384 and (relkind='r' or relkind='m') and relname = 'a' group by oid, relname;
+select sum(buffer.size) = diskquota.table_size.size from buffer, diskquota.table_size where buffer.oid = diskquota.table_size.tableid group by diskquota.table_size.size;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -601,7 +601,7 @@ calculate_table_disk_usage(bool is_init)
 		/* skip to recalculate the tables which are not in active list */
 		if (active_tbl_found)
 		{
-			/* pretend process as entrydb */
+			/* pretend process as utility mode, and append the table size on master */
 			GpRoleValue Gp_role_backup = Gp_role;
 			Gp_role = GP_ROLE_UTILITY;
 			active_table_entry->tablesize += (Size) DatumGetInt64(DirectFunctionCall1(pg_total_relation_size, ObjectIdGetDatum(relOid)));

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -42,6 +42,7 @@
 #include "utils/syscache.h"
 
 #include <stdlib.h>
+#include <cdb/cdbvars.h>
 
 #include "gp_activetable.h"
 #include "diskquota.h"
@@ -600,6 +601,12 @@ calculate_table_disk_usage(bool is_init)
 		/* skip to recalculate the tables which are not in active list */
 		if (active_tbl_found)
 		{
+			/* pretend process as entrydb */
+			GpRoleValue Gp_role_backup = Gp_role;
+			Gp_role = GP_ROLE_UTILITY;
+			active_table_entry->tablesize += (Size) DatumGetInt64(DirectFunctionCall1(pg_total_relation_size, ObjectIdGetDatum(relOid)));
+			Gp_role = Gp_role_backup;
+
 			/* firstly calculate the updated total size of a table */
 			updated_total_size = active_table_entry->tablesize - tsentry->totalsize;
 

--- a/sql/test_table_size.sql
+++ b/sql/test_table_size.sql
@@ -1,0 +1,14 @@
+-- Test tablesize table
+
+create table a(i text);
+
+insert into a select * from generate_series(1,10000);
+
+select pg_sleep(2);
+create table buffer(oid oid, relname name, size bigint);
+
+with size as ( select oid,relname,pg_total_relation_size(oid) from pg_class) insert into buffer select size.oid, size.relname, size.pg_total_relation_size  from size, diskquota.table_size as dt where dt.tableid = size.oid and relname = 'a';
+
+insert into buffer select oid, relname, sum(pg_total_relation_size(oid)) from gp_dist_random('pg_class') where oid > 16384 and (relkind='r' or relkind='m') and relname = 'a' group by oid, relname;
+
+select sum(buffer.size) = diskquota.table_size.size from buffer, diskquota.table_size where buffer.oid = diskquota.table_size.tableid group by diskquota.table_size.size;


### PR DESCRIPTION
For toast table, QD side also has some table file. pretend diskquota
process as entrydb and grab these small file size.