### PR TITLE
avoid run pg_relation_size() on master, fix the table_size test case

### DIFF
--- a/expected/test_table_size.out
+++ b/expected/test_table_size.out
@@ -12,7 +12,7 @@ select pg_sleep(2);
 create table buffer(oid oid, relname name, size bigint);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-with size as ( select oid,relname,pg_total_relation_size(oid) from pg_class) insert into buffer select size.oid, size.relname, size.pg_total_relation_size  from size, diskquota.table_size as dt where dt.tableid = size.oid and relname = 'a';
+insert in buffer select oid, relname, pg_total_relation_size(oid) from pg_class, diskquota.table_size as dt where dt.size = oid and relname = 'a';
 insert into buffer select oid, relname, sum(pg_total_relation_size(oid)) from gp_dist_random('pg_class') where oid > 16384 and (relkind='r' or relkind='m') and relname = 'a' group by oid, relname;
 select sum(buffer.size) = diskquota.table_size.size from buffer, diskquota.table_size where buffer.oid = diskquota.table_size.tableid group by diskquota.table_size.size;
  ?column? 

--- a/sql/test_table_size.sql
+++ b/sql/test_table_size.sql
@@ -7,7 +7,7 @@ insert into a select * from generate_series(1,10000);
 select pg_sleep(2);
 create table buffer(oid oid, relname name, size bigint);
 
-with size as ( select oid,relname,pg_total_relation_size(oid) from pg_class) insert into buffer select size.oid, size.relname, size.pg_total_relation_size  from size, diskquota.table_size as dt where dt.tableid = size.oid and relname = 'a';
+insert in buffer select oid, relname, pg_total_relation_size(oid) from pg_class, diskquota.table_size as dt where dt.size = oid and relname = 'a';
 
 insert into buffer select oid, relname, sum(pg_total_relation_size(oid)) from gp_dist_random('pg_class') where oid > 16384 and (relkind='r' or relkind='m') and relname = 'a' group by oid, relname;
 


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/pull/11178 https://github.com/greenplum-db/gpdb/pull/11240 https://github.com/greenplum-db/gpdb/pull/11239 prevents some size-related function from running on master.

fix this by changing the test SQL.

```
gpdb@127:postgres> explain analyze verbose insert into buffer select oid, relname, pg_total_relation_size(oid) from pg_class, diskquota.table_size as dt where dt.tableid = oid and relname = 'a';
+---------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                            |
|---------------------------------------------------------------------------------------------------------------------------------------|
| Insert on public.buffer  (cost=12.49..1183.99 rows=6 width=76) (never executed)                                                       |
|   ->  Hash Join  (cost=12.49..1183.82 rows=6 width=68) (actual time=1.581..2.329 rows=1 loops=1)                                      |
|         Output: pg_class.oid, pg_class.relname, pg_total_relation_size((pg_class.oid)::regclass)                                      |
|         Hash Cond: (dt.tableid = pg_class.oid)                                                                                        |
|         Executor Memory: 1kB  Segments: 1  Max: 1kB (segment 1)                                                                       |
|         work_mem: 1kB  Segments: 1  Max: 1kB (segment 1)  Workfile: (0 spilling)                                                      |
|         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.                                             |
|         ->  Seq Scan on diskquota.table_size dt  (cost=0.00..879.00 rows=25967 width=4) (actual time=0.021..0.031 rows=2 loops=1)     |
|               Output: dt.tableid                                                                                                      |
|         ->  Hash  (cost=12.48..12.48 rows=1 width=68) (actual time=0.790..0.790 rows=1 loops=1)                                       |
|               Output: pg_class.oid, pg_class.relname                                                                                  |
|               ->  Redistribute Motion 1:3  (slice1)  (cost=0.00..12.48 rows=1 width=68) (actual time=0.778..0.780 rows=1 loops=1)     |
|                     Output: pg_class.oid, pg_class.relname                                                                            |
|                     Hash Key: pg_class.oid                                                                                            |
|                     ->  Seq Scan on pg_catalog.pg_class  (cost=0.00..12.46 rows=1 width=68) (actual time=0.030..0.222 rows=1 loops=1) |
|                           Output: pg_class.oid, pg_class.relname                                                                      |
|                           Filter: (pg_class.relname = 'a'::name)                                                                      |
| Planning time: 2.079 ms                                                                                                               |
|   (slice0)    Executor memory: 2137K bytes avg x 3 workers, 2164K bytes max (seg1).  Work_mem: 1K bytes max.                          |
|   (slice1)    Executor memory: 92K bytes (entry db).                                                                                  |
| Memory used:  128000kB                                                                                                                |
| Optimizer: Postgres query optimizer                                                                                                   |
| Execution time: 4.451 ms                                                                                                              |
+---------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN
Time: 0.020s
```