### PR TITLE
Add .editorconfig to diskquota source tree.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*.{c,h,l,y,pl,pm}]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+[*.{sgml,xml}]
+indent_style = space
+indent_size = 1
+
+[*.xsl]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
The main use right now is getting properly spaced diff views on
GitHub, but perhaps this will also help developers with editors that
supports reading configuration from '.editorconfig'. The '.editorconfig'
is extracted from Postgres source tree.