### PR TITLE
Pause before DROP EXTENSION

### DIFF
--- a/tests/isolation2/sql/cleanup.sql
+++ b/tests/isolation2/sql/cleanup.sql
@@ -1,3 +1,5 @@
 -- start_ignore
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
 -- end_ignore

--- a/tests/regress/expected/clean.out
+++ b/tests/regress/expected/clean.out
@@ -1,4 +1,16 @@
 DROP TABLE badquota.t1;
 DROP ROLE testbody;
 DROP SCHEMA badquota;
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;

--- a/tests/regress/expected/test_drop_after_pause.out
+++ b/tests/regress/expected/test_drop_after_pause.out
@@ -1,8 +1,16 @@
 CREATE DATABASE test_drop_after_pause;
 \c test_drop_after_pause
 CREATE EXTENSION diskquota;
-SELECT FROM diskquota.pause();
---
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
 (1 row)
 
 DROP EXTENSION diskquota;
@@ -30,11 +38,23 @@ SELECT diskquota.wait_for_worker_new_epoch();
 (1 row)
 
 INSERT INTO SX.a SELECT generate_series(1,1000000); -- expect insert fail
-ERROR:  schema's disk space quota exceeded with name:41008  (seg0 127.0.0.1:6002 pid=388076)
+ERROR:  schema's disk space quota exceeded with name:746125  (seg0 127.0.0.1:6002 pid=22648)
 SELECT diskquota.disable_hardlimit();
  disable_hardlimit 
 -------------------
  
+(1 row)
+
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
 (1 row)
 
 DROP EXTENSION diskquota;

--- a/tests/regress/expected/test_extension.out
+++ b/tests/regress/expected/test_extension.out
@@ -23,7 +23,6 @@ show max_worker_processes;
 2
 \c dbx0
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 3
 CREATE SCHEMA SX;
@@ -74,7 +73,6 @@ ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx2
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 5
 CREATE SCHEMA SX;
@@ -99,7 +97,6 @@ ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx3
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 6
 CREATE SCHEMA SX;
@@ -124,7 +121,6 @@ ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx4
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 7
 CREATE SCHEMA SX;
@@ -149,7 +145,6 @@ ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx5
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 8
 CREATE SCHEMA SX;
@@ -174,7 +169,6 @@ ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx6
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 9
 CREATE SCHEMA SX;
@@ -199,7 +193,6 @@ ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx7
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 10
 CREATE SCHEMA SX;
@@ -224,7 +217,6 @@ ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx8
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 11
 CREATE SCHEMA SX;
@@ -249,74 +241,177 @@ ERROR:  schema's disk space quota exceeded with name:sx
 DROP TABLE SX.a;
 \c dbx9
 CREATE EXTENSION diskquota;
-ERROR:  [diskquota] failed to create diskquota extension: too many databases to monitor (diskquota_utility.c:290)
-\! sleep 2
+ERROR:  [diskquota] failed to create diskquota extension: too many databases to monitor (diskquota_utility.c:287)
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 11
 \c dbx10
 CREATE EXTENSION diskquota;
-ERROR:  [diskquota] failed to create diskquota extension: too many databases to monitor (diskquota_utility.c:290)
-\! sleep 2
+ERROR:  [diskquota] failed to create diskquota extension: too many databases to monitor (diskquota_utility.c:287)
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 11
 \c dbx0
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 10
 \c dbx1
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 9
 \c dbx2
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 8
 \c dbx3
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 7
 \c dbx4
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 6
 \c dbx5
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 5
 \c dbx6
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 4
 \c dbx7
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 3
 \c dbx8
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 2
 \c dbx9
+SELECT diskquota.pause();
+ERROR:  schema "diskquota" does not exist
+SELECT diskquota.wait_for_worker_new_epoch();
+ERROR:  schema "diskquota" does not exist
 DROP EXTENSION diskquota;
 ERROR:  extension "diskquota" does not exist
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 2
 \c dbx10
+SELECT diskquota.pause();
+ERROR:  schema "diskquota" does not exist
+SELECT diskquota.wait_for_worker_new_epoch();
+ERROR:  schema "diskquota" does not exist
 DROP EXTENSION diskquota;
 ERROR:  extension "diskquota" does not exist
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 2
-\c postgres
+\c contrib_regression
 DROP DATABASE dbx0 ;
 DROP DATABASE dbx1 ;
 DROP DATABASE dbx2 ;

--- a/tests/regress/expected/test_pause_and_resume_multiple_db.out
+++ b/tests/regress/expected/test_pause_and_resume_multiple_db.out
@@ -161,8 +161,32 @@ SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO s1.a SELECT generate_series(1,100); -- expect insert fail
 ERROR:  schema's disk space quota exceeded with name:s1
 \c test_pause_and_resume
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
 \c test_new_create_database
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
 \c contrib_regression
 DROP SCHEMA s1 CASCADE;

--- a/tests/regress/expected/test_recreate.out
+++ b/tests/regress/expected/test_recreate.out
@@ -4,6 +4,18 @@ CREATE DATABASE test_recreate;
 INSERT INTO diskquota_namespace.database_list(dbid) SELECT oid FROM pg_database WHERE datname = 'test_recreate';
 \c test_recreate
 CREATE EXTENSION diskquota; -- shoud be ok
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 DROP EXTENSION diskquota;
 \c contrib_regression
 DROP DATABASE test_recreate;

--- a/tests/regress/sql/clean.sql
+++ b/tests/regress/sql/clean.sql
@@ -2,4 +2,6 @@ DROP TABLE badquota.t1;
 DROP ROLE testbody;
 DROP SCHEMA badquota;
 
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;

--- a/tests/regress/sql/test_drop_after_pause.sql
+++ b/tests/regress/sql/test_drop_after_pause.sql
@@ -3,7 +3,8 @@ CREATE DATABASE test_drop_after_pause;
 \c test_drop_after_pause
 
 CREATE EXTENSION diskquota;
-SELECT FROM diskquota.pause();
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
 
 CREATE EXTENSION diskquota;
@@ -17,6 +18,8 @@ SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO SX.a SELECT generate_series(1,1000000); -- expect insert fail
 
 SELECT diskquota.disable_hardlimit();
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
 
 \c contrib_regression

--- a/tests/regress/sql/test_extension.sql
+++ b/tests/regress/sql/test_extension.sql
@@ -20,7 +20,6 @@ show max_worker_processes;
 
 \c dbx0
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -44,7 +43,6 @@ DROP TABLE SX.a;
 
 \c dbx2
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -56,7 +54,6 @@ DROP TABLE SX.a;
 
 \c dbx3
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -68,7 +65,6 @@ DROP TABLE SX.a;
 
 \c dbx4
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -80,7 +76,6 @@ DROP TABLE SX.a;
 
 \c dbx5
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -92,7 +87,6 @@ DROP TABLE SX.a;
 
 \c dbx6
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -104,7 +98,6 @@ DROP TABLE SX.a;
 
 \c dbx7
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -116,7 +109,6 @@ DROP TABLE SX.a;
 
 \c dbx8
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -128,70 +120,79 @@ DROP TABLE SX.a;
 
 \c dbx9
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx10
 CREATE EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx0
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx1
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx2
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx3
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx4
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx5
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx6
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx7
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx8
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx9
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 \c dbx10
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
-\! sleep 2
 \! ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
-\c postgres
+\c contrib_regression
 
 DROP DATABASE dbx0 ;
 DROP DATABASE dbx1 ;

--- a/tests/regress/sql/test_pause_and_resume_multiple_db.sql
+++ b/tests/regress/sql/test_pause_and_resume_multiple_db.sql
@@ -66,9 +66,13 @@ SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO s1.a SELECT generate_series(1,100); -- expect insert fail
 
 \c test_pause_and_resume
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
 
 \c test_new_create_database
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
 
 \c contrib_regression

--- a/tests/regress/sql/test_recreate.sql
+++ b/tests/regress/sql/test_recreate.sql
@@ -8,6 +8,8 @@ INSERT INTO diskquota_namespace.database_list(dbid) SELECT oid FROM pg_database 
 
 \c test_recreate
 CREATE EXTENSION diskquota; -- shoud be ok
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;
 
 \c contrib_regression


### PR DESCRIPTION
Currently, deadlock can occur when

- A user session is doing DROP EXTENSION, and
- A bgworker is loading quota configs using SPI.

This patch fixes the issue by pausing diskquota before DROP 
EXTENSION so that the bgworker will not load config anymore.

Note that this cannot be done using object_access_hook() because
the extension object is dropped AFTER dropping all tables that belong
to it.