### PR TITLE
Only collect active table info on diskquota enabled database

### DIFF
--- a/diskquota--1.0.sql
+++ b/diskquota--1.0.sql
@@ -9,6 +9,7 @@ CREATE SCHEMA diskquota;
 CREATE TABLE diskquota.quota_config (targetOid oid, quotatype int, quotalimitMB int8, PRIMARY KEY(targetOid, quotatype));
 
 SELECT pg_catalog.pg_extension_config_dump('diskquota.quota_config', '');
+SELECT gp_segment_id, pg_catalog.pg_extension_config_dump('diskquota.quota_config', '') from gp_dist_random('gp_id');
 
 CREATE FUNCTION diskquota.set_schema_quota(text, text)
 RETURNS void STRICT
@@ -16,6 +17,11 @@ AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
 CREATE FUNCTION diskquota.set_role_quota(text, text)
+RETURNS void STRICT
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+CREATE FUNCTION diskquota.update_diskquota_db_list(oid, int4)
 RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;

--- a/diskquota.c
+++ b/diskquota.c
@@ -889,10 +889,10 @@ del_dbid_from_database_list(Oid dbid)
 		ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute sql:'%s', errno:%d", str.data, errno)));
 	}
 	pfree(str.data);
-	
+
 	/* clean the dbid from shared memory*/
 	initStringInfo(&str);
-	appendStringInfo(&str, "select gp_segment_id, diskquota.update_diskquota_db_list(%u, 1)" 
+	appendStringInfo(&str, "select gp_segment_id, diskquota.update_diskquota_db_list(%u, 1)"
 			" from gp_dist_random('gp_id');", dbid);
 	ret = SPI_execute(str.data, true, 0);
 	if (ret != SPI_OK_SELECT)

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -162,7 +162,7 @@ report_active_table_helper(const RelFileNodeBackend *relFileNode)
 	DiskQuotaActiveTableFileEntry *entry;
 	DiskQuotaActiveTableFileEntry item;
 	bool		found = false;
-	Oid dbid = 24067;
+	Oid dbid = relFileNode->node.dbNode;
 
 	
 	/* We do not collect the active table in either master or mirror segments  */

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -162,6 +162,7 @@ report_active_table_helper(const RelFileNodeBackend *relFileNode)
 	DiskQuotaActiveTableFileEntry *entry;
 	DiskQuotaActiveTableFileEntry item;
 	bool		found = false;
+	Oid dbid = 24067;
 
 	
 	/* We do not collect the active table in either master or mirror segments  */
@@ -173,7 +174,7 @@ report_active_table_helper(const RelFileNodeBackend *relFileNode)
 	/* do not collect active table info when the database is not under monitoring.
 	 * this operation is read-only and does not require absolutely exact.
 	 * read the cache with out shared lock */
-	hash_search(monitoring_dbid_cache, &relFileNode->node.dbNode, HASH_FIND, &found);
+	hash_search(monitoring_dbid_cache, &dbid, HASH_FIND, &found);
 
 	if (!found)
 	{

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -42,7 +42,9 @@
 #include "utils/syscache.h"
 
 #include <stdlib.h>
-#include <cdb/cdbvars.h>
+#include "cdb/cdbvars.h"
+#include "cdb/cdbdisp_query.h"
+#include "cdb/cdbdispatchresult.h"
 
 #include "gp_activetable.h"
 #include "diskquota.h"
@@ -408,7 +410,16 @@ do_check_diskquota_state_is_ready(void)
 	int			ret;
 	TupleDesc	tupdesc;
 	int			i;
+	StringInfoData sql_command;
 
+	initStringInfo(&sql_command);
+	appendStringInfo(&sql_command, "select diskquota.update_diskquota_db_list(0, %u);",
+				MyDatabaseId);
+	ret = SPI_execute(sql_command.data, true, 0);
+        if (ret != SPI_OK_SELECT)
+                ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+                                                errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
+	pfree(sql_command.data);
 	/*
 	 * check diskquota state from table diskquota.state errors will be catch
 	 * at upper level function.
@@ -447,6 +458,7 @@ do_check_diskquota_state_is_ready(void)
 	}
 	ereport(WARNING, (errmsg("Diskquota is not in ready state. "
 							 "please run UDF init_table_size_table()")));
+
 	return false;
 }
 

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -412,8 +412,9 @@ do_check_diskquota_state_is_ready(void)
 	int			i;
 	StringInfoData sql_command;
 
+	/* Add the dbid to watching list, so the hook can catch the table change*/
 	initStringInfo(&sql_command);
-	appendStringInfo(&sql_command, "select diskquota.update_diskquota_db_list(0, %u);",
+	appendStringInfo(&sql_command, "select gp_segment_id, diskquota.update_diskquota_db_list(%u, 0) from gp_dist_random('gp_id');",
 				MyDatabaseId);
 	ret = SPI_execute(sql_command.data, true, 0);
         if (ret != SPI_OK_SELECT)


### PR DESCRIPTION
A new shared memory is used in the segments to identify which table should be collected.
Also related to https://github.com/greenplum-db/diskquota/pull/54