### PR TITLE
Ignore distribution notice in regression tests.

### DIFF
--- a/tests/init_file
+++ b/tests/init_file
@@ -3,7 +3,10 @@
 -- Individual tests can contain additional patterns specific to the test.
 
 -- start_matchignore
+# This pattern is extracted from gpdb/src/test/regress/init_file
+m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
 -- end_matchignore
+
 -- start_matchsubs
 m/diskquota.c:\d+\)/
 s/diskquota.c:\d+\)/diskquota.c:xxx/

--- a/tests/regress/expected/test_fetch_table_stat.out
+++ b/tests/regress/expected/test_fetch_table_stat.out
@@ -20,7 +20,6 @@ SELECT gp_inject_fault_infinite('diskquota_fetch_table_stat', 'error', dbid)
 SELECT COUNT(*)
     FROM (SELECT diskquota.diskquota_fetch_table_stat(1, array[(SELECT oid FROM pg_class WHERE relname='t_error_handling')])
           FROM gp_dist_random('gp_id') WHERE gp_segment_id=0) AS count;
-WARNING:  fault triggered, fault name:'diskquota_fetch_table_stat' fault type:'error'
  count 
 -------
      1


### PR DESCRIPTION
This PR is trying to fix CI building failure by ignoring distribution
notice in CTAS statements.

Co-Authored-by: Hao Zhang <hzhang2@vmware.com>