### PR TITLE
Add support for adding uncommitted relations to blackmap.

### DIFF
--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1389,6 +1389,36 @@ check_blackmap_by_relfilenode(RelFileNode relfilenode)
 }
 
 /*
+ * This function takes relowner, relnamespace, reltablespace as arguments,
+ * prepares the searching key of the global blackmap for us.
+ */
+static void
+prepare_blackmap_search_key(BlackMapEntry *keyitem, QuotaType type,
+							Oid relowner, Oid relnamespace, Oid reltablespace)
+{
+	Assert(keyitem != NULL);
+	memset(keyitem, 0, sizeof(BlackMapEntry));
+	if (type == ROLE_QUOTA || type == ROLE_TABLESPACE_QUOTA)
+		keyitem->targetoid = relowner;
+	else if (type == NAMESPACE_QUOTA || type == NAMESPACE_TABLESPACE_QUOTA)
+		keyitem->targetoid = relnamespace;
+	else
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("[diskquota] unknown quota type: %d", type)));
+
+	if (type == ROLE_TABLESPACE_QUOTA || type == NAMESPACE_TABLESPACE_QUOTA)
+		keyitem->tablespaceoid = reltablespace;
+	else
+	{
+		/* refer to add_quota_to_blacklist */
+		keyitem->tablespaceoid = InvalidOid;
+	}
+	keyitem->databaseoid = MyDatabaseId;
+	keyitem->targettype = type;
+}
+
+/*
  * Given table oid, check whether quota limit
  * of table's schema or table's owner are reached.
  * Do enforcement if quota exceeds.
@@ -1412,32 +1442,7 @@ check_blackmap_by_reloid(Oid reloid)
 	LWLockAcquire(diskquota_locks.black_map_lock, LW_SHARED);
 	for (QuotaType type = 0; type < NUM_QUOTA_TYPES; ++type)
 	{
-		if (type == ROLE_QUOTA || type == ROLE_TABLESPACE_QUOTA)
-		{
-			keyitem.targetoid = ownerOid;
-		}
-		else if (type == NAMESPACE_QUOTA || type == NAMESPACE_TABLESPACE_QUOTA)
-		{
-			keyitem.targetoid = nsOid;
-		}
-		else
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("[diskquota] unknown quota type: %d", type)));
-		}
-		if (type == ROLE_TABLESPACE_QUOTA || type == NAMESPACE_TABLESPACE_QUOTA)
-		{
-			keyitem.tablespaceoid = tablespaceoid;
-		}
-		else
-		{
-			/* refer to add_quota_to_blacklist */
-			keyitem.tablespaceoid = InvalidOid;
-		}
-		keyitem.databaseoid = MyDatabaseId;
-		keyitem.targettype = type;
-		memset(&keyitem.relfilenode, 0, sizeof(RelFileNode));
+		prepare_blackmap_search_key(&keyitem, type, ownerOid, nsOid, tablespaceoid);
 		entry = hash_search(disk_quota_black_map,
 					&keyitem,
 					HASH_FIND, &found);
@@ -1735,6 +1740,13 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 	hashctl.hcxt = CurrentMemoryContext;
 	hashctl.hash = tag_hash;
 
+	/*
+	 * Since uncommitted relations' information and the global blackmap entries
+	 * are cached in shared memory. The memory regions are guarded by lightweight
+	 * locks. In order not to hold multiple locks at the same time, We add blackmap
+	 * entries into the local_blackmap below and then flush the content of the
+	 * local_blackmap to the global blackmap at the end of this UDF.
+	 */
 	local_blackmap = hash_create("local_blackmap",
 								 1024, &hashctl,
 								 HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION);
@@ -1803,22 +1815,8 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 
 			for (QuotaType type = 0; type < NUM_QUOTA_TYPES; ++type)
 			{
-				/*
-				 * Check that if the current relation should be blocked.
-				 * FIXME: The logic of preparing the blackmap searching
-				 * key is identical to check_blackmap_by_reloid(), we can
-				 * make it into a static helper function.
-				 */
-				memset(&keyitem, 0, sizeof(BlackMapEntry));
-				if (type == ROLE_QUOTA || type == ROLE_TABLESPACE_QUOTA)
-					keyitem.targetoid = relowner;
-				else if (type == NAMESPACE_QUOTA || type == NAMESPACE_TABLESPACE_QUOTA)
-					keyitem.targetoid = relnamespace;
-				if (type == ROLE_TABLESPACE_QUOTA || type == NAMESPACE_TABLESPACE_QUOTA)
-					keyitem.tablespaceoid = reltablespace;
-				keyitem.databaseoid = MyDatabaseId;
-				keyitem.targettype = type;
-
+				/* Check that if the current relation should be blocked. */
+				prepare_blackmap_search_key(&keyitem, type, relowner, relnamespace, reltablespace);
 				blackmapentry = hash_search(local_blackmap,
 											&keyitem, HASH_FIND, &found);
 				if (found && blackmapentry)
@@ -1884,8 +1882,7 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 							memset(&blocked_filenode_keyitem, 0, sizeof(BlackMapEntry));
 							memcpy(&blocked_filenode_keyitem.relfilenode, &relfilenode, sizeof(RelFileNode));
 
-							LWLockAcquire(diskquota_locks.black_map_lock, LW_EXCLUSIVE);
-							blocked_filenode_entry = hash_search(disk_quota_black_map,
+							blocked_filenode_entry = hash_search(local_blackmap,
 																 &blocked_filenode_keyitem,
 																 HASH_ENTER_NULL, &found);
 							if (!found && blocked_filenode_entry)
@@ -1893,7 +1890,6 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 								memcpy(&blocked_filenode_entry->auxblockinfo, &keyitem, sizeof(BlackMapEntry));
 								blocked_filenode_entry->segexceeded = blackmapentry->segexceeded;
 							}
-							LWLockRelease(diskquota_locks.black_map_lock);
 						}
 					}
 					/*
@@ -1904,7 +1900,84 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 				}
 			}
 		}
+		else
+		{
+			/*
+			 * We cannot fetch the relation from syscache. It may be an uncommitted relation.
+			 * Let's try to fetch it from relation_cache.
+			 */
+			DiskQuotaRelationCacheEntry		   *relation_cache_entry;
+			bool								found;
+			LWLockAcquire(diskquota_locks.relation_cache_lock, LW_SHARED);
+			relation_cache_entry = hash_search(relation_cache, &active_oid,
+											   HASH_FIND, &found);
+			if (found && relation_cache_entry)
+			{
+				Oid				relnamespace = relation_cache_entry->namespaceoid;
+				Oid				reltablespace = relation_cache_entry->rnode.node.spcNode;
+				Oid				relowner = relation_cache_entry->owneroid;
+				BlackMapEntry	keyitem;
+				for (QuotaType type = 0; type < NUM_QUOTA_TYPES; ++type)
+				{
+					/* Check that if the current relation should be blocked. */
+					prepare_blackmap_search_key(&keyitem, type, relowner, relnamespace, reltablespace);
+					blackmapentry = hash_search(local_blackmap, &keyitem, HASH_FIND, &found);
+
+					if (found && blackmapentry)
+					{
+						List	   *oid_list = NIL;
+						ListCell   *cell = NULL;
+
+						/* Collect the relation oid together with its auxiliary relations' oid. */
+						oid_list = lappend_oid(oid_list, active_oid);
+						for (int auxoidcnt = 0; auxoidcnt < relation_cache_entry->auxrel_num; ++auxoidcnt)
+							oid_list = lappend_oid(oid_list, relation_cache_entry->auxrel_oid[auxoidcnt]);
+
+						foreach(cell, oid_list)
+						{
+							bool						found;
+							GlobalBlackMapEntry		   *blocked_filenode_entry;
+							BlackMapEntry				blocked_filenode_keyitem;
+							Oid							curr_oid = lfirst_oid(cell);
+
+							relation_cache_entry = hash_search(relation_cache,
+															   &curr_oid, HASH_FIND, &found);
+							if (found && relation_cache_entry)
+							{
+								memset(&blocked_filenode_keyitem, 0, sizeof(BlackMapEntry));
+								memcpy(&blocked_filenode_keyitem.relfilenode,
+									   &relation_cache_entry->rnode.node, sizeof(RelFileNode));
+
+								blocked_filenode_entry = hash_search(local_blackmap,
+																	 &blocked_filenode_keyitem,
+																	 HASH_ENTER_NULL, &found);
+								if (!found && blocked_filenode_entry)
+								{
+									memcpy(&blocked_filenode_entry->auxblockinfo, &keyitem, sizeof(BlackMapEntry));
+									blocked_filenode_entry->segexceeded = blackmapentry->segexceeded;
+								}
+							}
+						}
+					}
+				}
+			}
+			LWLockRelease(diskquota_locks.relation_cache_lock);
+		}
 	}
+
+	/* Flush the content of local_blackmap to the global blackmap. */
+	LWLockAcquire(diskquota_locks.black_map_lock, LW_EXCLUSIVE);
+	hash_seq_init(&hash_seq, local_blackmap);
+	while ((blackmapentry = hash_seq_search(&hash_seq)) != NULL)
+	{
+		bool					found;
+		GlobalBlackMapEntry	   *new_entry;
+		new_entry = hash_search(disk_quota_black_map, &blackmapentry->keyitem,
+								HASH_ENTER_NULL, &found);
+		if (!found && new_entry)
+			memcpy(new_entry, blackmapentry, sizeof(GlobalBlackMapEntry));
+	}
+	LWLockRelease(diskquota_locks.black_map_lock);
 
 	SPI_finish();
 	PG_RETURN_VOID();

--- a/tests/isolation2/expected/test_blackmap.out
+++ b/tests/isolation2/expected/test_blackmap.out
@@ -36,7 +36,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
 
 -- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=86819)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=65759)
 
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -75,7 +75,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
 
 -- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=86819)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=65759)
 
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -114,7 +114,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
 
 -- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=86819)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=65759)
 
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -155,7 +155,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
 
 -- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=86819)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=65759)
 
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -187,7 +187,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  tablespace:1663 schema:2200 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=86819)
+ERROR:  tablespace:1663 schema:2200 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=65759)
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
  refresh_blackmap 
@@ -218,7 +218,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  tablespace: 1663 role: 10 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=86819)
+ERROR:  tablespace: 1663 role: 10 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=65759)
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
  refresh_blackmap 
@@ -239,3 +239,443 @@ DROP TABLE blocked_t5;
 DROP
 DROP TABLE blocked_t6;
 DROP
+
+--
+-- Below are helper functions for testing adding uncommitted relations to blackmap.
+--
+-- start_ignore
+CREATE OR REPLACE LANGUAGE plpythonu;
+CREATE
+-- end_ignore
+CREATE TYPE cached_relation_entry AS ( reloid        oid, relname       text, relowner      oid, relnamespace  oid, reltablespace oid, relfilenode   oid, segid         int);
+CREATE
+
+-- This function dumps given relation_cache entries to the given file.
+CREATE OR REPLACE FUNCTION dump_relation_cache_to_file(filename text) RETURNS void AS $$ rv = plpy.execute(""" SELECT (oid, relname, relowner, relnamespace, reltablespace, relfilenode, gp_segment_id)::cached_relation_entry FROM gp_dist_random('pg_class') """) with open(filename, 'wt') as f: for v in rv: f.write(v['row'][1:-1] + '\n') $$ LANGUAGE plpythonu;
+CREATE
+
+-- This function reads relation_cache entries from the given file.
+CREATE OR REPLACE FUNCTION read_relation_cache_from_file(filename text) RETURNS SETOF cached_relation_entry AS $$ with open(filename) as f: for l in f: r = l.split(',') yield (r[0], r[1], r[2], r[3], r[4], r[5], r[6]) $$ LANGUAGE plpythonu;
+CREATE
+
+-- This function replaces the oid appears in the auxiliary relation's name
+-- with the corresponding relname of that oid.
+CREATE OR REPLACE FUNCTION replace_oid_with_relname(given_name text, filename text) RETURNS text AS $$                                                                      /*in func*/ BEGIN                                                                                   /*in func*/ RETURN COALESCE(                                                                      /*in func*/ REGEXP_REPLACE(given_name,                                                          /*in func*/ '^(pg_toast_|pg_aoseg_|pg_aovisimap_|pg_aoblkdir_|pg_aocsseg_)\d+',              /*in func*/ '\1' ||                                                                          /*in func*/ (SELECT DISTINCT relname FROM read_relation_cache_from_file(filename)            /*in func*/ WHERE reloid=REGEXP_REPLACE(given_name, '\D', '', 'g')::oid), 'g'), given_name);/*in func*/ END;                                                                                    /*in func*/ $$ LANGUAGE plpgsql;
+CREATE
+
+-- This function helps dispatch blackmap for the given relation to seg0.
+CREATE OR REPLACE FUNCTION block_uncommitted_relation_on_seg0(rel text, block_type text, segexceeded boolean, filename text) RETURNS void AS $$                                                      /*in func*/ DECLARE                                                                 /*in func*/ bt          int;                                                      /*in func*/ targetoid   oid;                                                      /*in func*/ BEGIN                                                                   /*in func*/ CASE block_type                                                       /*in func*/ WHEN 'NAMESPACE' THEN                                               /*in func*/ bt = 0;                                                           /*in func*/ SELECT relnamespace INTO targetoid                                /*in func*/ FROM read_relation_cache_from_file(filename)                    /*in func*/ WHERE relname=rel::text AND segid=0;                            /*in func*/ WHEN 'ROLE'      THEN                                               /*in func*/ bt = 1;                                                           /*in func*/ SELECT relowner INTO targetoid                                    /*in func*/ FROM read_relation_cache_from_file(filename)                    /*in func*/ WHERE relname=rel::text AND segid=0;                            /*in func*/ WHEN 'NAMESPACE_TABLESPACE' THEN                                    /*in func*/ bt = 2;                                                           /*in func*/ SELECT relnamespace INTO targetoid                                /*in func*/ FROM read_relation_cache_from_file(filename)                    /*in func*/ WHERE relname=rel::text AND segid=0;                            /*in func*/ WHEN 'ROLE_TABLESPACE' THEN                                         /*in func*/ bt = 3;                                                           /*in func*/ SELECT relowner INTO targetoid                                    /*in func*/ FROM read_relation_cache_from_file(filename)                    /*in func*/ WHERE relname=rel::text AND segid=0;                            /*in func*/ END CASE;                                                             /*in func*/ PERFORM diskquota.refresh_blackmap(                                   /*in func*/ ARRAY[                                                                /*in func*/ ROW(targetoid,                                                      /*in func*/ (SELECT oid FROM pg_database WHERE datname=current_database()), /*in func*/ (SELECT reltablespace                                           /*in func*/ FROM read_relation_cache_from_file(filename)                 /*in func*/ WHERE relname=rel::text AND segid=0),                        /*in func*/ bt,                                                             /*in func*/ segexceeded)                                                    /*in func*/ ]::diskquota.blackmap_entry[],                                      /*in func*/ ARRAY[(SELECT reloid FROM read_relation_cache_from_file(filename)     /*in func*/ WHERE relname=rel::text AND segid=0)::regclass]::oid[])      /*in func*/ FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;                     /*in func*/ END; $$                                                                 /*in func*/ LANGUAGE 'plpgsql';
+CREATE
+
+-- 7. Test that we are able to block an ordinary relation on seg0 by its relnamespace.
+1: BEGIN;
+BEGIN
+1: CREATE TABLE blocked_t7(i int);
+CREATE
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+ dump_relation_cache_to_file 
+-----------------------------
+                             
+(1 row)
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);  <waiting ...>
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE'::text, false, '/tmp/test_blackmap.csv'::text);
+ block_uncommitted_relation_on_seg0 
+------------------------------------
+                                    
+(1 row)
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text), be.target_type, be.target_oid FROM gp_dist_random('diskquota.blackmap') AS be, read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+ segid | relnamespace | reltablespace | relowner | replace_oid_with_relname | target_type     | target_oid 
+-------+--------------+---------------+----------+--------------------------+-----------------+------------
+ 0     | 2200         | 0             | 10       | blocked_t7               | NAMESPACE_QUOTA | 2200       
+(1 row)
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=65759)
+1: ABORT;
+ABORT
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+ refresh_blackmap 
+------------------
+                  
+(1 row)
+
+-- 8. Test that we are able to block an ordinary relation on seg0 by its relowner.
+1: BEGIN;
+BEGIN
+1: CREATE TABLE blocked_t7(i int);
+CREATE
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+ dump_relation_cache_to_file 
+-----------------------------
+                             
+(1 row)
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);  <waiting ...>
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'ROLE'::text, false, '/tmp/test_blackmap.csv'::text);
+ block_uncommitted_relation_on_seg0 
+------------------------------------
+                                    
+(1 row)
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text), be.target_type, be.target_oid FROM gp_dist_random('diskquota.blackmap') AS be, read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+ segid | relnamespace | reltablespace | relowner | replace_oid_with_relname | target_type | target_oid 
+-------+--------------+---------------+----------+--------------------------+-------------+------------
+ 0     | 2200         | 0             | 10       | blocked_t7               | ROLE_QUOTA  | 10         
+(1 row)
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  role's disk space quota exceeded with name:10  (seg0 127.0.0.1:6002 pid=65759)
+1: ABORT;
+ABORT
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+ refresh_blackmap 
+------------------
+                  
+(1 row)
+
+-- 9. Test that we are able to block an ordinary relation on seg0 by its relnamespace and reltablespace.
+1: BEGIN;
+BEGIN
+1: CREATE TABLE blocked_t7(i int);
+CREATE
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+ dump_relation_cache_to_file 
+-----------------------------
+                             
+(1 row)
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);  <waiting ...>
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE_TABLESPACE'::text, false, '/tmp/test_blackmap.csv'::text);
+ block_uncommitted_relation_on_seg0 
+------------------------------------
+                                    
+(1 row)
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text), be.target_type, be.target_oid FROM gp_dist_random('diskquota.blackmap') AS be, read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+ segid | relnamespace | reltablespace | relowner | replace_oid_with_relname | target_type                | target_oid 
+-------+--------------+---------------+----------+--------------------------+----------------------------+------------
+ 0     | 2200         | 0             | 10       | blocked_t7               | NAMESPACE_TABLESPACE_QUOTA | 2200       
+(1 row)
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  tablespace:1663 schema:2200 diskquota exceeded  (seg0 127.0.0.1:6002 pid=65759)
+1: ABORT;
+ABORT
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+ refresh_blackmap 
+------------------
+                  
+(1 row)
+
+-- 10. Test that we are able to block an ordinary relation on seg0 by its relowner and reltablespace.
+1: BEGIN;
+BEGIN
+1: CREATE TABLE blocked_t7(i int);
+CREATE
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+ dump_relation_cache_to_file 
+-----------------------------
+                             
+(1 row)
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);  <waiting ...>
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'ROLE_TABLESPACE'::text, false, '/tmp/test_blackmap.csv'::text);
+ block_uncommitted_relation_on_seg0 
+------------------------------------
+                                    
+(1 row)
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text), be.target_type, be.target_oid FROM gp_dist_random('diskquota.blackmap') AS be, read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+ segid | relnamespace | reltablespace | relowner | replace_oid_with_relname | target_type           | target_oid 
+-------+--------------+---------------+----------+--------------------------+-----------------------+------------
+ 0     | 2200         | 0             | 10       | blocked_t7               | ROLE_TABLESPACE_QUOTA | 10         
+(1 row)
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  tablespace: 1663 role: 10 diskquota exceeded  (seg0 127.0.0.1:6002 pid=65759)
+1: ABORT;
+ABORT
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+ refresh_blackmap 
+------------------
+                  
+(1 row)
+
+-- 11. Test that we are able to block an ordinary relation on seg0 by its relnamespace and reltablespace (segexceeded=true).
+1: BEGIN;
+BEGIN
+1: CREATE TABLE blocked_t7(i int);
+CREATE
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+ dump_relation_cache_to_file 
+-----------------------------
+                             
+(1 row)
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);  <waiting ...>
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE_TABLESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+ block_uncommitted_relation_on_seg0 
+------------------------------------
+                                    
+(1 row)
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text), be.target_type, be.target_oid FROM gp_dist_random('diskquota.blackmap') AS be, read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+ segid | relnamespace | reltablespace | relowner | replace_oid_with_relname | target_type                | target_oid 
+-------+--------------+---------------+----------+--------------------------+----------------------------+------------
+ 0     | 2200         | 0             | 10       | blocked_t7               | NAMESPACE_TABLESPACE_QUOTA | 2200       
+(1 row)
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  tablespace:1663 schema:2200 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=65759)
+1: ABORT;
+ABORT
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+ refresh_blackmap 
+------------------
+                  
+(1 row)
+
+-- 12. Test that we are able to block an ordinary relation on seg0 by its relowner and reltablespace (segexceeded=true).
+1: BEGIN;
+BEGIN
+1: CREATE TABLE blocked_t7(i int);
+CREATE
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+ dump_relation_cache_to_file 
+-----------------------------
+                             
+(1 row)
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);  <waiting ...>
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'ROLE_TABLESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+ block_uncommitted_relation_on_seg0 
+------------------------------------
+                                    
+(1 row)
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text), be.target_type, be.target_oid FROM gp_dist_random('diskquota.blackmap') AS be, read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+ segid | relnamespace | reltablespace | relowner | replace_oid_with_relname | target_type           | target_oid 
+-------+--------------+---------------+----------+--------------------------+-----------------------+------------
+ 0     | 2200         | 0             | 10       | blocked_t7               | ROLE_TABLESPACE_QUOTA | 10         
+(1 row)
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  tablespace: 1663 role: 10 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=65759)
+1: ABORT;
+ABORT
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+ refresh_blackmap 
+------------------
+                  
+(1 row)
+
+-- 13. Test that we are able to block a toast relation on seg0 by its namespace.
+1: BEGIN;
+BEGIN
+1: CREATE TABLE blocked_t7(i text);
+CREATE
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+ dump_relation_cache_to_file 
+-----------------------------
+                             
+(1 row)
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);  <waiting ...>
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+ block_uncommitted_relation_on_seg0 
+------------------------------------
+                                    
+(1 row)
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text) AS relname, be.target_type, be.target_oid FROM gp_dist_random('diskquota.blackmap') AS be, read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0 ORDER BY relname DESC;
+ segid | relnamespace | reltablespace | relowner | relname                   | target_type     | target_oid 
+-------+--------------+---------------+----------+---------------------------+-----------------+------------
+ 0     | 99           | 0             | 10       | pg_toast_blocked_t7_index | NAMESPACE_QUOTA | 2200       
+ 0     | 99           | 0             | 10       | pg_toast_blocked_t7       | NAMESPACE_QUOTA | 2200       
+ 0     | 2200         | 0             | 10       | blocked_t7                | NAMESPACE_QUOTA | 2200       
+(3 rows)
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=65759)
+1: ABORT;
+ABORT
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+ refresh_blackmap 
+------------------
+                  
+(1 row)
+
+-- 14. Test that we are able to block an appendonly relation on seg0 by its namespace.
+1: BEGIN;
+BEGIN
+1: CREATE TABLE blocked_t7(i int) WITH (appendonly=true);
+CREATE
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+ dump_relation_cache_to_file 
+-----------------------------
+                             
+(1 row)
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);  <waiting ...>
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+ block_uncommitted_relation_on_seg0 
+------------------------------------
+                                    
+(1 row)
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text) AS relname, be.target_type, be.target_oid FROM gp_dist_random('diskquota.blackmap') AS be, read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0 ORDER BY relname DESC;
+ segid | relnamespace | reltablespace | relowner | relname                       | target_type     | target_oid 
+-------+--------------+---------------+----------+-------------------------------+-----------------+------------
+ 0     | 6104         | 0             | 10       | pg_aovisimap_blocked_t7_index | NAMESPACE_QUOTA | 2200       
+ 0     | 6104         | 0             | 10       | pg_aovisimap_blocked_t7       | NAMESPACE_QUOTA | 2200       
+ 0     | 6104         | 0             | 10       | pg_aoseg_blocked_t7           | NAMESPACE_QUOTA | 2200       
+ 0     | 2200         | 0             | 10       | blocked_t7                    | NAMESPACE_QUOTA | 2200       
+(4 rows)
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=65759)
+1: ABORT;
+ABORT
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+ refresh_blackmap 
+------------------
+                  
+(1 row)
+
+-- 15. Test that we are able to block an appendonly (column oriented) relation on seg0 by its namespace.
+1: BEGIN;
+BEGIN
+1: CREATE TABLE blocked_t7(i int) WITH (appendonly=true, orientation=column);
+CREATE
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+ dump_relation_cache_to_file 
+-----------------------------
+                             
+(1 row)
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);  <waiting ...>
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+ block_uncommitted_relation_on_seg0 
+------------------------------------
+                                    
+(1 row)
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text) AS relname, be.target_type, be.target_oid FROM gp_dist_random('diskquota.blackmap') AS be, read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0 ORDER BY relname DESC;
+ segid | relnamespace | reltablespace | relowner | relname                       | target_type     | target_oid 
+-------+--------------+---------------+----------+-------------------------------+-----------------+------------
+ 0     | 6104         | 0             | 10       | pg_aovisimap_blocked_t7_index | NAMESPACE_QUOTA | 2200       
+ 0     | 6104         | 0             | 10       | pg_aovisimap_blocked_t7       | NAMESPACE_QUOTA | 2200       
+ 0     | 6104         | 0             | 10       | pg_aocsseg_blocked_t7         | NAMESPACE_QUOTA | 2200       
+ 0     | 2200         | 0             | 10       | blocked_t7                    | NAMESPACE_QUOTA | 2200       
+(4 rows)
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=65759)
+1: ABORT;
+ABORT
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+ refresh_blackmap 
+------------------
+                  
+(1 row)

--- a/tests/isolation2/sql/test_blackmap.sql
+++ b/tests/isolation2/sql/test_blackmap.sql
@@ -176,3 +176,333 @@ DROP TABLE blocked_t3;
 DROP TABLE blocked_t4;
 DROP TABLE blocked_t5;
 DROP TABLE blocked_t6;
+
+--
+-- Below are helper functions for testing adding uncommitted relations to blackmap.
+--
+-- start_ignore
+CREATE OR REPLACE LANGUAGE plpythonu;
+-- end_ignore
+CREATE TYPE cached_relation_entry AS (
+  reloid        oid,
+  relname       text,
+  relowner      oid,
+  relnamespace  oid,
+  reltablespace oid,
+  relfilenode   oid,
+  segid         int);
+
+-- This function dumps given relation_cache entries to the given file.
+CREATE OR REPLACE FUNCTION dump_relation_cache_to_file(filename text)
+  RETURNS void
+AS $$
+    rv = plpy.execute("""
+                      SELECT (oid, relname, relowner,
+                              relnamespace, reltablespace,
+                              relfilenode, gp_segment_id)::cached_relation_entry
+                      FROM gp_dist_random('pg_class')
+                      """)
+    with open(filename, 'wt') as f:
+        for v in rv:
+            f.write(v['row'][1:-1] + '\n')
+$$ LANGUAGE plpythonu;
+
+-- This function reads relation_cache entries from the given file.
+CREATE OR REPLACE FUNCTION read_relation_cache_from_file(filename text)
+  RETURNS SETOF cached_relation_entry
+AS $$
+   with open(filename) as f:
+       for l in f:
+           r = l.split(',')
+	   yield (r[0], r[1], r[2], r[3], r[4], r[5], r[6])
+$$ LANGUAGE plpythonu;
+
+-- This function replaces the oid appears in the auxiliary relation's name
+-- with the corresponding relname of that oid.
+CREATE OR REPLACE FUNCTION replace_oid_with_relname(given_name text, filename text)
+  RETURNS text AS $$                                                                      /*in func*/
+  BEGIN                                                                                   /*in func*/
+    RETURN COALESCE(                                                                      /*in func*/
+      REGEXP_REPLACE(given_name,                                                          /*in func*/
+         '^(pg_toast_|pg_aoseg_|pg_aovisimap_|pg_aoblkdir_|pg_aocsseg_)\d+',              /*in func*/
+         '\1' ||                                                                          /*in func*/
+	 (SELECT DISTINCT relname FROM read_relation_cache_from_file(filename)            /*in func*/
+          WHERE reloid=REGEXP_REPLACE(given_name, '\D', '', 'g')::oid), 'g'), given_name);/*in func*/
+  END;                                                                                    /*in func*/
+$$ LANGUAGE plpgsql;
+
+-- This function helps dispatch blackmap for the given relation to seg0.
+CREATE OR REPLACE FUNCTION block_uncommitted_relation_on_seg0(rel text, block_type text, segexceeded boolean, filename text)
+  RETURNS void AS $$                                                      /*in func*/
+  DECLARE                                                                 /*in func*/
+    bt          int;                                                      /*in func*/
+    targetoid   oid;                                                      /*in func*/
+  BEGIN                                                                   /*in func*/
+    CASE block_type                                                       /*in func*/
+      WHEN 'NAMESPACE' THEN                                               /*in func*/
+        bt = 0;                                                           /*in func*/
+        SELECT relnamespace INTO targetoid                                /*in func*/
+          FROM read_relation_cache_from_file(filename)                    /*in func*/
+	  WHERE relname=rel::text AND segid=0;                            /*in func*/
+      WHEN 'ROLE'      THEN                                               /*in func*/
+        bt = 1;                                                           /*in func*/
+        SELECT relowner INTO targetoid                                    /*in func*/
+          FROM read_relation_cache_from_file(filename)                    /*in func*/
+	  WHERE relname=rel::text AND segid=0;                            /*in func*/
+      WHEN 'NAMESPACE_TABLESPACE' THEN                                    /*in func*/
+        bt = 2;                                                           /*in func*/
+        SELECT relnamespace INTO targetoid                                /*in func*/
+          FROM read_relation_cache_from_file(filename)                    /*in func*/
+	  WHERE relname=rel::text AND segid=0;                            /*in func*/
+      WHEN 'ROLE_TABLESPACE' THEN                                         /*in func*/
+        bt = 3;                                                           /*in func*/
+        SELECT relowner INTO targetoid                                    /*in func*/
+          FROM read_relation_cache_from_file(filename)                    /*in func*/
+	  WHERE relname=rel::text AND segid=0;                            /*in func*/
+    END CASE;                                                             /*in func*/
+    PERFORM diskquota.refresh_blackmap(                                   /*in func*/
+    ARRAY[                                                                /*in func*/
+      ROW(targetoid,                                                      /*in func*/
+          (SELECT oid FROM pg_database WHERE datname=current_database()), /*in func*/
+          (SELECT reltablespace                                           /*in func*/
+             FROM read_relation_cache_from_file(filename)                 /*in func*/
+             WHERE relname=rel::text AND segid=0),                        /*in func*/
+          bt,                                                             /*in func*/
+          segexceeded)                                                    /*in func*/
+      ]::diskquota.blackmap_entry[],                                      /*in func*/
+    ARRAY[(SELECT reloid FROM read_relation_cache_from_file(filename)     /*in func*/
+             WHERE relname=rel::text AND segid=0)::regclass]::oid[])      /*in func*/
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;                     /*in func*/
+  END; $$                                                                 /*in func*/
+LANGUAGE 'plpgsql';
+
+-- 7. Test that we are able to block an ordinary relation on seg0 by its relnamespace.
+1: BEGIN;
+1: CREATE TABLE blocked_t7(i int);
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE'::text, false, '/tmp/test_blackmap.csv'::text);
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text),
+          be.target_type, be.target_oid
+     FROM gp_dist_random('diskquota.blackmap') AS be,
+          read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel
+     WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+1<:
+1: ABORT;
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap(
+  ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[])
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+
+-- 8. Test that we are able to block an ordinary relation on seg0 by its relowner.
+1: BEGIN;
+1: CREATE TABLE blocked_t7(i int);
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'ROLE'::text, false, '/tmp/test_blackmap.csv'::text);
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text),
+          be.target_type, be.target_oid
+     FROM gp_dist_random('diskquota.blackmap') AS be,
+          read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel
+     WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+1<:
+1: ABORT;
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap(
+  ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[])
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+
+-- 9. Test that we are able to block an ordinary relation on seg0 by its relnamespace and reltablespace.
+1: BEGIN;
+1: CREATE TABLE blocked_t7(i int);
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE_TABLESPACE'::text, false, '/tmp/test_blackmap.csv'::text);
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text),
+          be.target_type, be.target_oid
+     FROM gp_dist_random('diskquota.blackmap') AS be,
+          read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel
+     WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+1<:
+1: ABORT;
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap(
+  ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[])
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+
+-- 10. Test that we are able to block an ordinary relation on seg0 by its relowner and reltablespace.
+1: BEGIN;
+1: CREATE TABLE blocked_t7(i int);
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'ROLE_TABLESPACE'::text, false, '/tmp/test_blackmap.csv'::text);
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text),
+          be.target_type, be.target_oid
+     FROM gp_dist_random('diskquota.blackmap') AS be,
+          read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel
+     WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+1<:
+1: ABORT;
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap(
+  ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[])
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+
+-- 11. Test that we are able to block an ordinary relation on seg0 by its relnamespace and reltablespace (segexceeded=true).
+1: BEGIN;
+1: CREATE TABLE blocked_t7(i int);
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE_TABLESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text),
+          be.target_type, be.target_oid
+     FROM gp_dist_random('diskquota.blackmap') AS be,
+          read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel
+     WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+1<:
+1: ABORT;
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap(
+  ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[])
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+
+-- 12. Test that we are able to block an ordinary relation on seg0 by its relowner and reltablespace (segexceeded=true).
+1: BEGIN;
+1: CREATE TABLE blocked_t7(i int);
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'ROLE_TABLESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner, replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text),
+          be.target_type, be.target_oid
+     FROM gp_dist_random('diskquota.blackmap') AS be,
+          read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel
+     WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0;
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+1<:
+1: ABORT;
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap(
+  ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[])
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+
+-- 13. Test that we are able to block a toast relation on seg0 by its namespace.
+1: BEGIN;
+1: CREATE TABLE blocked_t7(i text);
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner,
+          replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text) AS relname,
+          be.target_type, be.target_oid
+     FROM gp_dist_random('diskquota.blackmap') AS be,
+          read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel
+     WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0
+     ORDER BY relname DESC;
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+1<:
+1: ABORT;
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap(
+  ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[])
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+
+-- 14. Test that we are able to block an appendonly relation on seg0 by its namespace.
+1: BEGIN;
+1: CREATE TABLE blocked_t7(i int) WITH (appendonly=true);
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner,
+          replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text) AS relname,
+          be.target_type, be.target_oid
+     FROM gp_dist_random('diskquota.blackmap') AS be,
+          read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel
+     WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0
+     ORDER BY relname DESC;
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+1<:
+1: ABORT;
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap(
+  ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[])
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
+
+-- 15. Test that we are able to block an appendonly (column oriented) relation on seg0 by its namespace.
+1: BEGIN;
+1: CREATE TABLE blocked_t7(i int) WITH (appendonly=true, orientation=column);
+1: SELECT dump_relation_cache_to_file('/tmp/test_blackmap.csv');
+-- Inject 'suspension' to check_blackmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Insert a small amount of data into blocked_t7. It will hang up at check_blackmap_by_relfilenode().
+1&: INSERT INTO blocked_t7 SELECT generate_series(1, 10000);
+SELECT block_uncommitted_relation_on_seg0('blocked_t7'::text, 'NAMESPACE'::text, true, '/tmp/test_blackmap.csv'::text);
+-- Show that blocked_t7 is blocked on seg0.
+2: SELECT rel.segid, rel.relnamespace, rel.reltablespace, rel.relowner,
+          replace_oid_with_relname(rel.relname, '/tmp/test_blackmap.csv'::text) AS relname,
+          be.target_type, be.target_oid
+     FROM gp_dist_random('diskquota.blackmap') AS be,
+          read_relation_cache_from_file('/tmp/test_blackmap.csv') AS rel
+     WHERE be.segid=rel.segid AND be.relnode=rel.relfilenode AND rel.relfilenode<>0
+     ORDER BY relname DESC;
+SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+1<:
+1: ABORT;
+-- Clean up the blackmap on seg0.
+SELECT diskquota.refresh_blackmap(
+  ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[])
+  FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;


### PR DESCRIPTION
This patch adds support for adding uncommitted relations to blackmap on
segment servers. Most of the codes share similar logic with adding
committed relations to blackmap. Test will be added in the next
following commits.