### PR TITLE
calculate table size for hard limit

### DIFF
--- a/diskquota.h
+++ b/diskquota.h
@@ -122,4 +122,5 @@ extern List *get_rel_oid_list(void);
 extern int64 calculate_relation_size_all_forks(RelFileNodeBackend *rnode, char relstorage);
 extern Relation diskquota_relation_open(Oid relid, LOCKMODE mode);
 extern List* diskquota_get_index_list(Oid relid);
+extern void GetAppendOnlyEntryAuxOidListByRelid(Oid reloid, Oid *segrelid, Oid *blkdirrelid, Oid *visimaprelid);
 #endif

--- a/diskquota.h
+++ b/diskquota.h
@@ -121,4 +121,5 @@ extern void truncateStringInfo(StringInfo str, int nchars);
 extern List *get_rel_oid_list(void);
 extern int64 calculate_relation_size_all_forks(RelFileNodeBackend *rnode, char relstorage);
 extern Relation diskquota_relation_open(Oid relid, LOCKMODE mode);
+extern List* diskquota_get_index_list(Oid relid);
 #endif

--- a/diskquota.h
+++ b/diskquota.h
@@ -122,5 +122,5 @@ extern List *get_rel_oid_list(void);
 extern int64 calculate_relation_size_all_forks(RelFileNodeBackend *rnode, char relstorage);
 extern Relation diskquota_relation_open(Oid relid, LOCKMODE mode);
 extern List* diskquota_get_index_list(Oid relid);
-extern void GetAppendOnlyEntryAuxOidListByRelid(Oid reloid, Oid *segrelid, Oid *blkdirrelid, Oid *visimaprelid);
+extern void diskquota_get_appendonly_aux_oid_list(Oid reloid, Oid *segrelid, Oid *blkdirrelid, Oid *visimaprelid);
 #endif

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -1175,7 +1175,7 @@ get_rel_oid_list(void)
 		oid = DatumGetObjectId(SPI_getbinval(tup,tupdesc, 1, &isnull));
 		if (!isnull)
 		{
-			List	   	*indexIds;
+			List *indexIds;
 			oidlist = lappend_oid(oidlist, oid);
 			indexIds = diskquota_get_index_list(oid);
 			if (indexIds != NIL )
@@ -1351,7 +1351,7 @@ diskquota_get_index_list(Oid relid)
  * Get auxiliary relations oid by searching the pg_appendonly table.
  */
 void
-GetAppendOnlyEntryAuxOidListByRelid(Oid reloid, Oid *segrelid, Oid *blkdirrelid, Oid *visimaprelid)
+diskquota_get_appendonly_aux_oid_list(Oid reloid, Oid *segrelid, Oid *blkdirrelid, Oid *visimaprelid)
 {
 	ScanKeyData			skey;
 	SysScanDesc			scan;

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -1309,3 +1309,46 @@ diskquota_relation_open(Oid relid, LOCKMODE mode)
 	PG_END_TRY();
 	return success_open ? rel : NULL;
 }
+
+List*
+diskquota_get_index_list(Oid relid)
+{
+    Relation	indrel;
+	SysScanDesc indscan;
+	ScanKeyData skey;
+	HeapTuple	htup;
+	List	   *result = NIL;
+
+	/* Prepare to scan pg_index for entries having indrelid = this rel. */
+	ScanKeyInit(&skey,
+				Anum_pg_index_indrelid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				relid);
+
+	indrel = heap_open(IndexRelationId, AccessShareLock);
+	indscan = systable_beginscan(indrel, IndexIndrelidIndexId, true,
+								 NULL, 1, &skey);
+
+	while (HeapTupleIsValid(htup = systable_getnext(indscan)))
+	{
+		Form_pg_index index = (Form_pg_index) GETSTRUCT(htup);
+
+		/*
+		 * Ignore any indexes that are currently being dropped. This will
+		 * prevent them from being searched, inserted into, or considered in
+		 * HOT-safety decisions. It's unsafe to touch such an index at all
+		 * since its catalog entries could disappear at any instant.
+		 */
+		if (!IndexIsLive(index))
+			continue;
+
+		/* Add index's OID to result list in the proper order */
+		result = lappend_oid(result, index->indexrelid);
+	}
+
+	systable_endscan(indscan);
+
+	heap_close(indrel, AccessShareLock);
+
+	return result;
+}

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -1307,7 +1307,7 @@ diskquota_relation_open(Oid relid, LOCKMODE mode)
 List*
 diskquota_get_index_list(Oid relid)
 {
-    Relation	indrel;
+	Relation	indrel;
 	SysScanDesc indscan;
 	ScanKeyData skey;
 	HeapTuple	htup;

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1795,7 +1795,7 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 					}
 
 					/* Append ao auxiliary relations and their indexes to the oid_list if any. */
-					GetAppendOnlyEntryAuxOidListByRelid(active_oid, &aosegrelid,
+					diskquota_get_appendonly_aux_oid_list(active_oid, &aosegrelid,
 														&aoblkdirrelid, &aovisimaprelid);
 					if (OidIsValid(aosegrelid))
 					{

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -777,7 +777,7 @@ merge_uncommitted_table_to_oidlist(List *oidlist)
 
 	remove_committed_relation_from_cache();
 
-	LWLockAcquire(diskquota_locks.relation_cache_lock, LW_EXCLUSIVE);
+	LWLockAcquire(diskquota_locks.relation_cache_lock, LW_SHARED);
 	hash_seq_init(&iter, relation_cache);
 	while ((entry = hash_seq_search(&iter)) != NULL)
 	{

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -768,8 +768,6 @@ static List*
 merge_uncommitted_table_to_oidlist(List *oidlist)
 {
 	HASH_SEQ_STATUS 			 iter;
-	Oid							 relid;
-	ListCell   		   			*l;
 	DiskQuotaRelationCacheEntry *entry;
 
 	if (relation_cache == NULL)
@@ -777,13 +775,9 @@ merge_uncommitted_table_to_oidlist(List *oidlist)
 		return oidlist;
 	}
 
-	LWLockAcquire(diskquota_locks.relation_cache_lock, LW_EXCLUSIVE);
-	foreach(l, oidlist)
-	{
-		relid = lfirst_oid(l);
-		remove_cache_entry_recursion_wio_lock(relid);
-	}
+	remove_committed_relation_from_cache();
 
+	LWLockAcquire(diskquota_locks.relation_cache_lock, LW_EXCLUSIVE);
 	hash_seq_init(&iter, relation_cache);
 	while ((entry = hash_seq_search(&iter)) != NULL)
 	{

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -625,8 +625,8 @@ do_check_diskquota_state_is_ready(void)
 
 	/* Add the dbid to watching list, so the hook can catch the table change*/
 	initStringInfo(&sql_command);
-	appendStringInfo(&sql_command, "select gp_segment_id, diskquota.update_diskquota_db_list(%u, 0) from gp_dist_random('gp_id');",
-				MyDatabaseId);
+	appendStringInfo(&sql_command, "select gp_segment_id, diskquota.update_diskquota_db_list(%u, 0) from gp_dist_random('gp_id')  UNION ALL select -1, diskquota.update_diskquota_db_list(%u, 0);",
+				MyDatabaseId, MyDatabaseId);
 	ret = SPI_execute(sql_command.data, true, 0);
         if (ret != SPI_OK_SELECT)
                 ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
@@ -764,6 +764,39 @@ refresh_disk_quota_usage(bool is_init)
 	return;
 }
 
+static List*
+merge_uncommitted_table_to_oidlist(List *oidlist)
+{
+	HASH_SEQ_STATUS 			 iter;
+	Oid							 relid;
+	ListCell   		   			*l;
+	DiskQuotaRelationCacheEntry *entry;
+
+	if (relation_cache == NULL)
+	{
+		return oidlist;
+	}
+
+	LWLockAcquire(diskquota_locks.relation_cache_lock, LW_EXCLUSIVE);
+	foreach(l, oidlist)
+	{
+		relid = lfirst_oid(l);
+		remove_cache_entry_recursion_wio_lock(relid);
+	}
+
+	hash_seq_init(&iter, relation_cache);
+	while ((entry = hash_seq_search(&iter)) != NULL)
+	{
+		if (entry->primary_table_relid == entry->relid)
+		{
+			oidlist = lappend_oid(oidlist, entry->relid);
+		}
+	}
+	LWLockRelease(diskquota_locks.relation_cache_lock);
+
+	return oidlist;
+}
+
 /*
  *  Incremental way to update the disk quota of every database objects
  *  Recalculate the table's disk usage when it's a new table or active table.
@@ -812,19 +845,41 @@ calculate_table_disk_usage(bool is_init)
 	 * and role_size_map
 	 */
 	oidlist = get_rel_oid_list();
+
+	oidlist = merge_uncommitted_table_to_oidlist(oidlist);
+	
 	foreach(l, oidlist)
 	{
 		HeapTuple	classTup;
-		Form_pg_class classForm;
+		Form_pg_class classForm = NULL;
+		Oid relnamespace = InvalidOid;
+		Oid relowner = InvalidOid;
+		Oid reltablespace = InvalidOid;
 		relOid = lfirst_oid(l);
 
 		classTup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relOid));
-		if (!HeapTupleIsValid(classTup))
+		if (HeapTupleIsValid(classTup))
 		{
-			elog(WARNING, "cache lookup failed for relation %u", relOid);
-			continue;
+			classForm = (Form_pg_class) GETSTRUCT(classTup);
+			relnamespace = classForm->relnamespace;
+			relowner = classForm->relowner;
+			reltablespace = classForm->reltablespace;
 		}
-		classForm = (Form_pg_class) GETSTRUCT(classTup);
+		else
+		{
+			LWLockAcquire(diskquota_locks.relation_cache_lock, LW_SHARED);
+			DiskQuotaRelationCacheEntry *relation_entry = hash_search(relation_cache, &relOid, HASH_FIND, NULL);
+			if (relation_entry == NULL)
+			{
+				elog(WARNING, "cache lookup failed for relation %u", relOid);
+				LWLockRelease(diskquota_locks.relation_cache_lock);
+				continue;
+			}
+			relnamespace = relation_entry->namespaceoid;
+			relowner = relation_entry->owneroid;
+			reltablespace = relation_entry->rnode.node.spcNode;
+			LWLockRelease(diskquota_locks.relation_cache_lock);
+		}
 
 		/*
 		 * The segid is the same as the content id in gp_segment_configuration
@@ -863,19 +918,7 @@ calculate_table_disk_usage(bool is_init)
 					/* pretend process as utility mode, and append the table size on master */
 					Gp_role = GP_ROLE_UTILITY;
 
-					/* DirectFunctionCall1 may fail, since table maybe dropped by other backend */
-					PG_TRY();
-					{
-						/* call pg_table_size to get the active table size */
-						active_table_entry->tablesize += (Size) DatumGetInt64(DirectFunctionCall1(pg_table_size, ObjectIdGetDatum(relOid)));
-					}
-					PG_CATCH();
-					{
-						HOLD_INTERRUPTS();
-						FlushErrorState();
-						RESUME_INTERRUPTS();
-					}
-					PG_END_TRY();
+					active_table_entry->tablesize += calculate_table_size(relOid);
 
 					Gp_role = GP_ROLE_DISPATCH;
 
@@ -901,63 +944,68 @@ calculate_table_disk_usage(bool is_init)
 			}
 
 			/* if schema change, transfer the file size */
-			if (tsentry->namespaceoid != classForm->relnamespace)
+			if (tsentry->namespaceoid != relnamespace)
 			{
 				transfer_table_for_quota(
 						tsentry->totalsize,
 						NAMESPACE_QUOTA,
 						(Oid[]){tsentry->namespaceoid},
-						(Oid[]){classForm->relnamespace},
+						(Oid[]){relnamespace},
 						key.segid);
 				transfer_table_for_quota(
 						tsentry->totalsize,
 						NAMESPACE_TABLESPACE_QUOTA,
 						(Oid[]){tsentry->namespaceoid, tsentry->tablespaceoid},
-						(Oid[]){classForm->relnamespace, tsentry->tablespaceoid},
+						(Oid[]){relnamespace, tsentry->tablespaceoid},
 						key.segid);
-				tsentry->namespaceoid = classForm->relnamespace;
+				tsentry->namespaceoid = relnamespace;
 			}
 			/* if owner change, transfer the file size */
-			if (tsentry->owneroid != classForm->relowner)
+			if (tsentry->owneroid != relowner)
 			{
 				transfer_table_for_quota(
 						tsentry->totalsize,
 						ROLE_QUOTA,
 						(Oid[]){tsentry->owneroid},
-						(Oid[]){classForm->relowner},
+						(Oid[]){relowner},
 						key.segid
 						);
 				transfer_table_for_quota(
 						tsentry->totalsize,
 						ROLE_TABLESPACE_QUOTA,
 						(Oid[]){tsentry->owneroid, tsentry->tablespaceoid},
-						(Oid[]){classForm->relowner, tsentry->tablespaceoid},
+						(Oid[]){relowner, tsentry->tablespaceoid},
 						key.segid
 						);
-				tsentry->owneroid = classForm->relowner;
+				tsentry->owneroid = relowner;
 			}
 
-			if (tsentry->tablespaceoid != classForm->reltablespace)
+			if (tsentry->tablespaceoid != reltablespace)
 			{
 				transfer_table_for_quota(
 						tsentry->totalsize,
 						NAMESPACE_TABLESPACE_QUOTA,
 						(Oid[]){tsentry->namespaceoid, tsentry->tablespaceoid},
-						(Oid[]){tsentry->namespaceoid, classForm->reltablespace},
+						(Oid[]){tsentry->namespaceoid, reltablespace},
 						key.segid
 						);
 				transfer_table_for_quota(
 						tsentry->totalsize,
 						ROLE_TABLESPACE_QUOTA,
 						(Oid[]){tsentry->owneroid, tsentry->tablespaceoid},
-						(Oid[]){tsentry->owneroid, classForm->reltablespace},
+						(Oid[]){tsentry->owneroid, reltablespace},
 						key.segid
 						);
-				tsentry->tablespaceoid = classForm->reltablespace;
+				tsentry->tablespaceoid = reltablespace;
 			}
 		}
-		heap_freetuple(classTup);
+		if (HeapTupleIsValid(classTup))
+		{
+			heap_freetuple(classTup);
+		}
 	}
+
+	list_free(oidlist);
 
 	hash_destroy(local_active_table_stat_map);
 

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -453,7 +453,7 @@ get_relation_entry_from_pg_class(Oid relid, DiskQuotaRelationCacheEntry* relatio
 	relation_entry->rnode.backend = classForm->relpersistence == RELPERSISTENCE_TEMP ? 
 									TempRelBackendId : InvalidBackendId;
 
-	// toast table
+	/* toast table */
 	if (OidIsValid(classForm->reltoastrelid))
 	{
 		add_auxrelation_to_relation_entry(classForm->reltoastrelid, relation_entry);
@@ -461,7 +461,7 @@ get_relation_entry_from_pg_class(Oid relid, DiskQuotaRelationCacheEntry* relatio
 
 	heap_freetuple(classTup);
 
-	// // ao table
+	/* ao table */
 	GetAppendOnlyEntryAuxOidListByRelid(relid, &segrelid, &blkdirrelid, &visimaprelid);
 	if (OidIsValid(segrelid))
 	{

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -556,7 +556,7 @@ do_calculate_table_size(DiskQuotaRelationCacheEntry *entry)
 Size
 calculate_table_size(Oid relid)
 {
-    DiskQuotaRelationCacheEntry entry = {0};
+	DiskQuotaRelationCacheEntry entry = {0};
 
 	get_relation_entry(relid, &entry);
 

--- a/relation_cache.h
+++ b/relation_cache.h
@@ -34,6 +34,5 @@ extern void update_relation_cache(Oid relid);
 extern Oid get_primary_table_oid(Oid relid);
 extern void remove_committed_relation_from_cache(void);
 extern Size calculate_table_size(Oid relid);
-extern void remove_cache_entry_recursion_wio_lock(Oid relid);
 
 #endif

--- a/relation_cache.h
+++ b/relation_cache.h
@@ -33,6 +33,7 @@ extern Oid get_uncommitted_table_relid(Oid relfilenode);
 extern void update_relation_cache(Oid relid);
 extern Oid get_primary_table_oid(Oid relid);
 extern void remove_committed_relation_from_cache(void);
-
+extern Size calculate_table_size(Oid relid);
+extern void remove_cache_entry_recursion_wio_lock(Oid relid);
 
 #endif

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -2,6 +2,7 @@ test: init
 test: prepare
 test: test_relation_size
 test: test_relation_cache
+test: test_uncommitted_table_size
 # disable this tese due to GPDB behavior change
 # test: test_table_size
 test: test_fast_disk_check

--- a/tests/regress/expected/test_uncommitted_table_size.out
+++ b/tests/regress/expected/test_uncommitted_table_size.out
@@ -56,6 +56,35 @@ SELECT pg_table_size('t2');
 
 commit;
 drop table t2;
+-- toast table
+begin;
+CREATE TABLE t3(t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO t3 SELECT repeat('a', 10000) FROM generate_series(1, 1000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't3'::regclass ORDER BY segid DESC;
+ tableid |  size  | segid 
+---------+--------+-------
+ t3      |  32768 |     2
+ t3      |  32768 |     1
+ t3      | 294912 |     0
+ t3      | 393216 |    -1
+(4 rows)
+
+SELECT pg_table_size('t3');
+ pg_table_size 
+---------------
+        393216
+(1 row)
+
+commit;
+drop table t3;
 -- AO table
 begin;
 CREATE TABLE ao (i int) WITH (appendonly=true);

--- a/tests/regress/expected/test_uncommitted_table_size.out
+++ b/tests/regress/expected/test_uncommitted_table_size.out
@@ -10,7 +10,7 @@ SELECT pg_sleep(5);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 't1'::regclass order by segid desc;SELECT pg_table_size('t1');
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't1'::regclass ORDER BY segid DESC;
  tableid |  size   | segid 
 ---------+---------+-------
  t1      | 1310720 |     2
@@ -19,6 +19,7 @@ SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 
  t1      | 3932160 |    -1
 (4 rows)
 
+SELECT pg_table_size('t1');
  pg_table_size 
 ---------------
        3932160
@@ -38,7 +39,7 @@ SELECT pg_sleep(5);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 't2'::regclass order by segid desc;SELECT pg_table_size('t2');
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't2'::regclass ORDER BY segid DESC;
  tableid |  size   | segid 
 ---------+---------+-------
  t2      | 1310720 |     2
@@ -47,6 +48,7 @@ SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 
  t2      | 3932160 |    -1
 (4 rows)
 
+SELECT pg_table_size('t2');
  pg_table_size 
 ---------------
        3932160
@@ -66,7 +68,7 @@ SELECT pg_sleep(5);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 'ao'::regclass order by segid desc;SELECT pg_table_size('ao');
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'ao'::regclass ORDER BY segid DESC;
  tableid |  size   | segid 
 ---------+---------+-------
  ao      |  398192 |     2
@@ -75,6 +77,7 @@ SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 
  ao      | 1263784 |    -1
 (4 rows)
 
+SELECT pg_table_size('ao');
  pg_table_size 
 ---------------
        1263784
@@ -94,7 +97,7 @@ SELECT pg_sleep(5);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 'aocs'::regclass order by segid desc;SELECT pg_table_size('aocs');
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'aocs'::regclass ORDER BY segid DESC;
  tableid |   size   | segid 
 ---------+----------+-------
  aocs    |  3375408 |     2
@@ -103,6 +106,7 @@ SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 
  aocs    | 10485912 |    -1
 (4 rows)
 
+SELECT pg_table_size('aocs');
  pg_table_size 
 ---------------
       10485912

--- a/tests/regress/expected/test_uncommitted_table_size.out
+++ b/tests/regress/expected/test_uncommitted_table_size.out
@@ -10,14 +10,11 @@ SELECT pg_sleep(5);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't1'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't1'::regclass and segid = -1;
  tableid |  size   | segid 
 ---------+---------+-------
- t1      | 1310720 |     2
- t1      | 1310720 |     1
- t1      | 1310720 |     0
  t1      | 3932160 |    -1
-(4 rows)
+(1 row)
 
 SELECT pg_table_size('t1');
  pg_table_size 
@@ -26,7 +23,7 @@ SELECT pg_table_size('t1');
 (1 row)
 
 commit;
-drop table t1;
+DROP table t1;
 -- heap table
 begin;
 CREATE TABLE t2(i int);
@@ -39,14 +36,11 @@ SELECT pg_sleep(5);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't2'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't2'::regclass and segid = -1;
  tableid |  size   | segid 
 ---------+---------+-------
- t2      | 1310720 |     2
- t2      | 1310720 |     1
- t2      | 1310720 |     0
  t2      | 3932160 |    -1
-(4 rows)
+(1 row)
 
 SELECT pg_table_size('t2');
  pg_table_size 
@@ -55,7 +49,29 @@ SELECT pg_table_size('t2');
 (1 row)
 
 commit;
-drop table t2;
+-- heap table index
+begin;
+CREATE INDEX idx2 on t2(i);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'idx2'::regclass and segid = -1;
+ tableid |  size   | segid 
+---------+---------+-------
+ idx2    | 2490368 |    -1
+(1 row)
+
+SELECT pg_table_size('idx2');
+ pg_table_size 
+---------------
+       2490368
+(1 row)
+
+commit;
+DROP table t2;
 -- toast table
 begin;
 CREATE TABLE t3(t text);
@@ -68,14 +84,11 @@ SELECT pg_sleep(5);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't3'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't3'::regclass and segid = -1;
  tableid |  size  | segid 
 ---------+--------+-------
- t3      |  32768 |     2
- t3      |  32768 |     1
- t3      | 294912 |     0
  t3      | 393216 |    -1
-(4 rows)
+(1 row)
 
 SELECT pg_table_size('t3');
  pg_table_size 
@@ -84,7 +97,7 @@ SELECT pg_table_size('t3');
 (1 row)
 
 commit;
-drop table t3;
+DROP table t3;
 -- AO table
 begin;
 CREATE TABLE ao (i int) WITH (appendonly=true);
@@ -97,14 +110,11 @@ SELECT pg_sleep(5);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'ao'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'ao'::regclass and segid = -1;
  tableid |  size   | segid 
 ---------+---------+-------
- ao      |  398192 |     2
- ao      |  399352 |     1
- ao      |  400704 |     0
  ao      | 1263784 |    -1
-(4 rows)
+(1 row)
 
 SELECT pg_table_size('ao');
  pg_table_size 
@@ -113,8 +123,30 @@ SELECT pg_table_size('ao');
 (1 row)
 
 commit;
+-- AOCS table index
+begin;
+CREATE INDEX ao_idx on ao(i);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'ao_idx'::regclass and segid = -1;
+ tableid |  size   | segid 
+---------+---------+-------
+ ao_idx  | 2490368 |    -1
+(1 row)
+
+SELECT pg_table_size('ao_idx');
+ pg_table_size 
+---------------
+       2490368
+(1 row)
+
+commit;
 DROP TABLE ao;
--- AOSC table
+-- AOCS table
 begin;
 CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
@@ -126,19 +158,38 @@ SELECT pg_sleep(5);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'aocs'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'aocs'::regclass and segid = -1;
  tableid |   size   | segid 
 ---------+----------+-------
- aocs    |  3375408 |     2
- aocs    |  3514672 |     1
- aocs    |  3497528 |     0
  aocs    | 10485912 |    -1
-(4 rows)
+(1 row)
 
 SELECT pg_table_size('aocs');
  pg_table_size 
 ---------------
       10485912
+(1 row)
+
+commit;
+-- AOCS table index
+begin;
+CREATE INDEX aocs_idx on aocs(i);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'aocs_idx'::regclass and segid = -1;
+ tableid  |  size  | segid 
+----------+--------+-------
+ aocs_idx | 524288 |    -1
+(1 row)
+
+SELECT pg_table_size('aocs_idx');
+ pg_table_size 
+---------------
+        524288
 (1 row)
 
 commit;

--- a/tests/regress/expected/test_uncommitted_table_size.out
+++ b/tests/regress/expected/test_uncommitted_table_size.out
@@ -1,0 +1,112 @@
+-- temp table
+begin;
+CREATE TEMP TABLE t1(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO t1 SELECT generate_series(1, 100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 't1'::regclass order by segid desc;SELECT pg_table_size('t1');
+ tableid |  size   | segid 
+---------+---------+-------
+ t1      | 1310720 |     2
+ t1      | 1310720 |     1
+ t1      | 1310720 |     0
+ t1      | 3932160 |    -1
+(4 rows)
+
+ pg_table_size 
+---------------
+       3932160
+(1 row)
+
+commit;
+drop table t1;
+-- heap table
+begin;
+CREATE TABLE t2(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO t2 SELECT generate_series(1, 100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 't2'::regclass order by segid desc;SELECT pg_table_size('t2');
+ tableid |  size   | segid 
+---------+---------+-------
+ t2      | 1310720 |     2
+ t2      | 1310720 |     1
+ t2      | 1310720 |     0
+ t2      | 3932160 |    -1
+(4 rows)
+
+ pg_table_size 
+---------------
+       3932160
+(1 row)
+
+commit;
+drop table t2;
+-- AO table
+begin;
+CREATE TABLE ao (i int) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO ao SELECT generate_series(1, 100000);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 'ao'::regclass order by segid desc;SELECT pg_table_size('ao');
+ tableid |  size   | segid 
+---------+---------+-------
+ ao      |  398192 |     2
+ ao      |  399352 |     1
+ ao      |  400704 |     0
+ ao      | 1263784 |    -1
+(4 rows)
+
+ pg_table_size 
+---------------
+       1263784
+(1 row)
+
+commit;
+DROP TABLE ao;
+-- AOSC table
+begin;
+CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO aocs SELECT i, repeat('a', 1000) FROM generate_series(1, 10000) AS i;
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 'aocs'::regclass order by segid desc;SELECT pg_table_size('aocs');
+ tableid |   size   | segid 
+---------+----------+-------
+ aocs    |  3375408 |     2
+ aocs    |  3514672 |     1
+ aocs    |  3497528 |     0
+ aocs    | 10485912 |    -1
+(4 rows)
+
+ pg_table_size 
+---------------
+      10485912
+(1 row)
+
+commit;
+DROP TABLE aocs;

--- a/tests/regress/sql/test_uncommitted_table_size.sql
+++ b/tests/regress/sql/test_uncommitted_table_size.sql
@@ -1,0 +1,39 @@
+-- temp table
+begin;
+CREATE TEMP TABLE t1(i int);
+INSERT INTO t1 SELECT generate_series(1, 100000);
+SELECT pg_sleep(5);
+SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 't1'::regclass order by segid desc;SELECT pg_table_size('t1');
+commit;
+
+drop table t1;
+
+-- heap table
+begin;
+CREATE TABLE t2(i int);
+INSERT INTO t2 SELECT generate_series(1, 100000);
+SELECT pg_sleep(5);
+SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 't2'::regclass order by segid desc;SELECT pg_table_size('t2');
+commit;
+
+drop table t2;
+
+-- AO table
+begin;
+CREATE TABLE ao (i int) WITH (appendonly=true);
+INSERT INTO ao SELECT generate_series(1, 100000);
+SELECT pg_sleep(5);
+SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 'ao'::regclass order by segid desc;SELECT pg_table_size('ao');
+commit;
+
+DROP TABLE ao;
+
+-- AOSC table
+begin;
+CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column);
+INSERT INTO aocs SELECT i, repeat('a', 1000) FROM generate_series(1, 10000) AS i;
+SELECT pg_sleep(5);
+SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 'aocs'::regclass order by segid desc;SELECT pg_table_size('aocs');
+commit;
+
+DROP TABLE aocs;

--- a/tests/regress/sql/test_uncommitted_table_size.sql
+++ b/tests/regress/sql/test_uncommitted_table_size.sql
@@ -3,7 +3,8 @@ begin;
 CREATE TEMP TABLE t1(i int);
 INSERT INTO t1 SELECT generate_series(1, 100000);
 SELECT pg_sleep(5);
-SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 't1'::regclass order by segid desc;SELECT pg_table_size('t1');
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't1'::regclass ORDER BY segid DESC;
+SELECT pg_table_size('t1');
 commit;
 
 drop table t1;
@@ -13,7 +14,8 @@ begin;
 CREATE TABLE t2(i int);
 INSERT INTO t2 SELECT generate_series(1, 100000);
 SELECT pg_sleep(5);
-SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 't2'::regclass order by segid desc;SELECT pg_table_size('t2');
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't2'::regclass ORDER BY segid DESC;
+SELECT pg_table_size('t2');
 commit;
 
 drop table t2;
@@ -23,7 +25,8 @@ begin;
 CREATE TABLE ao (i int) WITH (appendonly=true);
 INSERT INTO ao SELECT generate_series(1, 100000);
 SELECT pg_sleep(5);
-SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 'ao'::regclass order by segid desc;SELECT pg_table_size('ao');
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'ao'::regclass ORDER BY segid DESC;
+SELECT pg_table_size('ao');
 commit;
 
 DROP TABLE ao;
@@ -33,7 +36,8 @@ begin;
 CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column);
 INSERT INTO aocs SELECT i, repeat('a', 1000) FROM generate_series(1, 10000) AS i;
 SELECT pg_sleep(5);
-SELECT tableid::regclass, size, segid from diskquota.table_size where tableid = 'aocs'::regclass order by segid desc;SELECT pg_table_size('aocs');
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'aocs'::regclass ORDER BY segid DESC;
+SELECT pg_table_size('aocs');
 commit;
 
 DROP TABLE aocs;

--- a/tests/regress/sql/test_uncommitted_table_size.sql
+++ b/tests/regress/sql/test_uncommitted_table_size.sql
@@ -3,52 +3,76 @@ begin;
 CREATE TEMP TABLE t1(i int);
 INSERT INTO t1 SELECT generate_series(1, 100000);
 SELECT pg_sleep(5);
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't1'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't1'::regclass and segid = -1;
 SELECT pg_table_size('t1');
 commit;
 
-drop table t1;
+DROP table t1;
 
 -- heap table
 begin;
 CREATE TABLE t2(i int);
 INSERT INTO t2 SELECT generate_series(1, 100000);
 SELECT pg_sleep(5);
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't2'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't2'::regclass and segid = -1;
 SELECT pg_table_size('t2');
 commit;
 
-drop table t2;
+-- heap table index
+begin;
+CREATE INDEX idx2 on t2(i);
+SELECT pg_sleep(5);
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'idx2'::regclass and segid = -1;
+SELECT pg_table_size('idx2');
+commit;
+
+DROP table t2;
 
 -- toast table
 begin;
 CREATE TABLE t3(t text);
 INSERT INTO t3 SELECT repeat('a', 10000) FROM generate_series(1, 1000);
 SELECT pg_sleep(5);
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't3'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't3'::regclass and segid = -1;
 SELECT pg_table_size('t3');
 commit;
 
-drop table t3;
+DROP table t3;
 
 -- AO table
 begin;
 CREATE TABLE ao (i int) WITH (appendonly=true);
 INSERT INTO ao SELECT generate_series(1, 100000);
 SELECT pg_sleep(5);
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'ao'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'ao'::regclass and segid = -1;
 SELECT pg_table_size('ao');
+commit;
+
+-- AOCS table index
+begin;
+CREATE INDEX ao_idx on ao(i);
+SELECT pg_sleep(5);
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'ao_idx'::regclass and segid = -1;
+SELECT pg_table_size('ao_idx');
 commit;
 
 DROP TABLE ao;
 
--- AOSC table
+-- AOCS table
 begin;
 CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column);
 INSERT INTO aocs SELECT i, repeat('a', 1000) FROM generate_series(1, 10000) AS i;
 SELECT pg_sleep(5);
-SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'aocs'::regclass ORDER BY segid DESC;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'aocs'::regclass and segid = -1;
 SELECT pg_table_size('aocs');
+commit;
+
+-- AOCS table index
+begin;
+CREATE INDEX aocs_idx on aocs(i);
+SELECT pg_sleep(5);
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'aocs_idx'::regclass and segid = -1;
+SELECT pg_table_size('aocs_idx');
 commit;
 
 DROP TABLE aocs;

--- a/tests/regress/sql/test_uncommitted_table_size.sql
+++ b/tests/regress/sql/test_uncommitted_table_size.sql
@@ -20,6 +20,17 @@ commit;
 
 drop table t2;
 
+-- toast table
+begin;
+CREATE TABLE t3(t text);
+INSERT INTO t3 SELECT repeat('a', 10000) FROM generate_series(1, 1000);
+SELECT pg_sleep(5);
+SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 't3'::regclass ORDER BY segid DESC;
+SELECT pg_table_size('t3');
+commit;
+
+drop table t3;
+
 -- AO table
 begin;
 CREATE TABLE ao (i int) WITH (appendonly=true);


### PR DESCRIPTION
1. Add calculate_table_size() to calculate any table's size, including uncommitted table. In this procedure, no lock will be acquired, and the deadlock will be avoided.
2. Use SearchSysCache(), instead of relation_open(), to fetch table's pg_class.
3. Use diskquota_get_index_list(Oid) to fetch index list, instead of RelationGetIndexList(Relation), to avoid using relation_open(), which may cause deadlock.