### PR TITLE
Create database 'diskquota' before running regression tests.

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -1,4 +1,8 @@
 -- start_ignore
+CREATE DATABASE diskquota;
+-- end_ignore
+
+-- start_ignore
 \! gpconfig -c shared_preload_libraries -v diskquota > /dev/null
 -- end_ignore
 \! echo $?


### PR DESCRIPTION
We have to create database 'diskquota' manually before running
regression tests. This change helps resolve it by creating the
database in the init stage.