### PR TITLE
Refactor pause() to skip refreshing quota

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -79,6 +79,15 @@ static int	num_db = 0;
  */
 bool *diskquota_paused = NULL;
 
+bool
+diskquota_is_paused()
+{
+	LWLockAcquire(diskquota_locks.paused_lock, LW_SHARED);
+	bool paused = *diskquota_paused;
+	LWLockRelease(diskquota_locks.paused_lock);
+	return paused;
+}
+
 /* functions of disk quota*/
 void		_PG_init(void);
 void		_PG_fini(void);
@@ -365,7 +374,8 @@ disk_quota_worker_main(Datum main_arg)
 		}
 
 		/* Do the work */
-		refresh_disk_quota_model(false);
+		if (!diskquota_is_paused())
+			refresh_disk_quota_model(false);
 		worker_increase_epoch(MyDatabaseId);
 	}
 

--- a/diskquota.h
+++ b/diskquota.h
@@ -145,5 +145,6 @@ extern Oid diskquota_parse_primary_table_oid(Oid namespace, char *relname);
 
 extern bool worker_increase_epoch(Oid database_oid);
 extern unsigned int worker_get_epoch(Oid database_oid);
+extern bool diskquota_is_paused();
 
 #endif

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1599,17 +1599,12 @@ check_blackmap_by_reloid(Oid reloid)
 bool
 quota_check_common(Oid reloid, RelFileNode *relfilenode)
 {
-	bool	paused;
 	bool	enable_hardlimit;
 
 	if (!IsTransactionState())
 		return true;
 
-	LWLockAcquire(diskquota_locks.paused_lock, LW_SHARED);
-	paused = *diskquota_paused;
-	LWLockRelease(diskquota_locks.paused_lock);
-
-	if (paused)
+	if (diskquota_is_paused())
 		return true;
 
 	if (OidIsValid(reloid))

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -4,6 +4,7 @@ test: test_worker_epoch
 test: test_relation_size
 test: test_relation_cache
 test: test_uncommitted_table_size
+test: test_pause_and_resume
 # disable this tese due to GPDB behavior change
 # test: test_table_size
 test: test_fast_disk_check
@@ -16,7 +17,6 @@ test: test_vacuum
 test: test_primary_failure
 test: test_extension
 test: test_manytable
-test: test_pause_and_resume
 test: test_many_active_tables
 test: test_fetch_table_stat
 test: test_appendonly

--- a/tests/regress/expected/test_pause_and_resume.out
+++ b/tests/regress/expected/test_pause_and_resume.out
@@ -4,9 +4,6 @@ SET search_path TO s1;
 CREATE TABLE a(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE TABLE b(i int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- expect insert succeed
 INSERT INTO a SELECT generate_series(1,100000);
 SELECT diskquota.set_schema_quota('s1', '1 MB');
@@ -24,9 +21,6 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,100);
 ERROR:  schema's disk space quota exceeded with name:s1
--- expect insert fail
-INSERT INTO b SELECT generate_series(1,100);
-ERROR:  schema's disk space quota exceeded with name:s1
 -- pause extension
 SELECT diskquota.pause();
  pause 
@@ -34,10 +28,21 @@ SELECT diskquota.pause();
  
 (1 row)
 
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SELECT tableid::regclass, size, segid FROM diskquota.table_size 
+WHERE tableid = 'a'::regclass AND segid = -1;
+ tableid |  size   | segid 
+---------+---------+-------
+ a       | 3932160 |    -1
+(1 row)
+
 -- expect insert succeed
-INSERT INTO a SELECT generate_series(1,100);
--- expect insert succeed
-INSERT INTO b SELECT generate_series(1,100);
+INSERT INTO a SELECT generate_series(1,100000);
 -- resume extension
 SELECT diskquota.resume();
  resume 
@@ -45,12 +50,23 @@ SELECT diskquota.resume();
  
 (1 row)
 
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,100);
 ERROR:  schema's disk space quota exceeded with name:s1
--- expect insert fail
-INSERT INTO b SELECT generate_series(1,100);
-ERROR:  schema's disk space quota exceeded with name:s1
+-- table size should be updated after resume
+SELECT tableid::regclass, size, segid FROM diskquota.table_size 
+WHERE tableid = 'a'::regclass AND segid = -1;
+ tableid |  size   | segid 
+---------+---------+-------
+ a       | 7569408 |    -1
+(1 row)
+
 RESET search_path;
-DROP TABLE s1.a, s1.b;
+DROP TABLE s1.a;
 DROP SCHEMA s1;

--- a/tests/regress/sql/test_pause_and_resume.sql
+++ b/tests/regress/sql/test_pause_and_resume.sql
@@ -3,7 +3,6 @@ CREATE SCHEMA s1;
 SET search_path TO s1;
 
 CREATE TABLE a(i int);
-CREATE TABLE b(i int);
 
 -- expect insert succeed
 INSERT INTO a SELECT generate_series(1,100000);
@@ -12,26 +11,28 @@ SELECT diskquota.set_schema_quota('s1', '1 MB');
 SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,100);
--- expect insert fail
-INSERT INTO b SELECT generate_series(1,100);
 
 -- pause extension
 SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
+
+SELECT tableid::regclass, size, segid FROM diskquota.table_size 
+WHERE tableid = 'a'::regclass AND segid = -1;
 
 -- expect insert succeed
-INSERT INTO a SELECT generate_series(1,100);
--- expect insert succeed
-INSERT INTO b SELECT generate_series(1,100);
+INSERT INTO a SELECT generate_series(1,100000);
 
 -- resume extension
 SELECT diskquota.resume();
+SELECT diskquota.wait_for_worker_new_epoch();
 
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,100);
--- expect insert fail
-INSERT INTO b SELECT generate_series(1,100);
+
+-- table size should be updated after resume
+SELECT tableid::regclass, size, segid FROM diskquota.table_size 
+WHERE tableid = 'a'::regclass AND segid = -1;
 
 RESET search_path;
-DROP TABLE s1.a, s1.b;
+DROP TABLE s1.a;
 DROP SCHEMA s1;
-


### PR DESCRIPTION
Currently, diskquota.pause() only takes effect on quota checking.
Bgworkers still go over the loop to refreshing quota even if diskquota
is paused. This wastes computation resources and can cause flaky issues.

This fix makes bgworkers skip refreshing quota when the user pauses
diskquota entirely to avoid those issues. Table sizes can be updated
correctly after resume.