### PR TITLE
Allow nonsuperuser roles to manange disk qouta

### DIFF
--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -339,11 +339,13 @@ dispatch_pause_or_resume_command(Oid dbid, bool pause_extension)
 Datum
 diskquota_pause(PG_FUNCTION_ARGS)
 {
-	if (!superuser())
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to pause diskquota")));
+				 errmsg("must be superuser or diskquota_admin to pause diskquota")));
 	}
 
 	Oid dbid = MyDatabaseId;
@@ -383,11 +385,13 @@ diskquota_pause(PG_FUNCTION_ARGS)
 Datum
 diskquota_resume(PG_FUNCTION_ARGS)
 {
-	if (!superuser())
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to resume diskquota")));
+				 errmsg("must be superuser or diskquota_admin to resume diskquota")));
 	}
 
 	Oid dbid = MyDatabaseId;
@@ -596,11 +600,13 @@ set_role_quota(PG_FUNCTION_ARGS)
 	char	   *sizestr;
 	int64		quota_limit_mb;
 
-	if (!superuser())
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to set disk quota limit")));
+				 errmsg("must be superuser or diskquota_admin to set disk quota limit")));
 	}
 
 	rolname = text_to_cstring(PG_GETARG_TEXT_PP(0));
@@ -632,11 +638,13 @@ set_schema_quota(PG_FUNCTION_ARGS)
 	char	   *sizestr;
 	int64		quota_limit_mb;
 
-	if (!superuser())
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to set disk quota limit")));
+				 errmsg("must be superuser or diskquota_admin to set disk quota limit")));
 	}
 
 	nspname = text_to_cstring(PG_GETARG_TEXT_PP(0));
@@ -674,11 +682,13 @@ set_role_tablespace_quota(PG_FUNCTION_ARGS)
 	char   	*sizestr;
 	int64	quota_limit_mb;
 	
-	if (!superuser())
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to set disk quota limit")));
+				 errmsg("must be superuser or diskquota_admin to set disk quota limit")));
 	}
 
 	rolname = text_to_cstring(PG_GETARG_TEXT_PP(0));
@@ -722,11 +732,13 @@ set_schema_tablespace_quota(PG_FUNCTION_ARGS)
 	char   	*sizestr;
 	int64	quota_limit_mb;
 	
-	if (!superuser())
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to set disk quota limit")));
+				 errmsg("must be superuser or diskquota_admin to set disk quota limit")));
 	}
 
 	nspname = text_to_cstring(PG_GETARG_TEXT_PP(0));
@@ -1021,11 +1033,13 @@ update_diskquota_db_list(PG_FUNCTION_ARGS)
 	int	mode = PG_GETARG_INT32(1);
 	bool	found = false;
 
-	if (!superuser())
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to update db list")));
+				 errmsg("must be superuser or diskquota_admin to update db list")));
 	}
 
 	/* add/remove the dbid to monitoring database cache to filter out table not under
@@ -1069,11 +1083,15 @@ set_per_segment_quota(PG_FUNCTION_ARGS)
 	Oid		spcoid;
 	char	   	*spcname;
 	float4		ratio;
-	if (!superuser())
+	
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to set disk quota limit")));
+				 errmsg("must be superuser or diskquota_admin to set disk quota limit")));
 	}
 
 	spcname = text_to_cstring(PG_GETARG_TEXT_PP(0));

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1723,8 +1723,10 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 	HTAB				   *local_blackmap;
 	HASHCTL					hashctl;
 
-	if (!superuser())
-		errmsg("must be superuser to update blackmap");
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
+		errmsg("must be superuser or diskquota_admin to update blockmap");
 
 	if (ARR_NDIM(blackmap_array_type) > 1 || ARR_NDIM(active_oid_array_type) > 1)
 		ereport(ERROR, (errcode(ERRCODE_ARRAY_SUBSCRIPT_ERROR), errmsg("1-dimensional array needed")));
@@ -2175,10 +2177,12 @@ PG_FUNCTION_INFO_V1(diskquota_enable_hardlimit);
 Datum
 diskquota_enable_hardlimit(PG_FUNCTION_ARGS)
 {
-	if (!superuser())
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to enable hardlimit")));
+				 errmsg("must be superuser or diskquota_admin to enable hardlimit")));
 
 	/*
 	 * If this UDF is executed on segment servers, we should clear
@@ -2208,10 +2212,12 @@ PG_FUNCTION_INFO_V1(diskquota_disable_hardlimit);
 Datum
 diskquota_disable_hardlimit(PG_FUNCTION_ARGS)
 {
-	if (!superuser())
+	Oid role;
+	role = get_role_oid("diskquota_admin", true);
+	if (!superuser() && !is_member_of_role(GetUserId(), role))
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to disable hardlimit")));
+				 errmsg("must be superuser or diskquota_admin to disable hardlimit")));
 
 	pg_atomic_write_u32(diskquota_hardlimit, false);
 


### PR DESCRIPTION
The purpose of these patches is to allow non-superuser roles to managed  disk qouta in greeplum cluster. This is helpfully for cloud providers which can serve managed greenplum solution. This is undesirable to grant superuser to some customer roles, because superusers are able to perform almost anything on cluster VMs. The solution in to create some 'special' role (diskquota_admin) with needed permission and grant it to customer-side role

