### PR TITLE
Fix index tbl

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ check interval. Active tables are detected at Segment QE side: hooks in
 smgecreate(), smgrextend() and smgrtruncate() are used to detect active tables
 and store them (currently relfilenode) in the shared memory. Diskquota worker
 process will periodically call dispatch queries to all the segments and 
-consume active tables in shared memories, convert relfilenode to relaton oid, 
-and calcualte table size by calling pg_total_relation_size(), which will sum 
-the size of table (including: base, vm, fsm, toast and index) in each segment.
+consume active tables in shared memories, convert relfilenode to relaton oid,
+and calcualte table size by calling pg_table_size(), which will sum
+the size of table (including: base, vm, fsm, toast) in each segment.
 
 ## Enforcement
 Enforcement is implemented as hooks. There are two kinds of enforcement hooks:
@@ -230,7 +230,7 @@ END;
 'Create Table As' command has the similar problem.
 
 One solution direction is that we calculate the additional 'uncommited data size'
-for schema and role in worker process. Since pg_total_relation_size need to hold
+for schema and role in worker process. Since pg_table_size need to hold
 AccessShareLock to relation (And worker process don't even know this reloid exists),
 we need to skip it, and call stat() directly with tolerant to file unlink.
 Skip lock is dangerous and we plan to leave it as known issue at current stage.

--- a/concourse/scripts/test_diskquota.sh
+++ b/concourse/scripts/test_diskquota.sh
@@ -5,7 +5,7 @@ set -exo pipefail
 CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_DIR=${CWDIR}/../../../
 GPDB_CONCOURSE_DIR=${TOP_DIR}/gpdb_src/concourse/scripts
-CUT_NUMBER=5
+CUT_NUMBER=6
 
 source "${GPDB_CONCOURSE_DIR}/common.bash"
 source "${TOP_DIR}/diskquota_src/concourse/scripts/test_common.sh"
@@ -15,9 +15,6 @@ function _main() {
 
 	time make_cluster
 	time install_diskquota
-	if [ "${DISKQUOTA_OS}" == "ubuntu18.04" -o "${DISKQUOTA_OS}" == "rhel6" ]; then
-		CUT_NUMBER=6
-	fi
 
 	time test ${TOP_DIR}/diskquota_src/ true
 }

--- a/concourse/scripts/upgrade_extension.sh
+++ b/concourse/scripts/upgrade_extension.sh
@@ -5,7 +5,7 @@ set -exo pipefail
 CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_DIR=${CWDIR}/../../../
 GPDB_CONCOURSE_DIR=${TOP_DIR}/gpdb_src/concourse/scripts
-CUT_NUMBER=5
+CUT_NUMBER=6
 
 source "${GPDB_CONCOURSE_DIR}/common.bash"
 source "${TOP_DIR}/diskquota_src/concourse/scripts/test_common.sh"

--- a/diskquota.h
+++ b/diskquota.h
@@ -115,4 +115,5 @@ extern int	diskquota_max_active_tables;
 extern int 	SEGCOUNT;
 extern int  get_ext_major_version(void);
 extern void truncateStringInfo(StringInfo str, int nchars);
+extern List *get_rel_oid_list(void);
 #endif

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -4,7 +4,7 @@ test: prepare
 # test: test_table_size
 test: test_fast_disk_check
 #test: test_insert_after_drop
-test: test_role test_schema test_drop_table test_column test_copy test_update test_toast test_truncate test_reschema test_temp_role test_rename test_delete_quota test_mistake test_tablespace_role test_tablespace_schema test_tablespace_role_perseg test_tablespace_schema_perseg
+test: test_role test_schema test_drop_table test_column test_copy test_update test_toast test_truncate test_reschema test_temp_role test_rename test_delete_quota test_mistake test_tablespace_role test_tablespace_schema test_tablespace_role_perseg test_tablespace_schema_perseg test_index
 test: test_truncate
 test: test_delete_quota
 test: test_partition

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -70,13 +70,15 @@ static int64 get_size_in_mb(char *str);
 static void set_quota_config_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type);
 static void set_target_internal(Oid primaryoid, Oid spcoid, int64 quota_limit_mb, QuotaType type);
 static bool generate_insert_table_size_sql(StringInfoData *buf, int extMajorVersion);
+static char *convert_oidlist_to_string(List *oidlist);
 
 int get_ext_major_version(void);
+List *get_rel_oid_list(void);
 
 /* ---- Help Functions to set quota limit. ---- */
 /*
  * Initialize table diskquota.table_size.
- * calculate table size by UDF pg_total_relation_size
+ * calculate table size by UDF pg_table_size
  * This function is called by user, errors should not
  * be catch, and should be sent back to user
  */
@@ -106,22 +108,24 @@ init_table_size_table(PG_FUNCTION_ARGS)
 			 " please recreate diskquota extension",
 			 get_database_name(MyDatabaseId));
 	}
+	/* FIXME: should here use NoLock? */
 	heap_close(rel, NoLock);
 
 	/*
-	 * Why don't use insert into diskquota.table_size select from pg_total_relation_size here?
+	 * Why don't use insert into diskquota.table_size select from pg_table_size here?
 	 *
-	 * insert into foo select oid, pg_total_relation_size(oid), -1 from pg_class where
+	 * insert into foo select oid, pg_table_size(oid), -1 from pg_class where
 	 * oid >= 16384 and (relkind='r' or relkind='m');
 	 * ERROR:  This query is not currently supported by GPDB.  (entry db 127.0.0.1:6000 pid=61114)
 	 *
 	 * Some functions are peculiar in that they do their own dispatching.
-	 * Such as pg_total_relation_size.
+	 * Such as pg_table_size.
 	 * They do not work on entry db since we do not support dispatching
 	 * from entry-db currently.
 	 */
 	SPI_connect();
 	extMajorVersion = get_ext_major_version();
+	char *oids = convert_oidlist_to_string(get_rel_oid_list());
 
 	/* delete all the table size info in table_size if exist. */
 	initStringInfo(&buf);
@@ -134,13 +138,13 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	/* fetch table size for master*/
 	resetStringInfo(&buf);
 	appendStringInfo(&buf,
-					 "select oid, pg_total_relation_size(oid), -1"
+					 "select oid, pg_table_size(oid), -1"
 					 " from pg_class"
-					 " where oid >= %u and (relkind='r' or relkind='m')",
-					 FirstNormalObjectId);
+					 " where oid in (%s);",
+					 oids);
 	ret = SPI_execute(buf.data, false, 0);
 	if (ret != SPI_OK_SELECT)
-		elog(ERROR, "cannot fetch in pg_total_relation_size. error code %d", ret);
+		elog(ERROR, "cannot fetch in pg_table_size. error code %d", ret);
 
 	/* fill table_size table with table oid and size info for master. */
 	appendStringInfo(&insert_buf,
@@ -149,13 +153,13 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	/* fetch table size on segments*/
 	resetStringInfo(&buf);
 	appendStringInfo(&buf,
-			"select oid, pg_total_relation_size(oid), gp_segment_id"
+			"select oid, pg_table_size(oid), gp_segment_id"
 			" from gp_dist_random('pg_class')"
-			" where oid >= %u and (relkind='r' or relkind='m')",
-			FirstNormalObjectId);
+			" where oid in (%s);",
+			oids);
 	ret = SPI_execute(buf.data, false, 0);
 	if (ret != SPI_OK_SELECT)
-		elog(ERROR, "cannot fetch in pg_total_relation_size. error code %d", ret);
+		elog(ERROR, "cannot fetch in pg_table_size. error code %d", ret);
 
 	/* fill table_size table with table oid and size info for segments. */
 	insert_flag = insert_flag | generate_insert_table_size_sql(&insert_buf, extMajorVersion);
@@ -1023,4 +1027,81 @@ get_ext_major_version(void)
 		return (int)strtol(extversion, (char **) NULL, 10);
 	}
 	return 0;
+}
+
+static char *
+convert_oidlist_to_string(List *oidlist)
+{
+	StringInfoData 	buf;
+	bool		hasOid = false;
+	ListCell   *l;
+	initStringInfo(&buf);
+
+	foreach(l, oidlist)
+	{
+		Oid	oid = lfirst_oid(l);
+		appendStringInfo(&buf, "%u, ", oid);
+		hasOid = true;
+	}
+	if (hasOid)
+		truncateStringInfo(&buf, buf.len - strlen(", "));
+	return buf.data;
+}
+
+/*
+ * Get the list of oids of the tables which diskquota
+ * needs to care about in the database.
+ * Firstly the all the table oids which relkind is 'r'
+ * or 'm' and not system table.
+ * Then, fetch the indexes of those tables.
+ */
+
+List *
+get_rel_oid_list(void)
+{
+	List   		*oidlist = NIL;
+	StringInfoData	buf;
+	int             ret;
+
+	initStringInfo(&buf);
+	appendStringInfo(&buf,
+			"select oid "
+			" from pg_class"
+			" where oid >= %u and (relkind='r' or relkind='m')",
+			FirstNormalObjectId);
+	SPI_connect();
+	ret = SPI_execute(buf.data, false, 0);
+	if (ret != SPI_OK_SELECT)
+		elog(ERROR, "cannot fetch in pg_class. error code %d", ret);
+	TupleDesc tupdesc = SPI_tuptable->tupdesc;
+	for(int i = 0; i < SPI_processed; i++)
+	{
+		HeapTuple	tup;
+		bool        	isnull;
+		Oid         	oid;
+		ListCell   	*l;
+
+		tup = SPI_tuptable->vals[i];
+		oid = DatumGetObjectId(SPI_getbinval(tup,tupdesc, 1, &isnull));
+		if (!isnull)
+		{
+			Relation	relation;
+			List	   	*indexIds;
+			relation = try_relation_open(oid, NoLock, false);
+			if (relation == NULL)
+				continue;
+
+			oidlist = lappend_oid(oidlist, oid);
+			indexIds = RelationGetIndexList(relation);
+			if (indexIds != NIL )
+			{
+				foreach(l, indexIds)
+				{
+					oidlist = lappend_oid(oidlist, lfirst_oid(l));
+				}
+			}
+		        relation_close(relation, NoLock);
+		}
+	}
+	return oidlist;
 }

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -1086,7 +1086,7 @@ get_rel_oid_list(void)
 		{
 			Relation	relation;
 			List	   	*indexIds;
-			relation = try_relation_open(oid, NoLock, false);
+			relation = try_relation_open(oid, AccessShareLock, false);
 			if (relation == NULL)
 				continue;
 

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -108,7 +108,6 @@ init_table_size_table(PG_FUNCTION_ARGS)
 			 " please recreate diskquota extension",
 			 get_database_name(MyDatabaseId));
 	}
-	/* FIXME: should here use NoLock? */
 	heap_close(rel, NoLock);
 
 	/*
@@ -1069,7 +1068,7 @@ get_rel_oid_list(void)
 			" from pg_class"
 			" where oid >= %u and (relkind='r' or relkind='m')",
 			FirstNormalObjectId);
-	SPI_connect();
+
 	ret = SPI_execute(buf.data, false, 0);
 	if (ret != SPI_OK_SELECT)
 		elog(ERROR, "cannot fetch in pg_class. error code %d", ret);

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -1087,7 +1087,7 @@ get_rel_oid_list(void)
 			Relation	relation;
 			List	   	*indexIds;
 			relation = try_relation_open(oid, AccessShareLock, false);
-			if (relation == NULL)
+			if (!relation)
 				continue;
 
 			oidlist = lappend_oid(oidlist, oid);
@@ -1100,6 +1100,7 @@ get_rel_oid_list(void)
 				}
 			}
 		        relation_close(relation, NoLock);
+			list_free(indexIds);
 		}
 	}
 	return oidlist;

--- a/expected/test_index.out
+++ b/expected/test_index.out
@@ -35,7 +35,7 @@ SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and re
  1081344 |    -1
 (1 row)
 
--- create index for the table
+-- create index for the table, index in default tablespace
 CREATE INDEX a_index ON test_index_a(i);
 INSERT INTO test_index_a SELECT generate_series(1,10000);
 SELECT pg_sleep(5);
@@ -46,7 +46,7 @@ SELECT pg_sleep(5);
 
 -- expect insert success
 INSERT INTO test_index_a SELECT generate_series(1,100);
-SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name    ='indexschema1' and tablespace_name='indexspc';
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name ='indexschema1' and tablespace_name='indexspc';
  schema_name  | tablespace_name | quota_in_mb | nspsize_tablespace_in_bytes 
 --------------+-----------------+-------------+-----------------------------
  indexschema1 | indexspc        |           2 |                     1441792
@@ -59,6 +59,7 @@ SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (r
  1212416 |    -1
 (2 rows)
 
+-- add index to tablespace indexspc
 ALTER index a_index SET TABLESPACE indexspc;
 SELECT pg_sleep(20);
  pg_sleep 
@@ -66,7 +67,7 @@ SELECT pg_sleep(20);
  
 (1 row)
 
-SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name    ='indexschema1' and tablespace_name='indexspc';
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name ='indexschema1' and tablespace_name='indexspc';
  schema_name  | tablespace_name | quota_in_mb | nspsize_tablespace_in_bytes 
 --------------+-----------------+-------------+-----------------------------
  indexschema1 | indexspc        |           2 |                     2654208
@@ -78,6 +79,26 @@ SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (r
  1441792 |    -1
  1212416 |    -1
 (2 rows)
+
+-- expect insert fail
+INSERT INTO test_index_a SELECT generate_series(1,100);
+ERROR:  tablespace:indexspc schema:indexschema1 diskquota exceeded
+-- index tablespace quota exceeded 
+ALTER table test_index_a SET TABLESPACE pg_default;
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- expect insert success
+INSERT INTO test_index_a SELECT generate_series(1,100);
+INSERT INTO test_index_a SELECT generate_series(1,200000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
 
 -- expect insert fail
 INSERT INTO test_index_a SELECT generate_series(1,100);

--- a/expected/test_index.out
+++ b/expected/test_index.out
@@ -1,0 +1,90 @@
+-- Test schema
+-- start_ignore
+\! mkdir /tmp/indexspc
+-- end_ignore
+CREATE SCHEMA indexschema1;
+DROP TABLESPACE  IF EXISTS indexspc;
+NOTICE:  tablespace "indexspc" does not exist, skipping
+CREATE TABLESPACE indexspc LOCATION '/tmp/indexspc';
+SET search_path TO indexschema1;
+CREATE TABLE test_index_a(i int) TABLESPACE indexspc;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO test_index_a SELECT generate_series(1,20000);
+SELECT diskquota.set_schema_tablespace_quota('indexschema1', 'indexspc','2 MB');
+ set_schema_tablespace_quota 
+-----------------------------
+ 
+(1 row)
+
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name='indexschema1' and tablespace_name='indexspc';
+ schema_name  | tablespace_name | quota_in_mb | nspsize_tablespace_in_bytes 
+--------------+-----------------+-------------+-----------------------------
+ indexschema1 | indexspc        |           2 |                     1081344
+(1 row)
+
+SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and relname='test_index_a' and segid=-1;
+  size   | segid 
+---------+-------
+ 1081344 |    -1
+(1 row)
+
+-- create index for the table
+CREATE INDEX a_index ON test_index_a(i);
+INSERT INTO test_index_a SELECT generate_series(1,10000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- expect insert success
+INSERT INTO test_index_a SELECT generate_series(1,100);
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name    ='indexschema1' and tablespace_name='indexspc';
+ schema_name  | tablespace_name | quota_in_mb | nspsize_tablespace_in_bytes 
+--------------+-----------------+-------------+-----------------------------
+ indexschema1 | indexspc        |           2 |                     1441792
+(1 row)
+
+SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (relname='test_index_a' or relname='a_index') and segid=-1;
+  size   | segid 
+---------+-------
+ 1441792 |    -1
+ 1212416 |    -1
+(2 rows)
+
+ALTER index a_index SET TABLESPACE indexspc;
+SELECT pg_sleep(20);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name    ='indexschema1' and tablespace_name='indexspc';
+ schema_name  | tablespace_name | quota_in_mb | nspsize_tablespace_in_bytes 
+--------------+-----------------+-------------+-----------------------------
+ indexschema1 | indexspc        |           2 |                     2654208
+(1 row)
+
+SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (relname='test_index_a' or relname='a_index') and segid=-1;
+  size   | segid 
+---------+-------
+ 1441792 |    -1
+ 1212416 |    -1
+(2 rows)
+
+-- expect insert fail
+INSERT INTO test_index_a SELECT generate_series(1,100);
+ERROR:  tablespace:indexspc schema:indexschema1 diskquota exceeded
+RESET search_path;
+DROP INDEX indexschema1.a_index;
+DROP TABLE indexschema1.test_index_a;
+DROP SCHEMA indexschema1;
+DROP TABLESPACE indexspc;
+\! rm -rf /tmp/indexspc

--- a/expected/test_table_size.out
+++ b/expected/test_table_size.out
@@ -12,8 +12,7 @@ select pg_sleep(2);
 create table buffer(oid oid, relname name, size bigint);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'oid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into buffer select oid, relname, pg_total_relation_size(oid) from pg_class, diskquota.table_size as dt where dt.size = oid and relname = 'a';
-insert into buffer select oid, relname, sum(pg_total_relation_size(oid)) from gp_dist_random('pg_class') where oid > 16384 and (relkind='r' or relkind='m') and relname = 'a' group by oid, relname;
+insert into buffer select oid, relname, sum(pg_table_size(oid)) from gp_dist_random('pg_class') where oid > 16384 and (relkind='r' or relkind='m') and relname = 'a' group by oid, relname;
 select sum(buffer.size) = diskquota.table_size.size from buffer, diskquota.table_size where buffer.oid = diskquota.table_size.tableid group by diskquota.table_size.size;
  ?column? 
 ----------

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -395,7 +395,7 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 }
 
 /*
- * Call pg_total_relation_size to calcualte the
+ * Call pg_table_size to calcualte the
  * active table size on each segments.
  */
 static HTAB *
@@ -468,8 +468,8 @@ get_active_tables_stats(ArrayType *array)
 			 */
 			PG_TRY();
 			{
-				/* call pg_total_relation_size to get the active table size */
-				entry->tablesize = (Size) DatumGetInt64(DirectFunctionCall1(pg_total_relation_size,
+				/* call pg_table_size to get the active table size */
+				entry->tablesize = (Size) DatumGetInt64(DirectFunctionCall1(pg_table_size,
 																			ObjectIdGetDatum(relOid)));
 			}
 			PG_CATCH();

--- a/sql/test_index.sql
+++ b/sql/test_index.sql
@@ -13,18 +13,29 @@ SELECT diskquota.set_schema_tablespace_quota('indexschema1', 'indexspc','2 MB');
 SELECT pg_sleep(5);
 SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name='indexschema1' and tablespace_name='indexspc';
 SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and relname='test_index_a' and segid=-1;
--- create index for the table
+-- create index for the table, index in default tablespace
 CREATE INDEX a_index ON test_index_a(i);
 INSERT INTO test_index_a SELECT generate_series(1,10000);
 SELECT pg_sleep(5);
 -- expect insert success
 INSERT INTO test_index_a SELECT generate_series(1,100);
-SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name    ='indexschema1' and tablespace_name='indexspc';
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name ='indexschema1' and tablespace_name='indexspc';
 SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (relname='test_index_a' or relname='a_index') and segid=-1;
+-- add index to tablespace indexspc
 ALTER index a_index SET TABLESPACE indexspc;
 SELECT pg_sleep(20);
-SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name    ='indexschema1' and tablespace_name='indexspc';
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name ='indexschema1' and tablespace_name='indexspc';
 SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (relname='test_index_a' or relname='a_index') and segid=-1;
+-- expect insert fail
+INSERT INTO test_index_a SELECT generate_series(1,100);
+
+-- index tablespace quota exceeded 
+ALTER table test_index_a SET TABLESPACE pg_default;
+SELECT pg_sleep(5);
+-- expect insert success
+INSERT INTO test_index_a SELECT generate_series(1,100);
+INSERT INTO test_index_a SELECT generate_series(1,200000);
+SELECT pg_sleep(5);
 -- expect insert fail
 INSERT INTO test_index_a SELECT generate_series(1,100);
 RESET search_path;

--- a/sql/test_index.sql
+++ b/sql/test_index.sql
@@ -1,0 +1,35 @@
+-- Test schema
+-- start_ignore
+\! mkdir /tmp/indexspc
+-- end_ignore
+CREATE SCHEMA indexschema1;
+DROP TABLESPACE  IF EXISTS indexspc;
+CREATE TABLESPACE indexspc LOCATION '/tmp/indexspc';
+SET search_path TO indexschema1;
+
+CREATE TABLE test_index_a(i int) TABLESPACE indexspc;
+INSERT INTO test_index_a SELECT generate_series(1,20000);
+SELECT diskquota.set_schema_tablespace_quota('indexschema1', 'indexspc','2 MB');
+SELECT pg_sleep(5);
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name='indexschema1' and tablespace_name='indexspc';
+SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and relname='test_index_a' and segid=-1;
+-- create index for the table
+CREATE INDEX a_index ON test_index_a(i);
+INSERT INTO test_index_a SELECT generate_series(1,10000);
+SELECT pg_sleep(5);
+-- expect insert success
+INSERT INTO test_index_a SELECT generate_series(1,100);
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name    ='indexschema1' and tablespace_name='indexspc';
+SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (relname='test_index_a' or relname='a_index') and segid=-1;
+ALTER index a_index SET TABLESPACE indexspc;
+SELECT pg_sleep(20);
+SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name    ='indexschema1' and tablespace_name='indexspc';
+SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (relname='test_index_a' or relname='a_index') and segid=-1;
+-- expect insert fail
+INSERT INTO test_index_a SELECT generate_series(1,100);
+RESET search_path;
+DROP INDEX indexschema1.a_index;
+DROP TABLE indexschema1.test_index_a;
+DROP SCHEMA indexschema1;
+DROP TABLESPACE indexspc;
+\! rm -rf /tmp/indexspc

--- a/sql/test_table_size.sql
+++ b/sql/test_table_size.sql
@@ -7,8 +7,6 @@ insert into a select * from generate_series(1,10000);
 select pg_sleep(2);
 create table buffer(oid oid, relname name, size bigint);
 
-insert into buffer select oid, relname, pg_total_relation_size(oid) from pg_class, diskquota.table_size as dt where dt.size = oid and relname = 'a';
-
-insert into buffer select oid, relname, sum(pg_total_relation_size(oid)) from gp_dist_random('pg_class') where oid > 16384 and (relkind='r' or relkind='m') and relname = 'a' group by oid, relname;
+insert into buffer select oid, relname, sum(pg_table_size(oid)) from gp_dist_random('pg_class') where oid > 16384 and (relkind='r' or relkind='m') and relname = 'a' group by oid, relname;
 
 select sum(buffer.size) = diskquota.table_size.size from buffer, diskquota.table_size where buffer.oid = diskquota.table_size.tableid group by diskquota.table_size.size;


### PR DESCRIPTION
Support index in a different tablespace with the original table

* Use pg_table_size instead of pg_total_realtion_size to get the disk usage.
   pg_table_size includes all forks, toast, and toast index, except the index.

* Add a function to get the list oids of the tables which the diskquota needs to care about in the database
firstly , get the tables which rekind is “r” or “m” and not system tables
```
 "select oid from pg_class"
                        " where oid >= %u and (relkind='r' or relkind='m')",
                        FirstNormalObjectId);
```
then fetch the indexes of those tables and add them to the list.
Use the list of oids in init_table_size_table and calculate_table_disk_usage functions