### PR TITLE
Fix incorrect JOIN condition in test_blackmap.sql

### DIFF
--- a/tests/regress/expected/test_blackmap.out
+++ b/tests/regress/expected/test_blackmap.out
@@ -70,7 +70,7 @@ SELECT block_relation_on_seg0('blocked_t1'::regclass, 'NAMESPACE'::text);
 SELECT rel.relname, be.target_type, (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0;
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid;
   relname   |   target_type   | namespace_matched 
 ------------+-----------------+-------------------
  blocked_t1 | NAMESPACE_QUOTA | t
@@ -87,7 +87,7 @@ SELECT block_relation_on_seg0('blocked_t1'::regclass, 'ROLE'::text);
 SELECT rel.relname, be.target_type, (be.target_oid=rel.relowner) AS owner_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0;
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid;
   relname   | target_type | owner_matched 
 ------------+-------------+---------------
  blocked_t1 | ROLE_QUOTA  | t
@@ -110,7 +110,7 @@ SELECT rel.relname, be.target_type,
                     (be.tablespace_oid=rel.reltablespace) AS tablespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0;
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid;
   relname   |        target_type         | namespace_matched | tablespace_matched 
 ------------+----------------------------+-------------------+--------------------
  blocked_t1 | NAMESPACE_TABLESPACE_QUOTA | t                 | t
@@ -129,7 +129,7 @@ SELECT rel.relname, be.target_type,
                     (be.tablespace_oid=rel.reltablespace) AS tablespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0;
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid;
   relname   |      target_type      | owner_matched | tablespace_matched 
 ------------+-----------------------+---------------+--------------------
  blocked_t1 | ROLE_TABLESPACE_QUOTA | t             | t
@@ -156,7 +156,7 @@ SELECT replace_oid_with_relname(rel.relname),
        (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid
   ORDER BY rel.relname DESC;
  replace_oid_with_relname  | relkind |   target_type   | namespace_matched 
 ---------------------------+---------+-----------------+-------------------
@@ -187,7 +187,7 @@ SELECT replace_oid_with_relname(rel.relname),
        (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid
   ORDER BY rel.relname DESC;
    replace_oid_with_relname    | relkind |   target_type   | namespace_matched 
 -------------------------------+---------+-----------------+-------------------
@@ -221,7 +221,7 @@ SELECT replace_oid_with_relname(rel.relname),
        (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid
   ORDER BY rel.relname DESC;
    replace_oid_with_relname    | relkind |   target_type   | namespace_matched 
 -------------------------------+---------+-----------------+-------------------
@@ -255,7 +255,7 @@ SELECT replace_oid_with_relname(rel.relname),
        (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid
   ORDER BY rel.relname DESC;
    replace_oid_with_relname    | relkind |   target_type   | namespace_matched 
 -------------------------------+---------+-----------------+-------------------

--- a/tests/regress/sql/test_blackmap.sql
+++ b/tests/regress/sql/test_blackmap.sql
@@ -69,7 +69,7 @@ SELECT block_relation_on_seg0('blocked_t1'::regclass, 'NAMESPACE'::text);
 SELECT rel.relname, be.target_type, (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0;
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid;
 
 -- Insert an entry for blocked_t1 to blackmap on seg0.
 SELECT block_relation_on_seg0('blocked_t1'::regclass, 'ROLE'::text);
@@ -78,7 +78,7 @@ SELECT block_relation_on_seg0('blocked_t1'::regclass, 'ROLE'::text);
 SELECT rel.relname, be.target_type, (be.target_oid=rel.relowner) AS owner_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0;
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid;
 
 -- Create a tablespace to test the rest of blocking types.
 \! mkdir /tmp/blocked_space
@@ -94,7 +94,7 @@ SELECT rel.relname, be.target_type,
                     (be.tablespace_oid=rel.reltablespace) AS tablespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0;
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid;
 
 -- Insert an entry for blocked_t1 to blackmap on seg0.
 SELECT block_relation_on_seg0('blocked_t1'::regclass, 'ROLE_TABLESPACE'::text);
@@ -105,7 +105,7 @@ SELECT rel.relname, be.target_type,
                     (be.tablespace_oid=rel.reltablespace) AS tablespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0;
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid;
 
 --
 -- 2. Test that the relfilenodes of toast relation together with its
@@ -122,7 +122,7 @@ SELECT replace_oid_with_relname(rel.relname),
        (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid
   ORDER BY rel.relname DESC;
 
 --
@@ -141,7 +141,7 @@ SELECT replace_oid_with_relname(rel.relname),
        (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid
   ORDER BY rel.relname DESC;
 
 --
@@ -160,7 +160,7 @@ SELECT replace_oid_with_relname(rel.relname),
        (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid
   ORDER BY rel.relname DESC;
 
 --
@@ -179,7 +179,7 @@ SELECT replace_oid_with_relname(rel.relname),
        (be.target_oid=rel.relnamespace) AS namespace_matched
   FROM gp_dist_random('pg_class') AS rel,
        gp_dist_random('diskquota.blackmap') AS be
-  WHERE rel.relfilenode=be.relnode AND be.relnode<>0
+  WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid
   ORDER BY rel.relname DESC;
 
 -- Do some clean-ups.


### PR DESCRIPTION
This PR fixes incorrect JOIN condition in test_blackmap.sql. The
relfilenodes are not always different across segments. Hence, we should
add an additional JOIN condition to the test case or it will produce
unstable results.