### PR TITLE
Fix test case bug

### DIFF
--- a/tests/regress/expected/test_relation_size.out
+++ b/tests/regress/expected/test_relation_size.out
@@ -83,6 +83,7 @@ SELECT pg_relation_size('ao');
            100200
 (1 row)
 
+DROP TABLE ao;
 CREATE TABLE aocs (i int, t text) WITH (appendonly=true,  orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/tests/regress/sql/test_relation_size.sql
+++ b/tests/regress/sql/test_relation_size.sql
@@ -32,6 +32,7 @@ CREATE TABLE ao (i int) WITH (appendonly=true);
 INSERT INTO ao SELECT generate_series(1, 10000);
 SELECT diskquota.relation_size('ao');
 SELECT pg_relation_size('ao');
+DROP TABLE ao;
 
 CREATE TABLE aocs (i int, t text) WITH (appendonly=true,  orientation=column);
 INSERT INTO aocs SELECT i, repeat('a', 1000) FROM generate_series(1, 10000) AS i;


### PR DESCRIPTION
Drop test table after testing diskquota.relation_size(), because the relation_entry the table in this test case will affect the next test case.