### PR TITLE
Attempt to fix flaky test_primary_failure

### DIFF
--- a/tests/regress/expected/test_blackmap.out
+++ b/tests/regress/expected/test_blackmap.out
@@ -94,7 +94,7 @@ SELECT rel.relname, be.target_type, (be.target_oid=rel.relowner) AS owner_matche
 (1 row)
 
 -- Create a tablespace to test the rest of blocking types.
-\! mkdir /tmp/blocked_space
+\! mkdir -p /tmp/blocked_space
 CREATE TABLESPACE blocked_space LOCATION '/tmp/blocked_space';
 ALTER TABLE blocked_t1 SET TABLESPACE blocked_space;
 -- Insert an entry for blocked_t1 to blackmap on seg0.
@@ -278,6 +278,5 @@ DROP TABLE blocked_t3;
 DROP TABLE blocked_t4;
 DROP TABLE blocked_t5;
 DROP TABLESPACE blocked_space;
-\! rm -rf /tmp/blocked_space
 SET search_path TO DEFAULT;
 DROP SCHEMA s_blackmap;

--- a/tests/regress/expected/test_ctas_tablespace_role.out
+++ b/tests/regress/expected/test_ctas_tablespace_role.out
@@ -84,7 +84,6 @@ NOTICE:  table "aocs_table" does not exist, skipping
 RESET ROLE;
 RESET default_tablespace;
 DROP TABLESPACE ctas_rolespc;
-\! rm -rf /tmp/ctas_rolespc;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
 SELECT diskquota.disable_hardlimit();

--- a/tests/regress/expected/test_ctas_tablespace_schema.out
+++ b/tests/regress/expected/test_ctas_tablespace_schema.out
@@ -82,7 +82,6 @@ RESET search_path;
 RESET default_tablespace;
 DROP SCHEMA hardlimit_s;
 DROP TABLESPACE ctas_schemaspc;
-\! rm -rf /tmp/ctas_schemaspc;
 SELECT diskquota.disable_hardlimit();
  disable_hardlimit 
 -------------------

--- a/tests/regress/expected/test_index.out
+++ b/tests/regress/expected/test_index.out
@@ -1,6 +1,6 @@
 -- Test schema
 -- start_ignore
-\! mkdir /tmp/indexspc
+\! mkdir -p /tmp/indexspc
 -- end_ignore
 CREATE SCHEMA indexschema1;
 DROP TABLESPACE  IF EXISTS indexspc;
@@ -108,4 +108,3 @@ DROP INDEX indexschema1.a_index;
 DROP TABLE indexschema1.test_index_a;
 DROP SCHEMA indexschema1;
 DROP TABLESPACE indexspc;
-\! rm -rf /tmp/indexspc

--- a/tests/regress/expected/test_mistake.out
+++ b/tests/regress/expected/test_mistake.out
@@ -18,7 +18,7 @@ NOTICE:  resource queue required -- using default resource queue "pg_default"
 select diskquota.set_role_quota('rmistake', '0 MB');
 ERROR:  disk quota can not be set to 0 MB
 -- start_ignore
-\! mkdir /tmp/spcmistake
+\! mkdir -p /tmp/spcmistake
 -- end_ignore
 DROP TABLESPACE  IF EXISTS spcmistake;
 NOTICE:  tablespace "spcmistake" does not exist, skipping
@@ -32,4 +32,3 @@ ERROR:  per segment quota ratio can not be set to 0
 DROP SCHEMA nmistake;
 DROP ROLE rmistake;
 DROP TABLESPACE spcmistake;
-\! rm -rf /tmp/spcmistake

--- a/tests/regress/expected/test_relation_size.out
+++ b/tests/regress/expected/test_relation_size.out
@@ -31,7 +31,7 @@ SELECT pg_table_size('t2');
 (1 row)
 
 -- start_ignore
-\! mkdir /tmp/test_spc
+\! mkdir -p /tmp/test_spc
 -- end_ignore
 DROP TABLESPACE IF EXISTS test_spc;
 NOTICE:  tablespace "test_spc" does not exist, skipping
@@ -66,7 +66,6 @@ SELECT pg_table_size('t2');
 
 DROP TABLE t1, t2;
 DROP TABLESPACE test_spc;
-\! rm -rf /tmp/test_spc
 CREATE TABLE ao (i int) WITH (appendonly=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/tests/regress/expected/test_tablespace_role.out
+++ b/tests/regress/expected/test_tablespace_role.out
@@ -1,6 +1,6 @@
 -- Test role quota
 -- start_ignore
-\! mkdir /tmp/rolespc
+\! mkdir -p /tmp/rolespc
 -- end_ignore
 DROP TABLESPACE  IF EXISTS rolespc;
 NOTICE:  tablespace "rolespc" does not exist, skipping
@@ -83,7 +83,7 @@ INSERT INTO b SELECT generate_series(1,100);
 ERROR:  tablespace:rolespc role:rolespcu1 diskquota exceeded
 -- Test alter tablespace
 -- start_ignore
-\! mkdir /tmp/rolespc2
+\! mkdir -p /tmp/rolespc2
 -- end_ignore
 DROP TABLESPACE  IF EXISTS rolespc2;
 NOTICE:  tablespace "rolespc2" does not exist, skipping
@@ -155,5 +155,3 @@ RESET search_path;
 DROP SCHEMA rolespcrole;
 DROP TABLESPACE rolespc;
 DROP TABLESPACE rolespc2;
-\! rm -rf /tmp/rolespc;
-\! rm -rf /tmp/rolespc2

--- a/tests/regress/expected/test_tablespace_role_perseg.out
+++ b/tests/regress/expected/test_tablespace_role_perseg.out
@@ -1,6 +1,6 @@
 -- Test role quota
 -- start_ignore
-\! mkdir /tmp/rolespc_perseg
+\! mkdir -p /tmp/rolespc_perseg
 -- end_ignore
 DROP TABLESPACE  IF EXISTS rolespc_perseg;
 NOTICE:  tablespace "rolespc_perseg" does not exist, skipping
@@ -96,7 +96,7 @@ INSERT INTO b SELECT generate_series(1,100);
 ERROR:  tablespace:rolespc_perseg role:rolespc_persegu1 diskquota exceeded per segment quota
 -- Test alter tablespace
 -- start_ignore
-\! mkdir /tmp/rolespc_perseg2
+\! mkdir -p /tmp/rolespc_perseg2
 -- end_ignore
 DROP TABLESPACE  IF EXISTS rolespc_perseg2;
 NOTICE:  tablespace "rolespc_perseg2" does not exist, skipping
@@ -208,5 +208,3 @@ RESET search_path;
 DROP SCHEMA rolespc_persegrole;
 DROP TABLESPACE rolespc_perseg;
 DROP TABLESPACE rolespc_perseg2;
-\! rm -rf /tmp/rolespc_perseg;
-\! rm -rf /tmp/rolespc_perseg2

--- a/tests/regress/expected/test_tablespace_schema.out
+++ b/tests/regress/expected/test_tablespace_schema.out
@@ -1,6 +1,6 @@
 -- Test schema
 -- start_ignore
-\! mkdir /tmp/schemaspc
+\! mkdir -p /tmp/schemaspc
 -- end_ignore
 CREATE SCHEMA spcs1;
 DROP TABLESPACE  IF EXISTS schemaspc;
@@ -65,7 +65,7 @@ SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FR
 
 -- Test alter tablespace
 -- start_ignore
-\! mkdir /tmp/schemaspc2
+\! mkdir -p /tmp/schemaspc2
 -- end_ignore
 DROP TABLESPACE  IF EXISTS schemaspc2;
 NOTICE:  tablespace "schemaspc2" does not exist, skipping
@@ -135,5 +135,3 @@ DROP TABLE spcs1.a2, spcs1.a;
 DROP SCHEMA spcs1, spcs2;
 DROP TABLESPACE schemaspc;
 DROP TABLESPACE schemaspc2;
-\! rm -rf /tmp/schemaspc
-\! rm -rf /tmp/schemaspc2

--- a/tests/regress/expected/test_tablespace_schema_perseg.out
+++ b/tests/regress/expected/test_tablespace_schema_perseg.out
@@ -1,6 +1,6 @@
 -- Test schema
 -- start_ignore
-\! mkdir /tmp/schemaspc_perseg
+\! mkdir -p /tmp/schemaspc_perseg
 -- end_ignore
 -- Test tablespace quota perseg
 CREATE SCHEMA spcs1_perseg;
@@ -94,7 +94,7 @@ SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FR
 
 -- Test alter tablespace
 -- start_ignore
-\! mkdir /tmp/schemaspc_perseg2
+\! mkdir -p /tmp/schemaspc_perseg2
 -- end_ignore
 DROP TABLESPACE  IF EXISTS schemaspc_perseg2;
 NOTICE:  tablespace "schemaspc_perseg2" does not exist, skipping
@@ -209,5 +209,3 @@ DROP TABLE spcs1_perseg.a;
 DROP SCHEMA spcs1_perseg;
 DROP TABLESPACE schemaspc_perseg;
 DROP TABLESPACE schemaspc_perseg2;
-\! rm -rf /tmp/schemaspc_perseg
-\! rm -rf /tmp/schemaspc_perseg2

--- a/tests/regress/sql/test_blackmap.sql
+++ b/tests/regress/sql/test_blackmap.sql
@@ -81,7 +81,7 @@ SELECT rel.relname, be.target_type, (be.target_oid=rel.relowner) AS owner_matche
   WHERE rel.relfilenode=be.relnode AND be.relnode<>0 AND rel.gp_segment_id=be.segid;
 
 -- Create a tablespace to test the rest of blocking types.
-\! mkdir /tmp/blocked_space
+\! mkdir -p /tmp/blocked_space
 CREATE TABLESPACE blocked_space LOCATION '/tmp/blocked_space';
 ALTER TABLE blocked_t1 SET TABLESPACE blocked_space;
 
@@ -191,6 +191,5 @@ DROP TABLE blocked_t3;
 DROP TABLE blocked_t4;
 DROP TABLE blocked_t5;
 DROP TABLESPACE blocked_space;
-\! rm -rf /tmp/blocked_space
 SET search_path TO DEFAULT;
 DROP SCHEMA s_blackmap;

--- a/tests/regress/sql/test_ctas_tablespace_role.sql
+++ b/tests/regress/sql/test_ctas_tablespace_role.sql
@@ -41,7 +41,6 @@ DROP TABLE IF EXISTS aocs_table;
 RESET ROLE;
 RESET default_tablespace;
 DROP TABLESPACE ctas_rolespc;
-\! rm -rf /tmp/ctas_rolespc;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
 SELECT diskquota.disable_hardlimit();

--- a/tests/regress/sql/test_ctas_tablespace_schema.sql
+++ b/tests/regress/sql/test_ctas_tablespace_schema.sql
@@ -41,5 +41,4 @@ RESET search_path;
 RESET default_tablespace;
 DROP SCHEMA hardlimit_s;
 DROP TABLESPACE ctas_schemaspc;
-\! rm -rf /tmp/ctas_schemaspc;
 SELECT diskquota.disable_hardlimit();

--- a/tests/regress/sql/test_index.sql
+++ b/tests/regress/sql/test_index.sql
@@ -1,6 +1,6 @@
 -- Test schema
 -- start_ignore
-\! mkdir /tmp/indexspc
+\! mkdir -p /tmp/indexspc
 -- end_ignore
 CREATE SCHEMA indexschema1;
 DROP TABLESPACE  IF EXISTS indexspc;
@@ -43,4 +43,3 @@ DROP INDEX indexschema1.a_index;
 DROP TABLE indexschema1.test_index_a;
 DROP SCHEMA indexschema1;
 DROP TABLESPACE indexspc;
-\! rm -rf /tmp/indexspc

--- a/tests/regress/sql/test_mistake.sql
+++ b/tests/regress/sql/test_mistake.sql
@@ -11,7 +11,7 @@ CREATE ROLE rmistake;
 select diskquota.set_role_quota('rmistake', '0 MB');
 
 -- start_ignore
-\! mkdir /tmp/spcmistake
+\! mkdir -p /tmp/spcmistake
 -- end_ignore
 DROP TABLESPACE  IF EXISTS spcmistake;
 CREATE TABLESPACE spcmistake LOCATION '/tmp/spcmistake';
@@ -22,4 +22,3 @@ SELECT diskquota.set_per_segment_quota('spcmistake', 0);
 DROP SCHEMA nmistake;
 DROP ROLE rmistake;
 DROP TABLESPACE spcmistake;
-\! rm -rf /tmp/spcmistake

--- a/tests/regress/sql/test_relation_size.sql
+++ b/tests/regress/sql/test_relation_size.sql
@@ -9,7 +9,7 @@ SELECT diskquota.relation_size('t2');
 SELECT pg_table_size('t2');
 
 -- start_ignore
-\! mkdir /tmp/test_spc
+\! mkdir -p /tmp/test_spc
 -- end_ignore
 DROP TABLESPACE IF EXISTS test_spc;
 CREATE TABLESPACE test_spc LOCATION '/tmp/test_spc';
@@ -26,7 +26,6 @@ SELECT pg_table_size('t2');
 
 DROP TABLE t1, t2;
 DROP TABLESPACE test_spc;
-\! rm -rf /tmp/test_spc
 
 CREATE TABLE ao (i int) WITH (appendonly=true);
 INSERT INTO ao SELECT generate_series(1, 10000);

--- a/tests/regress/sql/test_tablespace_role.sql
+++ b/tests/regress/sql/test_tablespace_role.sql
@@ -1,6 +1,6 @@
 -- Test role quota
 -- start_ignore
-\! mkdir /tmp/rolespc
+\! mkdir -p /tmp/rolespc
 -- end_ignore
 DROP TABLESPACE  IF EXISTS rolespc;
 CREATE TABLESPACE rolespc LOCATION '/tmp/rolespc';
@@ -46,7 +46,7 @@ INSERT INTO b SELECT generate_series(1,100);
 
 -- Test alter tablespace
 -- start_ignore
-\! mkdir /tmp/rolespc2
+\! mkdir -p /tmp/rolespc2
 -- end_ignore
 DROP TABLESPACE  IF EXISTS rolespc2;
 CREATE TABLESPACE rolespc2 LOCATION '/tmp/rolespc2';
@@ -83,5 +83,3 @@ RESET search_path;
 DROP SCHEMA rolespcrole;
 DROP TABLESPACE rolespc;
 DROP TABLESPACE rolespc2;
-\! rm -rf /tmp/rolespc;
-\! rm -rf /tmp/rolespc2

--- a/tests/regress/sql/test_tablespace_role_perseg.sql
+++ b/tests/regress/sql/test_tablespace_role_perseg.sql
@@ -1,6 +1,6 @@
 -- Test role quota
 -- start_ignore
-\! mkdir /tmp/rolespc_perseg
+\! mkdir -p /tmp/rolespc_perseg
 -- end_ignore
 DROP TABLESPACE  IF EXISTS rolespc_perseg;
 CREATE TABLESPACE rolespc_perseg LOCATION '/tmp/rolespc_perseg';
@@ -47,7 +47,7 @@ INSERT INTO b SELECT generate_series(1,100);
 
 -- Test alter tablespace
 -- start_ignore
-\! mkdir /tmp/rolespc_perseg2
+\! mkdir -p /tmp/rolespc_perseg2
 -- end_ignore
 DROP TABLESPACE  IF EXISTS rolespc_perseg2;
 CREATE TABLESPACE rolespc_perseg2 LOCATION '/tmp/rolespc_perseg2';
@@ -95,5 +95,3 @@ RESET search_path;
 DROP SCHEMA rolespc_persegrole;
 DROP TABLESPACE rolespc_perseg;
 DROP TABLESPACE rolespc_perseg2;
-\! rm -rf /tmp/rolespc_perseg;
-\! rm -rf /tmp/rolespc_perseg2

--- a/tests/regress/sql/test_tablespace_schema.sql
+++ b/tests/regress/sql/test_tablespace_schema.sql
@@ -1,6 +1,6 @@
 -- Test schema
 -- start_ignore
-\! mkdir /tmp/schemaspc
+\! mkdir -p /tmp/schemaspc
 -- end_ignore
 CREATE SCHEMA spcs1;
 DROP TABLESPACE  IF EXISTS schemaspc;
@@ -36,7 +36,7 @@ SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FR
 
 -- Test alter tablespace
 -- start_ignore
-\! mkdir /tmp/schemaspc2
+\! mkdir -p /tmp/schemaspc2
 -- end_ignore
 DROP TABLESPACE  IF EXISTS schemaspc2;
 CREATE TABLESPACE schemaspc2 LOCATION '/tmp/schemaspc2';
@@ -71,6 +71,4 @@ DROP TABLE spcs1.a2, spcs1.a;
 DROP SCHEMA spcs1, spcs2;
 DROP TABLESPACE schemaspc;
 DROP TABLESPACE schemaspc2;
-\! rm -rf /tmp/schemaspc
-\! rm -rf /tmp/schemaspc2
 

--- a/tests/regress/sql/test_tablespace_schema_perseg.sql
+++ b/tests/regress/sql/test_tablespace_schema_perseg.sql
@@ -1,6 +1,6 @@
 -- Test schema
 -- start_ignore
-\! mkdir /tmp/schemaspc_perseg
+\! mkdir -p /tmp/schemaspc_perseg
 -- end_ignore
 -- Test tablespace quota perseg
 CREATE SCHEMA spcs1_perseg;
@@ -42,7 +42,7 @@ SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FR
 
 -- Test alter tablespace
 -- start_ignore
-\! mkdir /tmp/schemaspc_perseg2
+\! mkdir -p /tmp/schemaspc_perseg2
 -- end_ignore
 DROP TABLESPACE  IF EXISTS schemaspc_perseg2;
 CREATE TABLESPACE schemaspc_perseg2 LOCATION '/tmp/schemaspc_perseg2';
@@ -88,6 +88,4 @@ DROP TABLE spcs1_perseg.a;
 DROP SCHEMA spcs1_perseg;
 DROP TABLESPACE schemaspc_perseg;
 DROP TABLESPACE schemaspc_perseg2;
-\! rm -rf /tmp/schemaspc_perseg
-\! rm -rf /tmp/schemaspc_perseg2
 


### PR DESCRIPTION
Test case test_primary_failure will stop/start segment to produce a
mirror switch. But the segment start could fail while replaying xlog.
The failure was caused by the deleted tablespace directories in previous
test cases.

This commit removes the "rm" statement in those tablespace test cases and
add "-p" to the "mkdir" command line. The corresponding sub-directories
will be deleted by "DROP TABLESPACE" if the case passes.

Relevant logs:
```
2022-02-08 10:09:30.458183 CST,,,p1182584,th1235613568,,,,0,,,seg1,,,,,"LOG","00000","entering standby mode",,,,,,,0,,"xlog.c",6537,
2022-02-08 10:09:30.458670 CST,,,p1182584,th1235613568,,,,0,,,seg1,,,,,"LOG","00000","redo starts at E/24638A28",,,,,,,0,,"xlog.c",7153,
2022-02-08 10:09:30.468323 CST,"cc","postgres",p1182588,th1235613568,"[local]",,2022-02-08 10:09:30 CST,0,,,seg1,,,,,"FATAL","57P03","the database system is starting up"
,"last replayed record at E/2481EA70",,,,,,0,,"postmaster.c",2552,
2022-02-08 10:09:30.484792 CST,,,p1182584,th1235613568,,,,0,,,seg1,,,,,"FATAL","58P01","directory ""/tmp/test_spc"" does not exist",,"Create this directory for the table
space before restarting the server.",,,"xlog redo create tablespace: 2590660 ""/tmp/test_spc""",,0,,"tablespace.c",749,
```
