### PR TITLE
Fix #51 when there ary many table in gpdb

### DIFF
--- a/diskquota.h
+++ b/diskquota.h
@@ -3,6 +3,9 @@
 
 #include "storage/lwlock.h"
 
+/* max number of monitored database with diskquota enabled */
+#define MAX_NUM_MONITORED_DB 10
+
 typedef enum
 {
 	NAMESPACE_QUOTA,
@@ -21,12 +24,14 @@ typedef enum
 	DISKQUOTA_READY_STATE
 }			DiskQuotaState;
 
+#define DiskQuotaLocksItemNumber (5)
 struct DiskQuotaLocks
 {
 	LWLock	   *active_table_lock;
 	LWLock	   *black_map_lock;
 	LWLock	   *extension_ddl_message_lock;
 	LWLock	   *extension_ddl_lock; /* ensure create diskquota extension serially */
+	LWLock	   *monitoring_dbid_cache_lock;
 };
 typedef struct DiskQuotaLocks DiskQuotaLocks;
 

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -9,5 +9,6 @@ test: test_partition
 test: test_vacuum
 test: test_primary_failure
 test: test_extension
+test: test_manytable
 test: clean
 test: test_insert_after_drop

--- a/diskquota_schedule_int
+++ b/diskquota_schedule_int
@@ -6,5 +6,6 @@ test: test_role test_schema test_drop_table test_column test_copy test_update te
 test: test_truncate
 test: test_delete_quota
 test: test_partition
+test: test_manytable
 test: clean
 test: test_insert_after_drop

--- a/expected/test_manytable.out
+++ b/expected/test_manytable.out
@@ -1,0 +1,24 @@
+-- start_ignore
+-- test case manytable change cluster level config, can not run in parallel.
+\! gpconfig -c diskquota.max_active_tables -v 2 > /dev/null
+-- end_ignore
+\! echo $?
+0
+CREATE DATABASE test_manytable01;
+CREATE DATABASE test_manytable02;
+\c test_manytable01
+CREATE TABLE a01(i int) DISTRIBUTED BY (i);
+CREATE TABLE a02(i int) DISTRIBUTED BY (i);
+CREATE TABLE a03(i int) DISTRIBUTED BY (i);
+INSERT INTO a01 values(generate_series(0, 500));
+INSERT INTO a02 values(generate_series(0, 500));
+INSERT INTO a03 values(generate_series(0, 500));
+\c test_manytable02
+CREATE TABLE b01(i int) DISTRIBUTED BY (i);
+INSERT INTO b01 values(generate_series(0, 500));
+\c postgres
+DROP DATABASE test_manytable01;
+DROP DATABASE test_manytable02;
+-- start_ignore
+\! gpconfig -c diskquota.max_active_tables -v 1024 > /dev/null
+-- end_ignore

--- a/gp_activetable.h
+++ b/gp_activetable.h
@@ -24,6 +24,7 @@ extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
 
 extern HTAB *active_tables_map;
+extern HTAB *monitoring_dbid_cache;
 
 #define atooid(x)  ((Oid) strtoul((x), NULL, 10))
 

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -162,8 +162,8 @@ init_disk_quota_shmem(void)
 	 * resources in pgss_shmem_startup().
 	 */
 	RequestAddinShmemSpace(DiskQuotaShmemSize());
-	/* 4 locks for diskquota refer to init_lwlocks() for details */
-	RequestAddinLWLocks(4);
+	/* locks for diskquota refer to init_lwlocks() for details */
+	RequestAddinLWLocks(DiskQuotaLocksItemNumber);
 
 	/* Install startup hook to initialize our shared memory. */
 	prev_shmem_startup_hook = shmem_startup_hook;
@@ -212,6 +212,17 @@ disk_quota_shmem_startup(void)
 
 	init_shm_worker_active_tables();
 
+	memset(&hash_ctl, 0, sizeof(hash_ctl));
+	hash_ctl.keysize = sizeof(Oid);
+	hash_ctl.entrysize = sizeof(Oid);
+	hash_ctl.hash = oid_hash;
+
+	monitoring_dbid_cache = ShmemInitHash("table oid cache which shoud tracking",
+			MAX_NUM_MONITORED_DB,
+			MAX_NUM_MONITORED_DB,
+			&hash_ctl,
+			HASH_ELEM | HASH_FUNCTION);
+
 	LWLockRelease(AddinShmemInitLock);
 }
 
@@ -223,6 +234,7 @@ disk_quota_shmem_startup(void)
  * extension_ddl_message.
  * extension_ddl_lock is used to avoid concurrent diskquota
  * extension ddl(create/drop) command.
+ * monitoring_dbid_cache_lock is used to shared `monitoring_dbid_cache` on segment process.
  */
 static void
 init_lwlocks(void)
@@ -231,6 +243,7 @@ init_lwlocks(void)
 	diskquota_locks.black_map_lock = LWLockAssign();
 	diskquota_locks.extension_ddl_message_lock = LWLockAssign();
 	diskquota_locks.extension_ddl_lock = LWLockAssign();
+	diskquota_locks.monitoring_dbid_cache_lock = LWLockAssign();
 }
 
 /*
@@ -245,6 +258,7 @@ DiskQuotaShmemSize(void)
 	size = sizeof(ExtensionDDLMessage);
 	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_BLACK_ENTRIES, sizeof(BlackMapEntry)));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableEntry)));
+	size = add_size(size, hash_estimate_size(MAX_NUM_MONITORED_DB, sizeof(Oid)));
 	return size;
 }
 

--- a/sql/test_manytable.sql
+++ b/sql/test_manytable.sql
@@ -1,0 +1,29 @@
+-- start_ignore
+\! gpconfig -c diskquota.max_active_tables -v 2 > /dev/null
+-- end_ignore
+\! echo $?
+
+CREATE DATABASE test_manytable01;
+CREATE DATABASE test_manytable02;
+
+\c test_manytable01
+
+CREATE TABLE a01(i int) DISTRIBUTED BY (i);
+CREATE TABLE a02(i int) DISTRIBUTED BY (i);
+CREATE TABLE a03(i int) DISTRIBUTED BY (i);
+
+INSERT INTO a01 values(generate_series(0, 500));
+INSERT INTO a02 values(generate_series(0, 500));
+INSERT INTO a03 values(generate_series(0, 500));
+
+\c test_manytable02
+CREATE TABLE b01(i int) DISTRIBUTED BY (i);
+INSERT INTO b01 values(generate_series(0, 500));
+
+\c postgres
+DROP DATABASE test_manytable01;
+DROP DATABASE test_manytable02;
+
+-- start_ignore
+\! gpconfig -c diskquota.max_active_tables -v 1024 > /dev/null
+-- end_ignore


### PR DESCRIPTION
The issue described in #51 

in fact, there are 3 problems with this issue.

 1. `diskquota.max_active_tables` GUC never take effect (fixed by leskin-in).
 1. the `active_tables_map` actually store all table in prostgresql, not the table in `diskquota_namespace.database_list`.
 1. `diskquota.monitor_databases` GUC never used, different from the document.

The third problem I think it is a feature now, fix it will break current usage.

This PR focus on fixing the second problem. 

In this PR I add shared memory hashtable `monitoring_dbid_cache`, which keeps track of `diskquota_namespace.database_list`.

When file_smgr* hook invoked, check the hash table first and filter out the dbid which should not be monitored.
