### PR TITLE
Don't take relation's lock when fetching the relation's size.

### DIFF
--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -40,6 +40,7 @@
 #include "utils/memutils.h"
 #include "utils/numeric.h"
 #include "utils/snapmgr.h"
+#include "utils/syscache.h"
 #include "libpq-fe.h"
 
 #include <cdb/cdbvars.h>
@@ -1149,9 +1150,9 @@ get_rel_oid_list(void)
 
 	initStringInfo(&buf);
 	appendStringInfo(&buf,
-			"select oid "
-			" from pg_class"
-			" where oid >= %u and (relkind='r' or relkind='m')",
+			"select oid, relkind "
+			"from pg_class "
+			"where oid >= %u and (relkind='r' or relkind='m' or relkind = 'i')",
 			FirstNormalObjectId);
 
 	ret = SPI_execute(buf.data, false, 0);
@@ -1163,29 +1164,26 @@ get_rel_oid_list(void)
 		HeapTuple	tup;
 		bool        	isnull;
 		Oid         	oid;
-		ListCell   	*l;
+		char 			relkind;
 
 		tup = SPI_tuptable->vals[i];
 		oid = DatumGetObjectId(SPI_getbinval(tup,tupdesc, 1, &isnull));
+		relkind = DatumGetChar(SPI_getbinval(tup,tupdesc, 2, &isnull));
 		if (!isnull)
 		{
-			Relation	relation;
-			List	   	*indexIds;
-			relation = try_relation_open(oid, AccessShareLock, false);
-			if (!relation)
-				continue;
-
-			oidlist = lappend_oid(oidlist, oid);
-			indexIds = RelationGetIndexList(relation);
-			if (indexIds != NIL )
+			if (relkind == RELKIND_INDEX)
 			{
-				foreach(l, indexIds)
+				HeapTuple index_tup = SearchSysCacheCopy1(INDEXRELID, ObjectIdGetDatum(oid));
+				if (HeapTupleIsValid(index_tup))
 				{
-					oidlist = lappend_oid(oidlist, lfirst_oid(l));
+					Oid table_oid = DatumGetObjectId(SysCacheGetAttr(INDEXRELID, index_tup, Anum_pg_index_indrelid, &isnull));
+					HeapTuple table_tup = SearchSysCacheCopy1(RELOID, table_oid);
+					char table_kind = ((Form_pg_class) GETSTRUCT(table_tup))->relkind;
+					if (table_kind != RELKIND_RELATION && table_kind != RELKIND_MATVIEW)
+						continue;
 				}
 			}
-		    relation_close(relation, AccessShareLock);
-			list_free(indexIds);
+			oidlist = lappend_oid(oidlist, oid);
 		}
 	}
 	return oidlist;

--- a/gp_activetable.h
+++ b/gp_activetable.h
@@ -29,6 +29,7 @@ extern HTAB *gp_fetch_active_tables(bool force);
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
+extern void collect_relation_size(HTAB *local_table);
 
 extern HTAB *active_tables_map;
 extern HTAB *monitoring_dbid_cache;

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -771,6 +771,10 @@ calculate_table_disk_usage(bool is_init)
 	 * tables whose disk size changed will be treated as active
 	 */
 	local_active_table_stat_map = gp_fetch_active_tables(is_init);
+	/* pretend process as utility mode, and append the table size on master */
+	Gp_role = GP_ROLE_UTILITY;
+	collect_relation_size(local_active_table_stat_map);
+	Gp_role = GP_ROLE_DISPATCH;
 
 	/*
 	 * unset is_exist flag for tsentry in table_size_map this is used to
@@ -834,28 +838,6 @@ calculate_table_disk_usage(bool is_init)
 			/* skip to recalculate the tables which are not in active list */
 			if (active_tbl_found)
 			{
-				if (key.segid == -1)
-				{
-					/* pretend process as utility mode, and append the table size on master */
-					Gp_role = GP_ROLE_UTILITY;
-
-					/* DirectFunctionCall1 may fail, since table maybe dropped by other backend */
-					PG_TRY();
-					{
-						/* call pg_table_size to get the active table size */
-						active_table_entry->tablesize += (Size) DatumGetInt64(DirectFunctionCall1(pg_table_size, ObjectIdGetDatum(relOid)));
-					}
-					PG_CATCH();
-					{
-						HOLD_INTERRUPTS();
-						FlushErrorState();
-						RESUME_INTERRUPTS();
-					}
-					PG_END_TRY();
-
-					Gp_role = GP_ROLE_DISPATCH;
-
-				}
 				/* firstly calculate the updated total size of a table */
 				updated_total_size = active_table_entry->tablesize - tsentry->totalsize;
 


### PR DESCRIPTION
Currently, diskquota uses pg_table_size() to fetch relation's size. It
has the following drawbacks:

1. pg_table_size() requires taking the AccessShareLock of a relation and
   its indexes. When the relation is locked by AccessExclusive lock from
   another backend, the diskquota is blocked until the AccessShareLock
   is available. Besides, it also introduces potential deadlock to
   diskquota, since it can take multiple AccessShareLocks on different
   relations at the same time.

2. When we apply pg_table_size() on appendonly relations, it cannot give
   the actual file size when the relation is extending due to MVCC.

3. Fetching relations' size from segment servers and the master server
   shares the same logic, but we duplicate the codes here and there.

This patch resolves the mentioned issues by introducing a new helper
function 'collect_relation_size(HTAB *local_table)'. It takes a hash
table as argument and iterates over the pg_class table to acquire the
relfilenode for each relation. Then, it get the relation's size by
stat(2) the relfilenode directly and accumulate the size in local_table.

Co-Authored-By: Xuebin Su <sxuebin@vmware.com>
Co-Authored-By: Hao Zhang <hzhang2@vmware.com>