### PR TITLE
Fix incorrect number of locks in diskquota.

### DIFF
--- a/diskquota.h
+++ b/diskquota.h
@@ -28,7 +28,6 @@ typedef enum
 	DISKQUOTA_READY_STATE
 }			DiskQuotaState;
 
-#define DiskQuotaLocksItemNumber (sizeof(DiskQuotaLocks) / sizeof(void*))
 struct DiskQuotaLocks
 {
 	LWLock	   *active_table_lock;
@@ -39,6 +38,7 @@ struct DiskQuotaLocks
 	LWLock	   *paused_lock;
 };
 typedef struct DiskQuotaLocks DiskQuotaLocks;
+#define DiskQuotaLocksItemNumber (sizeof(DiskQuotaLocks) / sizeof(void*))
 
 /*
  * MessageBox is used to store a message for communication between

--- a/diskquota.h
+++ b/diskquota.h
@@ -28,7 +28,7 @@ typedef enum
 	DISKQUOTA_READY_STATE
 }			DiskQuotaState;
 
-#define DiskQuotaLocksItemNumber (5)
+#define DiskQuotaLocksItemNumber (sizeof(DiskQuotaLocks) / sizeof(void*))
 struct DiskQuotaLocks
 {
 	LWLock	   *active_table_lock;


### PR DESCRIPTION
Currently, we use DiskQuotaLocksItemNumber to count the number of
locks in diskquota. In de8418b, we forget to update it and it's causing
memory issues. To avoid such issues in future, we use
sizeof(DiskQuotaLocks) / sizeof(void*) to calculate the correct number
of locks.

Co-authored-by: Hao Zhang <hzhang2@vmware.com>