### PR TITLE
Test when table is created before quota is set

### DIFF
--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -13,6 +13,8 @@ test: test_update_db_cache
 test: test_fast_disk_check
 #test: test_insert_after_drop
 test: test_role test_schema test_drop_table test_column test_copy test_update test_toast test_truncate test_reschema test_temp_role test_rename test_delete_quota test_mistake test_tablespace_role test_tablespace_schema test_tablespace_role_perseg test_tablespace_schema_perseg test_index test_recreate
+test: test_ctas_no_preload_lib
+test: test_ctas_before_set_quota
 test: test_truncate
 test: test_delete_quota
 test: test_partition

--- a/tests/regress/expected/test_ctas_before_set_quota.out
+++ b/tests/regress/expected/test_ctas_before_set_quota.out
@@ -1,0 +1,61 @@
+CREATE ROLE test SUPERUSER;
+SET ROLE test;
+CREATE TABLE t_before_set_quota (i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SELECT tableid::regclass, size, segid FROM diskquota.table_size
+WHERE tableid = 't_before_set_quota'::regclass ORDER BY segid;
+      tableid       |  size   | segid 
+--------------------+---------+-------
+ t_before_set_quota | 3637248 |    -1
+ t_before_set_quota | 1212416 |     0
+ t_before_set_quota | 1212416 |     1
+ t_before_set_quota | 1212416 |     2
+(4 rows)
+
+-- Ensure that the table is not active
+SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
+FROM gp_dist_random('gp_id');
+ diskquota_fetch_table_stat 
+----------------------------
+(0 rows)
+
+SELECT diskquota.set_role_quota(current_role, '1MB');
+ set_role_quota 
+----------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+-- Expect that current role is in the blackmap 
+SELECT rolname FROM pg_authid, diskquota.blackmap WHERE oid = target_oid;
+ rolname 
+---------
+ test
+(1 row)
+
+SELECT diskquota.set_role_quota(current_role, '-1');
+ set_role_quota 
+----------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+DROP TABLE t_before_set_quota;
+RESET ROLE;
+DROP ROLE test;

--- a/tests/regress/expected/test_ctas_no_preload_lib.out
+++ b/tests/regress/expected/test_ctas_no_preload_lib.out
@@ -9,11 +9,13 @@ DISTRIBUTED BY (i);
 \! gpconfig -c shared_preload_libraries -v 'diskquota'> /dev/null 
 \! gpstop -far > /dev/null
 \c
--- Make sure that the worker has started
-SELECT diskquota.wait_for_worker_new_epoch();
- wait_for_worker_new_epoch 
----------------------------
- t
+-- Make sure that the worker has started. 
+-- We cannot use wait_for_worker_new_epoch() here because the worker might not
+-- have started yet.
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
 (1 row)
 
 SET ROLE test;

--- a/tests/regress/expected/test_ctas_no_preload_lib.out
+++ b/tests/regress/expected/test_ctas_no_preload_lib.out
@@ -1,0 +1,86 @@
+\! gpconfig -c shared_preload_libraries -v '' > /dev/null 
+\! gpstop -far > /dev/null
+\c
+CREATE ROLE test SUPERUSER;
+SET ROLE test;
+-- Create table with diskquota disabled
+CREATE TABLE t_without_diskquota (i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+\! gpconfig -c shared_preload_libraries -v 'diskquota'> /dev/null 
+\! gpstop -far > /dev/null
+\c
+-- Make sure that the worker has started
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SET ROLE test;
+-- Init table_size to include the table
+SELECT diskquota.init_table_size_table();
+ init_table_size_table 
+-----------------------
+ 
+(1 row)
+
+-- Restart to load diskquota.table_size to the memory.
+\! gpstop -far > /dev/null
+\c
+SET ROLE test;
+SELECT tableid::regclass, size, segid FROM diskquota.table_size
+WHERE tableid = 't_without_diskquota'::regclass ORDER BY segid;
+       tableid       |  size   | segid 
+---------------------+---------+-------
+ t_without_diskquota | 3637248 |    -1
+ t_without_diskquota | 1212416 |     0
+ t_without_diskquota | 1212416 |     1
+ t_without_diskquota | 1212416 |     2
+(4 rows)
+
+-- Ensure that the table is not active
+SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
+FROM gp_dist_random('gp_id');
+ diskquota_fetch_table_stat 
+----------------------------
+(0 rows)
+
+SELECT diskquota.set_role_quota(current_role, '1MB');
+ set_role_quota 
+----------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+-- Expect that current role is in the blackmap 
+SELECT rolname FROM pg_authid, diskquota.blackmap WHERE oid = target_oid;
+ rolname 
+---------
+ test
+(1 row)
+
+SELECT diskquota.set_role_quota(current_role, '-1');
+ set_role_quota 
+----------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SELECT rolname FROM pg_authid, diskquota.blackmap WHERE oid = target_oid;
+ rolname 
+---------
+(0 rows)
+
+DROP TABLE t_without_diskquota;
+RESET ROLE;
+DROP ROLE test;

--- a/tests/regress/expected/test_index.out
+++ b/tests/regress/expected/test_index.out
@@ -8,8 +8,6 @@ NOTICE:  tablespace "indexspc" does not exist, skipping
 CREATE TABLESPACE indexspc LOCATION '/tmp/indexspc';
 SET search_path TO indexschema1;
 CREATE TABLE test_index_a(i int) TABLESPACE indexspc DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO test_index_a SELECT generate_series(1,20000);
 SELECT diskquota.set_schema_tablespace_quota('indexschema1', 'indexspc','2 MB');
  set_schema_tablespace_quota 
@@ -23,17 +21,25 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t
 (1 row)
 
-SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name='indexschema1' and tablespace_name='indexspc';
+SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes 
+FROM diskquota.show_fast_schema_tablespace_quota_view 
+WHERE schema_name='indexschema1' and tablespace_name='indexspc';
  schema_name  | tablespace_name | quota_in_mb | nspsize_tablespace_in_bytes 
 --------------+-----------------+-------------+-----------------------------
  indexschema1 | indexspc        |           2 |                     1081344
 (1 row)
 
-SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and relname='test_index_a' and segid=-1;
-  size   | segid 
----------+-------
- 1081344 |    -1
-(1 row)
+SELECT tableid::regclass, size, segid 
+FROM diskquota.table_size 
+WHERE tableid = 'test_index_a'::regclass
+ORDER BY segid;
+   tableid    |  size   | segid 
+--------------+---------+-------
+ test_index_a | 1081344 |    -1
+ test_index_a |  360448 |     0
+ test_index_a |  360448 |     1
+ test_index_a |  360448 |     2
+(4 rows)
 
 -- create index for the table, index in default tablespace
 CREATE INDEX a_index ON test_index_a(i);
@@ -52,12 +58,29 @@ SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM 
  indexschema1 | indexspc        |           2 |                     1441792
 (1 row)
 
-SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (relname='test_index_a' or relname='a_index') and segid=-1;
-  size   | segid 
----------+-------
- 1441792 |    -1
- 1212416 |    -1
-(2 rows)
+SELECT tableid::regclass, size, segid 
+FROM diskquota.table_size 
+WHERE tableid = 'test_index_a'::regclass
+ORDER BY segid;
+   tableid    |  size   | segid 
+--------------+---------+-------
+ test_index_a | 1441792 |    -1
+ test_index_a |  491520 |     0
+ test_index_a |  491520 |     1
+ test_index_a |  458752 |     2
+(4 rows)
+
+SELECT tableid::regclass, size, segid 
+FROM diskquota.table_size 
+WHERE tableid = 'a_index'::regclass
+ORDER BY segid;
+ tableid |  size   | segid 
+---------+---------+-------
+ a_index | 1212416 |    -1
+ a_index |  393216 |     0
+ a_index |  393216 |     1
+ a_index |  393216 |     2
+(4 rows)
 
 -- add index to tablespace indexspc
 ALTER index a_index SET TABLESPACE indexspc;

--- a/tests/regress/expected/test_role.out
+++ b/tests/regress/expected/test_role.out
@@ -6,12 +6,8 @@ NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE u2 NOLOGIN;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE b OWNER TO u1;
 CREATE TABLE b2 (t TEXT) DISTRIBUTED BY (t);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE b2 OWNER TO u1;
 SELECT diskquota.set_role_quota('u1', '1 MB');
  set_role_quota 
@@ -20,7 +16,7 @@ SELECT diskquota.set_role_quota('u1', '1 MB');
 (1 row)
 
 INSERT INTO b SELECT generate_series(1,100);
--- expect insert fail
+-- expect insert success
 INSERT INTO b SELECT generate_series(1,100000);
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
@@ -70,6 +66,30 @@ SELECT role_name, quota_in_mb, rolsize_in_bytes FROM diskquota.show_fast_role_qu
 -----------+-------------+------------------
  u1        |           1 |          4194304
 (1 row)
+
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size
+WHERE tableid = 'b'::regclass
+ORDER BY segid;
+ tableid |  size   | segid 
+---------+---------+-------
+ b       | 4063232 |    -1
+ b       | 1343488 |     0
+ b       | 1343488 |     1
+ b       | 1343488 |     2
+(4 rows)
+
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size
+WHERE tableid = 'b2'::regclass
+ORDER BY segid;
+ tableid |  size  | segid 
+---------+--------+-------
+ b2      | 131072 |    -1
+ b2      |  32768 |     0
+ b2      |  32768 |     1
+ b2      |  32768 |     2
+(4 rows)
 
 ALTER TABLE b OWNER TO u2;
 SELECT diskquota.wait_for_worker_new_epoch();

--- a/tests/regress/sql/test_ctas_before_set_quota.sql
+++ b/tests/regress/sql/test_ctas_before_set_quota.sql
@@ -1,0 +1,32 @@
+CREATE ROLE test SUPERUSER;
+
+SET ROLE test;
+
+CREATE TABLE t_before_set_quota (i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+
+SELECT diskquota.wait_for_worker_new_epoch();
+
+SELECT tableid::regclass, size, segid FROM diskquota.table_size
+WHERE tableid = 't_before_set_quota'::regclass ORDER BY segid;
+
+-- Ensure that the table is not active
+SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
+FROM gp_dist_random('gp_id');
+
+SELECT diskquota.set_role_quota(current_role, '1MB');
+
+SELECT diskquota.wait_for_worker_new_epoch();
+
+-- Expect that current role is in the blackmap 
+SELECT rolname FROM pg_authid, diskquota.blackmap WHERE oid = target_oid;
+
+SELECT diskquota.set_role_quota(current_role, '-1');
+
+SELECT diskquota.wait_for_worker_new_epoch();
+
+DROP TABLE t_before_set_quota;
+
+RESET ROLE;
+
+DROP ROLE test;

--- a/tests/regress/sql/test_ctas_no_preload_lib.sql
+++ b/tests/regress/sql/test_ctas_no_preload_lib.sql
@@ -14,8 +14,10 @@ DISTRIBUTED BY (i);
 \! gpstop -far > /dev/null
 \c
 
--- Make sure that the worker has started
-SELECT diskquota.wait_for_worker_new_epoch();
+-- Make sure that the worker has started. 
+-- We cannot use wait_for_worker_new_epoch() here because the worker might not
+-- have started yet.
+SELECT pg_sleep(1);
 
 SET ROLE test;
 

--- a/tests/regress/sql/test_ctas_no_preload_lib.sql
+++ b/tests/regress/sql/test_ctas_no_preload_lib.sql
@@ -1,0 +1,54 @@
+\! gpconfig -c shared_preload_libraries -v '' > /dev/null 
+\! gpstop -far > /dev/null
+\c
+
+CREATE ROLE test SUPERUSER;
+
+SET ROLE test;
+
+-- Create table with diskquota disabled
+CREATE TABLE t_without_diskquota (i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+
+\! gpconfig -c shared_preload_libraries -v 'diskquota'> /dev/null 
+\! gpstop -far > /dev/null
+\c
+
+-- Make sure that the worker has started
+SELECT diskquota.wait_for_worker_new_epoch();
+
+SET ROLE test;
+
+-- Init table_size to include the table
+SELECT diskquota.init_table_size_table();
+
+-- Restart to load diskquota.table_size to the memory.
+\! gpstop -far > /dev/null
+\c
+SET ROLE test;
+
+SELECT tableid::regclass, size, segid FROM diskquota.table_size
+WHERE tableid = 't_without_diskquota'::regclass ORDER BY segid;
+
+-- Ensure that the table is not active
+SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
+FROM gp_dist_random('gp_id');
+
+SELECT diskquota.set_role_quota(current_role, '1MB');
+
+SELECT diskquota.wait_for_worker_new_epoch();
+
+-- Expect that current role is in the blackmap 
+SELECT rolname FROM pg_authid, diskquota.blackmap WHERE oid = target_oid;
+
+SELECT diskquota.set_role_quota(current_role, '-1');
+
+SELECT diskquota.wait_for_worker_new_epoch();
+
+SELECT rolname FROM pg_authid, diskquota.blackmap WHERE oid = target_oid;
+
+DROP TABLE t_without_diskquota;
+
+RESET ROLE;
+
+DROP ROLE test;

--- a/tests/regress/sql/test_index.sql
+++ b/tests/regress/sql/test_index.sql
@@ -9,10 +9,19 @@ SET search_path TO indexschema1;
 
 CREATE TABLE test_index_a(i int) TABLESPACE indexspc DISTRIBUTED BY (i);
 INSERT INTO test_index_a SELECT generate_series(1,20000);
+
 SELECT diskquota.set_schema_tablespace_quota('indexschema1', 'indexspc','2 MB');
 SELECT diskquota.wait_for_worker_new_epoch();
-SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name='indexschema1' and tablespace_name='indexspc';
-SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and relname='test_index_a' and segid=-1;
+
+SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes 
+FROM diskquota.show_fast_schema_tablespace_quota_view 
+WHERE schema_name='indexschema1' and tablespace_name='indexspc';
+
+SELECT tableid::regclass, size, segid 
+FROM diskquota.table_size 
+WHERE tableid = 'test_index_a'::regclass
+ORDER BY segid;
+
 -- create index for the table, index in default tablespace
 CREATE INDEX a_index ON test_index_a(i);
 INSERT INTO test_index_a SELECT generate_series(1,10000);
@@ -20,7 +29,17 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert success
 INSERT INTO test_index_a SELECT generate_series(1,100);
 SELECT schema_name,tablespace_name,quota_in_mb,nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name ='indexschema1' and tablespace_name='indexspc';
-SELECT size, segid FROM diskquota.table_size , pg_class where tableid=oid and (relname='test_index_a' or relname='a_index') and segid=-1;
+
+SELECT tableid::regclass, size, segid 
+FROM diskquota.table_size 
+WHERE tableid = 'test_index_a'::regclass
+ORDER BY segid;
+
+SELECT tableid::regclass, size, segid 
+FROM diskquota.table_size 
+WHERE tableid = 'a_index'::regclass
+ORDER BY segid;
+
 -- add index to tablespace indexspc
 ALTER index a_index SET TABLESPACE indexspc;
 SELECT diskquota.wait_for_worker_new_epoch();

--- a/tests/regress/sql/test_role.sql
+++ b/tests/regress/sql/test_role.sql
@@ -13,7 +13,7 @@ ALTER TABLE b2 OWNER TO u1;
 SELECT diskquota.set_role_quota('u1', '1 MB');
 
 INSERT INTO b SELECT generate_series(1,100);
--- expect insert fail
+-- expect insert success
 INSERT INTO b SELECT generate_series(1,100000);
 SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert fail
@@ -31,6 +31,18 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert fail
 INSERT INTO b SELECT generate_series(1,100);
 SELECT role_name, quota_in_mb, rolsize_in_bytes FROM diskquota.show_fast_role_quota_view WHERE role_name='u1';
+
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size
+WHERE tableid = 'b'::regclass
+ORDER BY segid;
+
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size
+WHERE tableid = 'b2'::regclass
+ORDER BY segid;
+
+
 ALTER TABLE b OWNER TO u2;
 SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert succeed


### PR DESCRIPTION
This patch adds test cases to ensure that diskquota works when table
is created before quota is set. Specifically,

- When diskquota is preloaded, quota usage is updated automatically
for each active table. Therefore, quotas work once they are set and no
more action is required from the user.
 - When diskquota is NOT preloaded, no active tables will be recorded.
 As a result, when diskquota is preloaded again, the user need to
 SELECT diskquota.init_table_size_table(); and restarts GPDB manually
 in order to update the quota usage.

 This patch also fixes some minor issues in the existing cases.

This is to replace PR #125 .