### PR TITLE
Wait until deleted tuples are dead before VACUUM

### DIFF
--- a/tests/regress/expected/test_partition.out
+++ b/tests/regress/expected/test_partition.out
@@ -45,6 +45,12 @@ ERROR:  schema's disk space quota exceeded with name:s8
 INSERT INTO measurement SELECT 1, '2006-03-03' ,1,1;
 ERROR:  schema's disk space quota exceeded with name:s8
 DELETE FROM measurement WHERE logdate='2006-03-02';
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 VACUUM FULL measurement;
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 

--- a/tests/regress/expected/test_vacuum.out
+++ b/tests/regress/expected/test_vacuum.out
@@ -27,6 +27,12 @@ ERROR:  schema's disk space quota exceeded with name:s6
 INSERT INTO b SELECT generate_series(1,10);
 ERROR:  schema's disk space quota exceeded with name:s6
 DELETE FROM a WHERE i > 10;
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 VACUUM FULL a;
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 

--- a/tests/regress/sql/test_partition.sql
+++ b/tests/regress/sql/test_partition.sql
@@ -25,6 +25,7 @@ INSERT INTO measurement SELECT 1, '2006-02-02' ,1,1;
 -- expect insert fail
 INSERT INTO measurement SELECT 1, '2006-03-03' ,1,1;
 DELETE FROM measurement WHERE logdate='2006-03-02';
+SELECT diskquota.wait_for_worker_new_epoch();
 VACUUM FULL measurement;
 SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO measurement SELECT 1, '2006-02-02' ,1,1;

--- a/tests/regress/sql/test_vacuum.sql
+++ b/tests/regress/sql/test_vacuum.sql
@@ -11,6 +11,7 @@ INSERT INTO a SELECT generate_series(1,10);
 -- expect insert fail
 INSERT INTO b SELECT generate_series(1,10);
 DELETE FROM a WHERE i > 10;
+SELECT diskquota.wait_for_worker_new_epoch();
 VACUUM FULL a;
 SELECT diskquota.wait_for_worker_new_epoch();
 SELECT tableid::regclass, size, segid from diskquota.table_size WHERE tableid::regclass::name NOT LIKE '%.%' ORDER BY size, segid DESC;


### PR DESCRIPTION
Consider a user session that does a DELETE followed by a VACUUM FULL to
reclaim the disk space. If, at the same time, the bgworker loads config
by doing a SELECT, and the SELECT begins before the DELETE ends, while ends
after the VACUUM FULL begins:

bgw: ---------[ SELECT ]----------->
usr: ---[ DELETE ]-[ VACUUM FULL ]-->

then the tuples deleted will be marked as RECENTLY_DEAD instead of DEAD.
As a result, the deleted tuples cannot be removed by VACUUM FULL.

The fix lets the user session wait for the bgworker to finish the current
SELECT before starting VACUUM FULL .