### PR TITLE
Improve error handling in diskquota_fetch_table_stat().

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,18 @@ REGRESS_OPTS = --schedule=diskquota_schedule_int --init-file=init_file
 else
 REGRESS_OPTS = --schedule=diskquota_schedule --init-file=init_file
 endif
+
+# FIXME: This check is hacky, since test_fetch_table_stat relies on the
+# gp_inject_fault extension, we detect if the extension is built with
+# greenplum by checking the output of the command 'pg_config --configure'.
+# In the future, if the diskquota is built with GPDB7, or we backport the
+# commit below to 6X_STABLE, we don't need this check.
+# https://github.com/greenplum-db/gpdb/commit/8b897b12f6cb13753985faacab8e4053bf797a8b
+ifneq (,$(findstring '--enable-debug-extensions',$(shell pg_config --configure)))
+REGRESS_OPTS += --load-extension=gp_inject_fault
+else
+REGRESS_OPTS += --exclude-tests=test_fetch_table_stat
+endif
+
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -14,4 +14,5 @@ test: test_extension
 test: test_manytable
 test: test_pause_and_resume
 test: test_many_active_tables
+test: test_fetch_table_stat
 test: clean

--- a/expected/test_fetch_table_stat.out
+++ b/expected/test_fetch_table_stat.out
@@ -1,0 +1,38 @@
+--
+-- 1. Test that when an error occurs in diskquota_fetch_table_stat
+--    the error message is preserved for us to debug.
+--
+CREATE TABLE t_error_handling (i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Inject an error to a segment server, since this UDF is only called on segments.
+SELECT gp_inject_fault_infinite('diskquota_fetch_table_stat', 'error', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- Dispatch diskquota_fetch_table_stat to segments.
+-- There should be a warning message from segment server saying:
+-- fault triggered, fault name:'diskquota_fetch_table_stat' fault type:'error'
+-- We're not interested in the oid here, we aggregate the result by COUNT(*).
+SELECT COUNT(*)
+    FROM (SELECT diskquota.diskquota_fetch_table_stat(1, array[(SELECT oid FROM pg_class WHERE relname='t_error_handling')])
+          FROM gp_dist_random('gp_id') WHERE gp_segment_id=0) AS count;
+WARNING:  fault triggered, fault name:'diskquota_fetch_table_stat' fault type:'error'
+ count 
+-------
+     1
+(1 row)
+
+-- Reset the fault injector to prevent future failure.
+SELECT gp_inject_fault_infinite('diskquota_fetch_table_stat', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- Do some clean-ups.
+DROP TABLE t_error_handling;

--- a/init_file
+++ b/init_file
@@ -11,4 +11,9 @@ m/diskquota_utility.c:\d+\)/
 s/diskquota_utility.c:\d+\)/diskquota_utility.c:xxx/
 m/^CONTEXT:*/
 s/^CONTEXT:/DETAIL:/
+
+# Remove segment identifiers from error message.
+# E.g., (slice1 XXX.XXX.XXX.XXX:XXXX pid=XXXX)
+m/(slice\d+ [0-9.]+:\d+ pid=\d+)/
+s/(slice\d+ [0-9.]+:\d+ pid=\d+)//
 -- end_matchsubs

--- a/sql/test_fetch_table_stat.sql
+++ b/sql/test_fetch_table_stat.sql
@@ -1,0 +1,24 @@
+--
+-- 1. Test that when an error occurs in diskquota_fetch_table_stat
+--    the error message is preserved for us to debug.
+--
+
+CREATE TABLE t_error_handling (i int);
+-- Inject an error to a segment server, since this UDF is only called on segments.
+SELECT gp_inject_fault_infinite('diskquota_fetch_table_stat', 'error', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=0;
+
+-- Dispatch diskquota_fetch_table_stat to segments.
+-- There should be a warning message from segment server saying:
+-- fault triggered, fault name:'diskquota_fetch_table_stat' fault type:'error'
+-- We're not interested in the oid here, we aggregate the result by COUNT(*).
+SELECT COUNT(*)
+    FROM (SELECT diskquota.diskquota_fetch_table_stat(1, array[(SELECT oid FROM pg_class WHERE relname='t_error_handling')])
+          FROM gp_dist_random('gp_id') WHERE gp_segment_id=0) AS count;
+
+-- Reset the fault injector to prevent future failure.
+SELECT gp_inject_fault_infinite('diskquota_fetch_table_stat', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=0;
+
+-- Do some clean-ups.
+DROP TABLE t_error_handling;


### PR DESCRIPTION
Historically, diskquota fetches tables' size by applying pg_table_size()
on a given oid list. It may invoke pg_table_size() several times in one
transaction. In order to tolerate exceptions, we wrap it with PG_TRY()
and consume any errors throwed by pg_table_size() using FlushErrorState().
It has the following 2 potential risks.

1. Deadlock: Considering we have a table 't1' (reloid=oid1) and it has a
   partition 't1_1_prt_11' (reloid=oid2).
   When diskquota_fetch_table_stat(1, '{oid2, oid1}'::oid[]) is called
   in session 'A', this UDF will invoke pg_table_size() on 't1_1_prt_11'
   and 't1' respectively. When pg_table_size('t1_1_prt_11') throws an
   exception, the AccessShareLock acquired from session 'A' will be held
   until the whole transaction ends. At the same time, when another
   session 'B' is performing 'ALTER TABLE t1', it will acquire the
   AccessExclusiveLock on 't1' and 't1_1_prt_11' respectively. As a result,
   the session 'A' is holding the AccessShareLock on 't1_1_prt_11' and is
   waiting for AccessShareLock on 't1'; the session 'B' is holding the
   AccessExclusiveLock on 't1' and is waiting for the AccessExclusiveLock
   on 't1_1_prt_11'.

2. Error message is missing. We should preserve the error message by calling
   CopyErrorData() before FlushErrorState() and elog(WARNING, error_messgae).

Co-Authored-by: Xuebin Su <sxuebin@vmware.com>
Co-Authored-by: Hao Zhang <hzhang2@vmware.com>