### PR TITLE
be nice with scheduler when naptime = 0

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -359,7 +359,8 @@ disk_quota_worker_main(Datum main_arg)
 		 */
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-					   diskquota_naptime * 1000L);
+					   // be nice to scheduler when naptime == 0 and diskquota_is_paused() == true
+					   diskquota_naptime == 0 ? 1:  diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
 
 		/* Emergency bailout if postmaster has died */
@@ -376,6 +377,7 @@ disk_quota_worker_main(Datum main_arg)
 		/* Do the work */
 		if (!diskquota_is_paused())
 			refresh_disk_quota_model(false);
+
 		worker_increase_epoch(MyDatabaseId);
 	}
 

--- a/diskquota.c
+++ b/diskquota.c
@@ -459,7 +459,8 @@ disk_quota_launcher_main(Datum main_arg)
 		 */
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-					   diskquota_naptime * 1000L);
+					   // wait at least one time slice, avoid 100% CPU usage
+					   diskquota_naptime == 0 ? 1 : diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
 
 		/* Emergency bailout if postmaster has died */

--- a/diskquota.c
+++ b/diskquota.c
@@ -316,9 +316,12 @@ disk_quota_worker_main(Datum main_arg)
 		}
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-					   // be nice to scheduler when naptime == 0 and diskquota_is_paused() == true
-					   diskquota_naptime == 0 ? usleep(1), 0 : diskquota_naptime * 1000L);
+					   diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
+
+		// be nice to scheduler when naptime == 0 and diskquota_is_paused() == true
+		if (!diskquota_naptime)
+			usleep(1);
 
 		/* Emergency bailout if postmaster has died */
 		if (rc & WL_POSTMASTER_DEATH)
@@ -360,9 +363,12 @@ disk_quota_worker_main(Datum main_arg)
 		 */
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-					   // be nice to scheduler when naptime == 0 and diskquota_is_paused() == true
-					   diskquota_naptime == 0 ? usleep(1), 0:  diskquota_naptime * 1000L);
+					   diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
+
+		// be nice to scheduler when naptime == 0 and diskquota_is_paused() == true
+		if (!diskquota_naptime)
+			usleep(1);
 
 		/* Emergency bailout if postmaster has died */
 		if (rc & WL_POSTMASTER_DEATH)
@@ -462,9 +468,12 @@ disk_quota_launcher_main(Datum main_arg)
 		 */
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-					   // wait at least one time slice, avoid 100% CPU usage
-					   diskquota_naptime == 0 ? usleep(1), 0 : diskquota_naptime * 1000L);
+					   diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
+
+		// wait at least one time slice, avoid 100% CPU usage
+		if (!diskquota_naptime)
+			usleep(1);
 
 		/* Emergency bailout if postmaster has died */
 		if (rc & WL_POSTMASTER_DEATH)

--- a/diskquota.c
+++ b/diskquota.c
@@ -56,6 +56,8 @@ PG_MODULE_MAGIC;
 #define DISKQUOTA_DB	"diskquota"
 #define DISKQUOTA_APPLICATION_NAME  "gp_reserved_gpdiskquota"
 
+extern int usleep(useconds_t usec); // in <unistd.h>
+
 /* flags set by signal handlers */
 static volatile sig_atomic_t got_sighup = false;
 static volatile sig_atomic_t got_sigterm = false;

--- a/diskquota.c
+++ b/diskquota.c
@@ -316,7 +316,8 @@ disk_quota_worker_main(Datum main_arg)
 		}
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-					   diskquota_naptime * 1000L);
+					   // be nice to scheduler when naptime == 0 and diskquota_is_paused() == true
+					   diskquota_naptime == 0 ? usleep(1), 0 : diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
 
 		/* Emergency bailout if postmaster has died */
@@ -360,7 +361,7 @@ disk_quota_worker_main(Datum main_arg)
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
 					   // be nice to scheduler when naptime == 0 and diskquota_is_paused() == true
-					   diskquota_naptime == 0 ? 1:  diskquota_naptime * 1000L);
+					   diskquota_naptime == 0 ? usleep(1), 0:  diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
 
 		/* Emergency bailout if postmaster has died */
@@ -462,7 +463,7 @@ disk_quota_launcher_main(Datum main_arg)
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
 					   // wait at least one time slice, avoid 100% CPU usage
-					   diskquota_naptime == 0 ? 1 : diskquota_naptime * 1000L);
+					   diskquota_naptime == 0 ? usleep(1), 0 : diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
 
 		/* Emergency bailout if postmaster has died */


### PR DESCRIPTION
before: 
![1](https://user-images.githubusercontent.com/12945182/150718950-05d36c91-e268-4fa3-a9aa-f120a2025251.png)
after:
![2](https://user-images.githubusercontent.com/12945182/150718965-9a193a49-ceca-4de8-b575-2a89c6525dbb.png)
with diskauota paused:
![2022-01-24_12-03](https://user-images.githubusercontent.com/12945182/150720233-7e861167-7004-48ee-90c4-8a0b99d461d7.png)


this PR avoids a busy loop in diskquota launcher when naptime = 0. save 100% (1core) CPU resource.