### PR TITLE
Fix flaky test case in isolation2/test_relation_size.sql

### DIFF
--- a/tests/isolation2/expected/test_relation_size.out
+++ b/tests/isolation2/expected/test_relation_size.out
@@ -17,29 +17,37 @@ SELECT diskquota.relation_size('t_dropped');
 (1 row)
 
 -- Inject 'suspension' to servers.
-SELECT gp_inject_fault_infinite('diskquota_before_stat_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p';
+SELECT gp_inject_fault_infinite('diskquota_before_stat_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content>=0;
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
  Success:                 
  Success:                 
- Success:                 
-(4 rows)
+(3 rows)
 
 -- Session 1 will hang before applying stat(2) to the physical file.
 1&: SELECT diskquota.relation_size('t_dropped');  <waiting ...>
+-- Wait until the fault is triggered to avoid the following race condition:
+-- The 't_dropped' table is dropped before evaluating "SELECT diskquota.relation_size('t_dropped')"
+-- and the query will fail with 'ERROR: relation "t_dropped" does not exist'
+SELECT gp_wait_until_triggered_fault('diskquota_before_stat_relfilenode', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
 -- Drop the table.
 DROP TABLE t_dropped;
 DROP
 -- Remove the injected 'suspension'.
-SELECT gp_inject_fault_infinite('diskquota_before_stat_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p';
+SELECT gp_inject_fault_infinite('diskquota_before_stat_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content>=0;
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
  Success:                 
  Success:                 
- Success:                 
-(4 rows)
+(3 rows)
 -- Session 1 will continue and returns 0.
 1<:  <... completed>
  relation_size 


### PR DESCRIPTION
This PR is trying to fix a race condition in `isolation2/test_relation_size`. It's observed in our CI https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/diskquota-pr-gpdb-6x/jobs/test_diskquota_pr/builds/30

-- edited by beeender start--
The pipeline has been renamed:
https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/DEPRECATED:diskquota-pr-gpdb-6x/jobs/test_diskquota_pr/builds/30
-- edited by beeender end--