### PR TITLE
Fix bug: table's relation_cache_entry is not be removed after vacuum full

### DIFF
--- a/relation_cache.c
+++ b/relation_cache.c
@@ -289,9 +289,14 @@ remove_committed_relation_from_cache(void)
 	hash_seq_init(&iter, local_relation_cache);
 	while ((local_entry = hash_seq_search(&iter)) != NULL)
 	{
-		if (SearchSysCacheExists1(RELOID, local_entry->relid))
+		/* The committed table's oid can be fetched by RelidByRelfilenode().
+		 * If the table's relfilenode is modified and its relation_cache_entry
+		 * remains in relation_cache, the outdated relation_cache_entry should 
+		 * be removed.
+		 */
+		if (OidIsValid(RelidByRelfilenode(local_entry->rnode.node.spcNode, local_entry->rnode.node.relNode)))
 		{
-			remove_cache_entry(local_entry->relid, InvalidOid);
+			remove_cache_entry(InvalidOid, local_entry->rnode.node.relNode);
 		}
 	}
 	hash_destroy(local_relation_cache);

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -289,7 +289,8 @@ remove_committed_relation_from_cache(void)
 	hash_seq_init(&iter, local_relation_cache);
 	while ((local_entry = hash_seq_search(&iter)) != NULL)
 	{
-		/* The committed table's oid can be fetched by RelidByRelfilenode().
+		/*
+		 * The committed table's oid can be fetched by RelidByRelfilenode().
 		 * If the table's relfilenode is modified and its relation_cache_entry
 		 * remains in relation_cache, the outdated relation_cache_entry should 
 		 * be removed.

--- a/tests/regress/expected/test_vacuum.out
+++ b/tests/regress/expected/test_vacuum.out
@@ -34,6 +34,19 @@ SELECT pg_sleep(20);
  
 (1 row)
 
+SELECT tableid::regclass, size, segid from diskquota.table_size WHERE tableid::regclass::name not like '%.%' ORDER BY size, segid DESC;
+ tableid | size  | segid 
+---------+-------+-------
+ b       |     0 |     2
+ b       |     0 |     1
+ b       |     0 |     0
+ b       |     0 |    -1
+ a       | 32768 |     2
+ a       | 32768 |     1
+ a       | 32768 |     0
+ a       | 98304 |    -1
+(8 rows)
+
 -- expect insert succeed
 INSERT INTO a SELECT generate_series(1,10);
 INSERT INTO b SELECT generate_series(1,10);

--- a/tests/regress/expected/test_vacuum.out
+++ b/tests/regress/expected/test_vacuum.out
@@ -34,7 +34,7 @@ SELECT pg_sleep(20);
  
 (1 row)
 
-SELECT tableid::regclass, size, segid from diskquota.table_size WHERE tableid::regclass::name not like '%.%' ORDER BY size, segid DESC;
+SELECT tableid::regclass, size, segid from diskquota.table_size WHERE tableid::regclass::name NOT LIKE '%.%' ORDER BY size, segid DESC;
  tableid | size  | segid 
 ---------+-------+-------
  b       |     0 |     2

--- a/tests/regress/sql/test_vacuum.sql
+++ b/tests/regress/sql/test_vacuum.sql
@@ -13,6 +13,8 @@ INSERT INTO b SELECT generate_series(1,10);
 DELETE FROM a WHERE i > 10;
 VACUUM FULL a;
 SELECT pg_sleep(20);
+SELECT tableid::regclass, size, segid from diskquota.table_size WHERE tableid::regclass::name not like '%.%' ORDER BY size, segid DESC;
+
 -- expect insert succeed
 INSERT INTO a SELECT generate_series(1,10);
 INSERT INTO b SELECT generate_series(1,10);


### PR DESCRIPTION
The modified table's relation_cache_entry is not be removed after vacuum full.
Use RelidByRelfilenode() to check whether the table is committed, and remove its relation_cache_entry.