### PR TITLE
Add support for pausing and resuming the extension.

### DIFF
--- a/diskquota--1.0--2.0.sql
+++ b/diskquota--1.0--2.0.sql
@@ -22,6 +22,16 @@ RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
+CREATE OR REPLACE FUNCTION diskquota.pause()
+RETURNS void STRICT
+AS 'MODULE_PATHNAME', 'diskquota_pause'
+LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION diskquota.resume()
+RETURNS void STRICT
+AS 'MODULE_PATHNAME', 'diskquota_resume'
+LANGUAGE C;
+
 ALTER TABLE diskquota.table_size ADD COLUMN segid smallint DEFAULT -1;
 ALTER TABLE diskquota.table_size DROP CONSTRAINT table_size_pkey;
 ALTER TABLE diskquota.table_size ADD PRIMARY KEY (tableid,segid);

--- a/diskquota--2.0--1.0.sql
+++ b/diskquota--2.0--1.0.sql
@@ -4,6 +4,9 @@ DROP FUNCTION IF EXISTS diskquota.set_role_tablespace_quota(text, text, text);
 
 DROP FUNCTION IF EXISTS diskquota.set_per_segment_quota(text, float4);
 
+DROP FUNCTION IF EXISTS diskquota.pause();
+
+DROP FUNCTION IF EXISTS diskquota.resume();
 
 CREATE OR REPLACE VIEW diskquota.show_fast_schema_quota_view AS
 select pgns.nspname as schema_name, pgc.relnamespace as schema_oid, qc.quotalimitMB as quota_in_mb, sum(ts.size) as nspsize_in_bytes

--- a/diskquota--2.0.sql
+++ b/diskquota--2.0.sql
@@ -64,6 +64,16 @@ RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
+CREATE OR REPLACE FUNCTION diskquota.pause()
+RETURNS void STRICT
+AS 'MODULE_PATHNAME', 'diskquota_pause'
+LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION diskquota.resume()
+RETURNS void STRICT
+AS 'MODULE_PATHNAME', 'diskquota_resume'
+LANGUAGE C;
+
 CREATE VIEW diskquota.show_fast_schema_quota_view AS
 select pgns.nspname as schema_name, pgc.relnamespace as schema_oid, qc.quotalimitMB as quota_in_mb, sum(ts.size) as nspsize_in_bytes
 from diskquota.table_size as ts,

--- a/diskquota.c
+++ b/diskquota.c
@@ -84,6 +84,13 @@ ExtensionDDLMessage *extension_ddl_message = NULL;
 static HTAB *disk_quota_worker_map = NULL;
 static int	num_db = 0;
 
+/*
+ * diskquota_paused is a flag used to pause the extension (when the flag is
+ * enabled, the extension keeps counting the disk usage but doesn't emit an
+ * error when the disk usage limit is exceeded).
+ */
+bool *diskquota_paused = NULL;
+
 /* functions of disk quota*/
 void		_PG_init(void);
 void		_PG_fini(void);

--- a/diskquota.h
+++ b/diskquota.h
@@ -36,6 +36,7 @@ struct DiskQuotaLocks
 	LWLock	   *extension_ddl_message_lock;
 	LWLock	   *extension_ddl_lock; /* ensure create diskquota extension serially */
 	LWLock	   *monitoring_dbid_cache_lock;
+	LWLock	   *paused_lock;
 };
 typedef struct DiskQuotaLocks DiskQuotaLocks;
 
@@ -90,6 +91,7 @@ typedef enum MessageResult MessageResult;
 
 extern DiskQuotaLocks diskquota_locks;
 extern ExtensionDDLMessage *extension_ddl_message;
+extern bool *diskquota_paused;
 
 /* drop extension hook */
 extern void register_diskquota_object_access_hook(void);

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -12,4 +12,5 @@ test: test_vacuum
 test: test_primary_failure
 test: test_extension
 test: test_manytable
+test: test_pause_and_resume
 test: clean

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -343,7 +343,7 @@ diskquota_pause(PG_FUNCTION_ARGS)
 	*diskquota_paused = true;
 	LWLockRelease(diskquota_locks.paused_lock);
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (IS_QUERY_DISPATCHER())
 		dispatch_pause_or_resume_command(true /* pause_extension */);
 
 	PG_RETURN_VOID();
@@ -368,7 +368,7 @@ diskquota_resume(PG_FUNCTION_ARGS)
 	*diskquota_paused = false;
 	LWLockRelease(diskquota_locks.paused_lock);
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (IS_QUERY_DISPATCHER())
 		dispatch_pause_or_resume_command(false /* pause_extension */);
 
 	PG_RETURN_VOID();

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -40,9 +40,12 @@
 #include "utils/memutils.h"
 #include "utils/numeric.h"
 #include "utils/snapmgr.h"
+#include "libpq-fe.h"
 
 #include <cdb/cdbvars.h>
 #include <cdb/cdbutil.h>
+#include <cdb/cdbdisp_query.h>
+#include <cdb/cdbdispatchresult.h>
 
 #include "diskquota.h"
 #include "gp_activetable.h"
@@ -51,6 +54,8 @@
 
 PG_FUNCTION_INFO_V1(init_table_size_table);
 PG_FUNCTION_INFO_V1(diskquota_start_worker);
+PG_FUNCTION_INFO_V1(diskquota_pause);
+PG_FUNCTION_INFO_V1(diskquota_resume);
 PG_FUNCTION_INFO_V1(set_schema_quota);
 PG_FUNCTION_INFO_V1(set_role_quota);
 PG_FUNCTION_INFO_V1(set_schema_tablespace_quota);
@@ -286,6 +291,86 @@ diskquota_start_worker(PG_FUNCTION_ARGS)
 	{
 		ereport(WARNING, (errmsg("database is not empty, please run `select diskquota.init_table_size_table()` to initialize table_size information for diskquota extension. Note that for large database, this function may take a long time.")));
 	}
+	PG_RETURN_VOID();
+}
+
+/*
+ * Dispatch pausing/resuming command to segments.
+ */
+static void
+dispatch_pause_or_resume_command(bool pause_extension)
+{
+	CdbPgResults cdb_pgresults = {NULL, 0};
+	int			i;
+	StringInfoData sql;
+
+	initStringInfo(&sql);
+	appendStringInfo(&sql, "SELECT diskquota.%s", pause_extension ? "pause()" : "resume()");
+	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
+
+	for (i = 0; i < cdb_pgresults.numResults; ++i)
+	{
+		PGresult *pgresult = cdb_pgresults.pg_results[i];
+		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
+		{
+			cdbdisp_clearCdbPgResults(&cdb_pgresults);
+			ereport(ERROR,
+				(errmsg("[diskquota] %s extension on segments, encounter unexpected result from segment: %d",
+						pause_extension ? "pausing" : "resuming",
+						PQresultStatus(pgresult))));
+		}
+	}
+	cdbdisp_clearCdbPgResults(&cdb_pgresults);
+}
+
+/*
+ * Set diskquota_paused to true.
+ * This function is called by user. After this function being called, diskquota
+ * keeps counting the disk usage but doesn't emit an error when the disk usage
+ * limit is exceeded.
+ */
+Datum
+diskquota_pause(PG_FUNCTION_ARGS)
+{
+	if (!superuser())
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to pause diskquota")));
+	}
+
+	LWLockAcquire(diskquota_locks.paused_lock, LW_EXCLUSIVE);
+	*diskquota_paused = true;
+	LWLockRelease(diskquota_locks.paused_lock);
+
+	if (Gp_role == GP_ROLE_DISPATCH)
+		dispatch_pause_or_resume_command(true /* pause_extension */);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * Set diskquota_paused to false.
+ * This function is called by user. After this function being called, diskquota
+ * resume to emit an error when the disk usage limit is exceeded.
+ */
+Datum
+diskquota_resume(PG_FUNCTION_ARGS)
+{
+	if (!superuser())
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to resume diskquota")));
+	}
+
+	LWLockAcquire(diskquota_locks.paused_lock, LW_EXCLUSIVE);
+	*diskquota_paused = false;
+	LWLockRelease(diskquota_locks.paused_lock);
+
+	if (Gp_role == GP_ROLE_DISPATCH)
+		dispatch_pause_or_resume_command(false /* pause_extension */);
+
 	PG_RETURN_VOID();
 }
 

--- a/expected/test_pause_and_resume.out
+++ b/expected/test_pause_and_resume.out
@@ -1,0 +1,56 @@
+-- Test pause and resume.
+CREATE SCHEMA s1;
+SET search_path TO s1;
+CREATE TABLE a(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE b(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- expect insert succeed
+INSERT INTO a SELECT generate_series(1,100000);
+SELECT diskquota.set_schema_quota('s1', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- expect insert fail
+INSERT INTO a SELECT generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:s1
+-- expect insert fail
+INSERT INTO b SELECT generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:s1
+-- pause extension
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+-- expect insert succeed
+INSERT INTO a SELECT generate_series(1,100);
+-- expect insert succeed
+INSERT INTO b SELECT generate_series(1,100);
+-- resume extension
+SELECT diskquota.resume();
+ resume 
+--------
+ 
+(1 row)
+
+-- expect insert fail
+INSERT INTO a SELECT generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:s1
+-- expect insert fail
+INSERT INTO b SELECT generate_series(1,100);
+ERROR:  schema's disk space quota exceeded with name:s1
+RESET search_path;
+DROP TABLE s1.a, s1.b;
+DROP SCHEMA s1;

--- a/sql/test_pause_and_resume.sql
+++ b/sql/test_pause_and_resume.sql
@@ -1,0 +1,37 @@
+-- Test pause and resume.
+CREATE SCHEMA s1;
+SET search_path TO s1;
+
+CREATE TABLE a(i int);
+CREATE TABLE b(i int);
+
+-- expect insert succeed
+INSERT INTO a SELECT generate_series(1,100000);
+
+SELECT diskquota.set_schema_quota('s1', '1 MB');
+SELECT pg_sleep(5);
+-- expect insert fail
+INSERT INTO a SELECT generate_series(1,100);
+-- expect insert fail
+INSERT INTO b SELECT generate_series(1,100);
+
+-- pause extension
+SELECT diskquota.pause();
+
+-- expect insert succeed
+INSERT INTO a SELECT generate_series(1,100);
+-- expect insert succeed
+INSERT INTO b SELECT generate_series(1,100);
+
+-- resume extension
+SELECT diskquota.resume();
+
+-- expect insert fail
+INSERT INTO a SELECT generate_series(1,100);
+-- expect insert fail
+INSERT INTO b SELECT generate_series(1,100);
+
+RESET search_path;
+DROP TABLE s1.a, s1.b;
+DROP SCHEMA s1;
+


### PR DESCRIPTION
This change adds two additional functions for user calling:

1. diskquota.pause_extension()
   After this function being called, diskquota keeps counting
   the disk usage but doesn't emit an error when the disk usage
  limit is exceeded.

2. diskquota.resume_extension()
   After this function being called, diskquota resumes to emit
   an error when the disk usage limit is exceeded.