### PR TITLE
Fix pipeline

### DIFF
--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -11,7 +11,7 @@ groups:
 
 resource_types:
 - name: gcs
-  type: docker-image
+  type: registry-image
   source:
     repository: frodenas/gcs-resource
 
@@ -20,25 +20,25 @@ resources:
 # Image Resources
 
 - name: centos-gpdb-dev-6
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/data-gpdb-public-images/gpdb5-centos6-build-test
     tag: latest
 
 - name: centos-gpdb-dev-7
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/data-gpdb-public-images/gpdb5-centos7-build-test
     tag: latest
 
 - name: ubuntu18-image-build
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-build
     tag: latest
 
 - name: ubuntu18-image-test
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test
     tag: latest

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -22,25 +22,25 @@ resources:
 - name: centos-gpdb-dev-6
   type: docker-image
   source:
-    repository: pivotaldata/centos-gpdb-dev
-    tag: '6-gcc6.2-llvm3.7'
+    repository: gcr.io/data-gpdb-public-images/gpdb5-centos6-build-test
+    tag: latest
 
 - name: centos-gpdb-dev-7
   type: docker-image
   source:
-    repository: pivotaldata/centos-gpdb-dev
-    tag: '7-gcc6.2-llvm3.7'
+    repository: gcr.io/data-gpdb-public-images/gpdb5-centos7-build-test
+    tag: latest
 
 - name: ubuntu18-image-build
   type: docker-image
   source:
-    repository: pivotaldata/gpdb6-ubuntu18.04-build
+    repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-build
     tag: latest
 
 - name: ubuntu18-image-test
   type: docker-image
   source:
-    repository: pivotaldata/gpdb6-ubuntu18.04-test
+    repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test
     tag: latest
 
 # Github Source Codes
@@ -103,6 +103,8 @@ jobs:
     image: centos-gpdb-dev-7
     input_mapping:
       bin_diskquota: diskquota_artifacts
+    params:
+      DISKQUOTA_OS: rhel7
 
 - name: diskquota_centos6_build_test
   max_in_flight: 3
@@ -124,6 +126,8 @@ jobs:
     image: centos-gpdb-dev-6
     input_mapping:
       bin_diskquota: diskquota_artifacts
+    params:
+      DISKQUOTA_OS: rhel6
 
 - name: diskquota_ubuntu18_build_test
   max_in_flight: 3
@@ -146,4 +150,5 @@ jobs:
     image: ubuntu18-image-test
     input_mapping:
       bin_diskquota: diskquota_artifacts
-
+    params:
+      DISKQUOTA_OS: ubuntu18.04

--- a/concourse/scripts/test_diskquota.sh
+++ b/concourse/scripts/test_diskquota.sh
@@ -5,7 +5,7 @@ set -exo pipefail
 CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_DIR=${CWDIR}/../../../
 GPDB_CONCOURSE_DIR=${TOP_DIR}/gpdb_src/concourse/scripts
-CUT_NUMBER=6
+CUT_NUMBER=5
 
 source "${GPDB_CONCOURSE_DIR}/common.bash"
 function test(){	
@@ -53,8 +53,8 @@ function _main() {
 
 	time make_cluster
 	time install_diskquota
-	if [ "${DISKQUOTA_OS}" == "rhel7" ]; then
-		CUT_NUMBER=5
+	if [ "${DISKQUOTA_OS}" == "ubuntu18.04" ]; then
+		CUT_NUMBER=6
 	fi
 
 	time test


### PR DESCRIPTION
* Fix the docker image
* Fix test_diskquota.sh

The current diskquota pipeline which using the pipeline.yml is: 
https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/diskquota-gpdb-6X-stable
This pipeline is failed now.

The testing diskquota pipeline for this pr is: https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/diskquota-gpdb-6x-stable-xiwang