### PR TITLE
Dispatch only once for all tables when init()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.so
+build
 
 regression.out
 regression.diffs

--- a/diskquota--2.0.sql
+++ b/diskquota--2.0.sql
@@ -175,7 +175,7 @@ INSERT INTO diskquota.state SELECT (count(relname) = 0)::int FROM pg_class AS c,
 -- refer to see test case 'test_drop_after_pause'
 SELECT FROM diskquota.resume();
 
-CREATE OR REPLACE FUNCTION diskquota.pull_all_table_size(OUT tableid oid, OUT size bigint, OUT segid int) RETURNS SETOF RECORD AS 'MODULE_PATHNAME', 'pull_all_table_size' LANGUAGE C;
+CREATE OR REPLACE FUNCTION diskquota.pull_all_table_size(OUT tableid oid, OUT size bigint, OUT segid smallint) RETURNS SETOF RECORD AS '$libdir/diskquota-2.0.so', 'pull_all_table_size' LANGUAGE C;
 
 -- Starting the worker has to be the last step.
 CREATE FUNCTION diskquota.diskquota_start_worker() RETURNS void STRICT AS '$libdir/diskquota-2.0.so' LANGUAGE C;

--- a/diskquota--2.0.sql
+++ b/diskquota--2.0.sql
@@ -171,10 +171,13 @@ GROUP BY pgc.relowner, reltablespace, pgr.rolname, pgsp.spcname, qc.quotalimitMB
 -- prepare to boot
 INSERT INTO diskquota.state SELECT (count(relname) = 0)::int FROM pg_class AS c, pg_namespace AS n WHERE c.oid > 16384 AND relnamespace = n.oid AND nspname != 'diskquota';
 
-CREATE FUNCTION diskquota.diskquota_start_worker() RETURNS void STRICT AS '$libdir/diskquota-2.0.so' LANGUAGE C;
-SELECT diskquota.diskquota_start_worker();
-DROP FUNCTION diskquota.diskquota_start_worker();
-
 -- re-dispatch pause status to false. in case user pause-drop-recreate.
 -- refer to see test case 'test_drop_after_pause'
 SELECT FROM diskquota.resume();
+
+CREATE OR REPLACE FUNCTION diskquota.pull_all_table_size(OUT tableid oid, OUT size bigint, OUT segid int) RETURNS SETOF RECORD AS 'MODULE_PATHNAME', 'pull_all_table_size' LANGUAGE C;
+
+-- Starting the worker has to be the last step.
+CREATE FUNCTION diskquota.diskquota_start_worker() RETURNS void STRICT AS '$libdir/diskquota-2.0.so' LANGUAGE C;
+SELECT diskquota.diskquota_start_worker();
+DROP FUNCTION diskquota.diskquota_start_worker();

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -88,7 +88,6 @@ init_table_size_table(PG_FUNCTION_ARGS)
 {
 	int		ret;
 	StringInfoData	buf;
-	StringInfoData	insert_buf;
 
 	RangeVar   	*rv;
 	Relation	rel;
@@ -127,7 +126,6 @@ init_table_size_table(PG_FUNCTION_ARGS)
 
 	/* delete all the table size info in table_size if exist. */
 	initStringInfo(&buf);
-	initStringInfo(&insert_buf);
 	appendStringInfo(&buf, "truncate table diskquota.table_size;");
 	ret = SPI_execute(buf.data, false, 0);
 	if (ret != SPI_OK_UTILITY)
@@ -274,7 +272,7 @@ pull_all_table_size(PG_FUNCTION_ARGS)
 		tupdesc = CreateTemplateTupleDesc(3, false /*hasoid*/);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "TABLEID", OIDOID, -1 /*typmod*/, 0 /*attdim*/);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "SIZE", INT8OID, -1 /*typmod*/, 0 /*attdim*/);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "SEGID", INT4OID, -1 /*typmod*/, 0 /*attdim*/);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "SEGID", INT2OID, -1 /*typmod*/, 0 /*attdim*/);
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 
 		/* Create a local hash table and fill it with entries from shared memory. */

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -157,7 +157,7 @@ init_table_size_table(PG_FUNCTION_ARGS)
 		resetStringInfo(&buf);
 		appendStringInfo(&buf, "INSERT INTO diskquota.table_size WITH total_size AS "
 								"(SELECT * from diskquota.pull_all_table_size() "
-								"UNION ALL SELECT tableid, size, segid FROM table_size) "	
+								"UNION ALL SELECT tableid, size, segid FROM diskquota.table_size) "	
 								"SELECT tableid, sum(size) as size, -1 as segid FROM total_size GROUP BY tableid;");
 		ret = SPI_execute(buf.data, false, 0);
 		if (ret != SPI_OK_INSERT)

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -222,7 +222,7 @@ calculate_all_table_size()
 
 		rnode.node.dbNode = MyDatabaseId;
 		rnode.node.relNode = classForm->relfilenode;
-		rnode.node.spcNode = OidIsValid(classForm->reltablespace) ? classForm->reltablespace : DEFAULTTABLESPACE_OID;
+		rnode.node.spcNode = OidIsValid(classForm->reltablespace) ? classForm->reltablespace : MyDatabaseTableSpace;
 		rnode.backend = classForm->relpersistence == RELPERSISTENCE_TEMP ? TempRelBackendId : InvalidBackendId;
 		tablesize = calculate_relation_size_all_forks(&rnode, classForm->relstorage);
 

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -145,7 +145,7 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	else
 	{
 		resetStringInfo(&buf);
-		appendStringInfo(&buf, "insert into diskquota.table_size WITH all_size AS "
+		appendStringInfo(&buf, "INSERT INTO diskquota.table_size WITH all_size AS "
 								"(SELECT diskquota.pull_all_table_size() as a FROM gp_dist_random('gp_id')) "	
 								"SELECT (a).* FROM all_size;");
 		ret = SPI_execute(buf.data, false, 0);
@@ -153,6 +153,7 @@ init_table_size_table(PG_FUNCTION_ARGS)
 			elog(ERROR, "cannot insert into table_size table: error code %d", ret);
 
 		resetStringInfo(&buf);
+        /* size is the sum of size on master and on all segments when segid == -1. */
 		appendStringInfo(&buf, "INSERT INTO diskquota.table_size WITH total_size AS "
 								"(SELECT * from diskquota.pull_all_table_size() "
 								"UNION ALL SELECT tableid, size, segid FROM diskquota.table_size) "	

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -1,5 +1,6 @@
 test: config
 test: test_create_extension
+test: test_init_table_size_table
 test: test_relation_size
 test: test_relation_cache
 test: test_uncommitted_table_size

--- a/tests/regress/expected/test_init_table_size_table.out
+++ b/tests/regress/expected/test_init_table_size_table.out
@@ -1,48 +1,44 @@
 -- heap table
-CREATE TABLE t(i int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t(i int) DISTRIBUTED BY (i);
 INSERT INTO t SELECT generate_series(1, 100000);
 -- heap table index
 CREATE INDEX idx on t(i);
 -- toast table
-CREATE TABLE toast(t text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE toast(t text)  DISTRIBUTED BY (t);
 INSERT INTO toast SELECT repeat('a', 10000) FROM generate_series(1, 1000);
 -- toast table index
 CREATE INDEX toast_idx on toast(t);
 -- AO table
-CREATE TABLE ao (i int) WITH (appendonly=true);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE ao (i int) WITH (appendonly=true)  DISTRIBUTED BY (i);
 INSERT INTO ao SELECT generate_series(1, 100000);
 -- AO table index
 CREATE INDEX ao_idx on ao(i);
 -- AOCS table
-CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (i);
 INSERT INTO aocs SELECT i, repeat('a', 1000) FROM generate_series(1, 10000) AS i;
 -- AOCS table index
 CREATE INDEX aocs_idx on aocs(i);
-SELECT pg_sleep(5);
- pg_sleep 
-----------
- 
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
 (1 row)
 
-select tableid::regclass, size from diskquota.table_size where segid = -1 and tableid::regclass::name not like '%.%' order by tableid;
-  tableid  |   size   
------------+----------
- t         |  3932160
- idx       |  2490368
- toast     |   393216
- toast_idx |   327680
- ao        |  1591464
- ao_idx    |  2490368
- aocs      | 10813592
- aocs_idx  |   524288
+-- Tables here are fetched by diskquota_fetch_table_stat()
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size 
+WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
+ORDER BY tableid;
+  tableid  |   size   | segid 
+-----------+----------+-------
+ t         |  3932160 |    -1
+ idx       |  2490368 |    -1
+ toast     |   393216 |    -1
+ toast_idx |   327680 |    -1
+ ao        |  1591464 |    -1
+ ao_idx    |  2490368 |    -1
+ aocs      | 10813592 |    -1
+ aocs_idx  |   524288 |    -1
 (8 rows)
 
 -- init diskquota.table_size
@@ -52,17 +48,21 @@ SELECT diskquota.init_table_size_table();
  
 (1 row)
 
-select tableid::regclass, size from diskquota.table_size where segid = -1 and tableid::regclass::name not like '%.%' order by tableid;
-  tableid  |   size   
------------+----------
- t         |  3932160
- idx       |  2490368
- toast     |   393216
- toast_idx |   327680
- ao        |  1591464
- ao_idx    |  2490368
- aocs      | 10813592
- aocs_idx  |   524288
+-- diskquota.table_size should not change after init_table_size_table()
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size 
+WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
+ORDER BY tableid;
+  tableid  |   size   | segid 
+-----------+----------+-------
+ t         |  3932160 |    -1
+ idx       |  2490368 |    -1
+ toast     |   393216 |    -1
+ toast_idx |   327680 |    -1
+ ao        |  1591464 |    -1
+ ao_idx    |  2490368 |    -1
+ aocs      | 10813592 |    -1
+ aocs_idx  |   524288 |    -1
 (8 rows)
 
 DROP TABLE t;

--- a/tests/regress/expected/test_init_table_size_table.out
+++ b/tests/regress/expected/test_init_table_size_table.out
@@ -1,0 +1,71 @@
+-- heap table
+CREATE TABLE t(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO t SELECT generate_series(1, 100000);
+-- heap table index
+CREATE INDEX idx on t(i);
+-- toast table
+CREATE TABLE toast(t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO toast SELECT repeat('a', 10000) FROM generate_series(1, 1000);
+-- toast table index
+CREATE INDEX toast_idx on toast(t);
+-- AO table
+CREATE TABLE ao (i int) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO ao SELECT generate_series(1, 100000);
+-- AO table index
+CREATE INDEX ao_idx on ao(i);
+-- AOCS table
+CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO aocs SELECT i, repeat('a', 1000) FROM generate_series(1, 10000) AS i;
+-- AOCS table index
+CREATE INDEX aocs_idx on aocs(i);
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+select tableid::regclass, size from diskquota.table_size where segid = -1 and tableid::regclass::name not like '%.%' order by tableid;
+  tableid  |   size   
+-----------+----------
+ t         |  3932160
+ idx       |  2490368
+ toast     |   393216
+ toast_idx |   327680
+ ao        |  1591464
+ ao_idx    |  2490368
+ aocs      | 10813592
+ aocs_idx  |   524288
+(8 rows)
+
+-- init diskquota.table_size
+SELECT diskquota.init_table_size_table();
+ init_table_size_table 
+-----------------------
+ 
+(1 row)
+
+select tableid::regclass, size from diskquota.table_size where segid = -1 and tableid::regclass::name not like '%.%' order by tableid;
+  tableid  |   size   
+-----------+----------
+ t         |  3932160
+ idx       |  2490368
+ toast     |   393216
+ toast_idx |   327680
+ ao        |  1591464
+ ao_idx    |  2490368
+ aocs      | 10813592
+ aocs_idx  |   524288
+(8 rows)
+
+DROP TABLE t;
+DROP TABLE toast;
+DROP TABLE ao;
+DROP TABLE aocs;

--- a/tests/regress/sql/test_init_table_size_table.sql
+++ b/tests/regress/sql/test_init_table_size_table.sql
@@ -1,38 +1,47 @@
 -- heap table
-CREATE TABLE t(i int);
+CREATE TABLE t(i int) DISTRIBUTED BY (i);
 INSERT INTO t SELECT generate_series(1, 100000);
 
 -- heap table index
 CREATE INDEX idx on t(i);
 
 -- toast table
-CREATE TABLE toast(t text);
+CREATE TABLE toast(t text)  DISTRIBUTED BY (t);
 INSERT INTO toast SELECT repeat('a', 10000) FROM generate_series(1, 1000);
 
 -- toast table index
 CREATE INDEX toast_idx on toast(t);
 
 -- AO table
-CREATE TABLE ao (i int) WITH (appendonly=true);
+CREATE TABLE ao (i int) WITH (appendonly=true)  DISTRIBUTED BY (i);
 INSERT INTO ao SELECT generate_series(1, 100000);
 
 -- AO table index
 CREATE INDEX ao_idx on ao(i);
 
 -- AOCS table
-CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column);
+CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (i);
 INSERT INTO aocs SELECT i, repeat('a', 1000) FROM generate_series(1, 10000) AS i;
 
 -- AOCS table index
 CREATE INDEX aocs_idx on aocs(i);
 
-SELECT pg_sleep(5);
+SELECT diskquota.wait_for_worker_new_epoch();
 
-select tableid::regclass, size from diskquota.table_size where segid = -1 and tableid::regclass::name not like '%.%' order by tableid;
+-- Tables here are fetched by diskquota_fetch_table_stat()
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size 
+WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
+ORDER BY tableid;
 
 -- init diskquota.table_size
 SELECT diskquota.init_table_size_table();
-select tableid::regclass, size from diskquota.table_size where segid = -1 and tableid::regclass::name not like '%.%' order by tableid;
+
+-- diskquota.table_size should not change after init_table_size_table()
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size 
+WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
+ORDER BY tableid;
 
 DROP TABLE t;
 DROP TABLE toast;

--- a/tests/regress/sql/test_init_table_size_table.sql
+++ b/tests/regress/sql/test_init_table_size_table.sql
@@ -1,0 +1,40 @@
+-- heap table
+CREATE TABLE t(i int);
+INSERT INTO t SELECT generate_series(1, 100000);
+
+-- heap table index
+CREATE INDEX idx on t(i);
+
+-- toast table
+CREATE TABLE toast(t text);
+INSERT INTO toast SELECT repeat('a', 10000) FROM generate_series(1, 1000);
+
+-- toast table index
+CREATE INDEX toast_idx on toast(t);
+
+-- AO table
+CREATE TABLE ao (i int) WITH (appendonly=true);
+INSERT INTO ao SELECT generate_series(1, 100000);
+
+-- AO table index
+CREATE INDEX ao_idx on ao(i);
+
+-- AOCS table
+CREATE TABLE aocs (i int, t text) WITH (appendonly=true, orientation=column);
+INSERT INTO aocs SELECT i, repeat('a', 1000) FROM generate_series(1, 10000) AS i;
+
+-- AOCS table index
+CREATE INDEX aocs_idx on aocs(i);
+
+SELECT pg_sleep(5);
+
+select tableid::regclass, size from diskquota.table_size where segid = -1 and tableid::regclass::name not like '%.%' order by tableid;
+
+-- init diskquota.table_size
+SELECT diskquota.init_table_size_table();
+select tableid::regclass, size from diskquota.table_size where segid = -1 and tableid::regclass::name not like '%.%' order by tableid;
+
+DROP TABLE t;
+DROP TABLE toast;
+DROP TABLE ao;
+DROP TABLE aocs;


### PR DESCRIPTION
Add UDF `pull_all_table_size()` to accelerate `init_table_size_table()`. In this UDF:
1. we traverse pg_class to calculate the relation size of each relation;
2. parse the auxiliary table's name to get the relevant primary table's oid;
3. add the size of the auxiliary table to the primary table's size.

It can avoid multiple `relation_open()` and dispatching `pg_table_size()` to all segments.