### PR TITLE
ci: compile 2.X binary on fly when doing upgrade test

### DIFF
--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -8,16 +8,16 @@ groups:
     - diskquota_centos6_build_test
     - diskquota_centos7_build_test
     - diskquota_ubuntu18_build_test
-    - diskquota_centos7_extension_upgrade_1.0_2.0
+    - diskquota_gpdb6_centos7_upgrade_1.0_to_2.0
 - name: GPDB6
   jobs:
     - diskquota_centos6_build_test
     - diskquota_centos7_build_test
     - diskquota_rhel8_build_test
     - diskquota_ubuntu18_build_test
-- name: GPDB6_UPGRADE
+- name: UPGRADE
   jobs:
-    - diskquota_centos7_extension_upgrade_1.0_2.0
+    - diskquota_gpdb6_centos7_upgrade_1.0_to_2.0
 
 resource_types:
 - name: gcs
@@ -69,19 +69,12 @@ resources:
     repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test
     tag: latest
 
-- name: bin_diskquota_centos7_1.0
+- name: released_bin_diskquota_centos7_1.X
   type: gcs
   source:
     bucket: {{gcs-bucket}}
     json_key: {{concourse-gcs-resources-service-account-key}}
     regexp: diskquota/released/gpdb6/diskquota-(1.*)-rhel7_x86_64.tar.gz
-
-- name: bin_diskquota_centos7
-  type: gcs
-  source:
-    bucket: {{gcs-bucket-dev}}
-    json_key: {{concourse-gcs-resources-service-account-key}}
-    versioned_file: diskquota/intermediates/gpdb6/diskquota-master-rhel7_x86_64.tar.gz
 
 # Github Source Codes
 
@@ -150,10 +143,6 @@ jobs:
       bin_diskquota: diskquota_artifacts
     params:
       DISKQUOTA_OS: rhel7
-  - aggregate:
-    - put: bin_diskquota_centos7
-      params:
-        file: diskquota_artifacts/diskquota*.tar.gz
 
 - name: diskquota_rhel8_build_test
   max_in_flight: 3
@@ -226,25 +215,26 @@ jobs:
     params:
       DISKQUOTA_OS: ubuntu18.04
 
-- name: diskquota_centos7_extension_upgrade_1.0_2.0
+- name: diskquota_gpdb6_centos7_upgrade_1.0_to_2.0
   max_in_flight: 3
   plan:
   - aggregate:
+    - get: gpdb_src
     - get: centos-gpdb-dev-7
-    - get: bin_diskquota_old
-      resource: bin_diskquota_centos7_1.0
-    - get: bin_diskquota_centos7
-      trigger: true
+    - get: bin_diskquota_1X
+      resource: released_bin_diskquota_centos7_1.X
     - get: bin_gpdb
       resource: bin_gpdb_centos7
-    - get: gpdb_src
     - get: diskquota_src
-  - task: upgrade_extension
-    file: diskquota_src/concourse/tasks/upgrade_extension.yml
-    input_mapping:
-      bin_diskquota_new: bin_diskquota_centos7
+      trigger: true
+  - task: build_diskquota
+    file: diskquota_src/concourse/tasks/build_diskquota.yml
     image: centos-gpdb-dev-7
     params:
       DISKQUOTA_OS: rhel7
-      OLD_VERSION: "1.0"
-      NEW_VERSION: "2.0"
+  - task: test_upgrade
+    file: diskquota_src/concourse/tasks/upgrade_extension.yml
+    image: centos-gpdb-dev-7
+    input_mapping:
+      bin_diskquota_1X: bin_diskquota_1X
+      bin_diskquota_2X: diskquota_artifacts

--- a/concourse/scripts/upgrade_extension.sh
+++ b/concourse/scripts/upgrade_extension.sh
@@ -5,19 +5,18 @@ set -exo pipefail
 CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_DIR=${CWDIR}/../../../
 GPDB_CONCOURSE_DIR=${TOP_DIR}/gpdb_src/concourse/scripts
-CUT_NUMBER=6
 
 source "${GPDB_CONCOURSE_DIR}/common.bash"
 source "${TOP_DIR}/diskquota_src/concourse/scripts/test_common.sh"
 
 # those two functions are called by upgrade_test
 function install_old_version_diskquota() {
-	tar -xzf ../../bin_diskquota_old/*.tar.gz -C /usr/local/greenplum-db-devel
+	tar -xzf ../../bin_diskquota_1X/*.tar.gz -C /usr/local/greenplum-db-devel
 }
 
 function install_new_version_diskquota() {
 	# the current dir is upgrade_test
-	tar -xzf ../../bin_diskquota_new/*.tar.gz -C /usr/local/greenplum-db-devel
+	tar -xzf ../../bin_diskquota_2X/*.tar.gz -C /usr/local/greenplum-db-devel
 }
 
 function _main() {
@@ -25,15 +24,15 @@ function _main() {
 	time setup_gpadmin_user
 
 	time make_cluster
-	if [ "${DISKQUOTA_OS}" == "ubuntu18.04" ]; then
-		CUT_NUMBER=6
-	fi
+
 	# firstly install an old version diskquota to start diskquota
-	tar -xzf bin_diskquota_old/*.tar.gz -C /usr/local/greenplum-db-devel
+	tar -xzf bin_diskquota_1X/*.tar.gz -C /usr/local/greenplum-db-devel
+
 	# export install_old_version_diskquota install_new_version_diskquota function, becuase they will be called by upgrade_test
 	export -f install_old_version_diskquota
 	export -f install_new_version_diskquota
-	time test  ${TOP_DIR}/diskquota_src/upgrade_test false
+
+	time test ${TOP_DIR}/diskquota_src/upgrade_test false
 }
 
 _main "$@"

--- a/concourse/tasks/upgrade_extension.yml
+++ b/concourse/tasks/upgrade_extension.yml
@@ -3,14 +3,10 @@ image_resource:
   type: docker-image
 inputs:
   - name: bin_gpdb
-  - name: bin_diskquota_old
-  - name: bin_diskquota_new
   - name: gpdb_src
   - name: diskquota_src
+  - name: bin_diskquota_1X
+  - name: bin_diskquota_2X
 
 run:
   path: diskquota_src/concourse/scripts/upgrade_extension.sh
-params:
-  DISKQUOTA_OS:
-  OLD_VERSION:
-  NEW_VERSION:

--- a/upgrade_test/diskquota_schedule_downgrade
+++ b/upgrade_test/diskquota_schedule_downgrade
@@ -4,7 +4,7 @@ test: init
 test: prepare
 test: set_config
 # execute downgrade scripts
-test: downgrade_extension
+test: downgrade_extension_to_1X
 test: test_role test_schema test_reschema test_temp_role test_rename test_delete_quota
 test: clean
 
@@ -15,7 +15,7 @@ test: install_new_version
 test: init
 test: prepare
 test: set_config
-test: downgrade_extension
+test: downgrade_extension_to_1X
 # downgrade diskquota to old version
 test: install_old_version
 # run by old version diskquota

--- a/upgrade_test/diskquota_schedule_upgrade
+++ b/upgrade_test/diskquota_schedule_upgrade
@@ -16,7 +16,7 @@ test: prepare
 test: set_config
 # upgrade diskquota to new version
 test: install_new_version
-test: upgrade_extension
+test: upgrade_extension_to_2X
 # run by new version diskquota
 test: test_role test_schema test_reschema test_temp_role test_rename test_delete_quota test_tablespace_schema test_tablespace_role test_tablespace_schema_perseg test_tablespace_role_perseg
 test: clean

--- a/upgrade_test/expected/downgrade_extension.out
+++ b/upgrade_test/expected/downgrade_extension.out
@@ -1,2 +1,0 @@
-\set old_version `echo $OLD_VERSION`
-alter extension diskquota update to :'old_version';

--- a/upgrade_test/expected/downgrade_extension_to_1X.out
+++ b/upgrade_test/expected/downgrade_extension_to_1X.out
@@ -1,0 +1,1 @@
+alter extension diskquota update to '1.0';

--- a/upgrade_test/expected/upgrade_extension.out
+++ b/upgrade_test/expected/upgrade_extension.out
@@ -1,2 +1,0 @@
-\set new_version `echo $NEW_VERSION`
-alter extension diskquota update to :'new_version';

--- a/upgrade_test/expected/upgrade_extension_to_2X.out
+++ b/upgrade_test/expected/upgrade_extension_to_2X.out
@@ -1,0 +1,1 @@
+alter extension diskquota update to '2.0';

--- a/upgrade_test/sql/downgrade_extension.sql
+++ b/upgrade_test/sql/downgrade_extension.sql
@@ -1,2 +1,0 @@
-\set old_version `echo $OLD_VERSION`
-alter extension diskquota update to :'old_version';

--- a/upgrade_test/sql/downgrade_extension_to_1X.sql
+++ b/upgrade_test/sql/downgrade_extension_to_1X.sql
@@ -1,0 +1,1 @@
+alter extension diskquota update to '1.0';

--- a/upgrade_test/sql/upgrade_extension.sql
+++ b/upgrade_test/sql/upgrade_extension.sql
@@ -1,2 +1,0 @@
-\set new_version `echo $NEW_VERSION`
-alter extension diskquota update to :'new_version';

--- a/upgrade_test/sql/upgrade_extension_to_2X.sql
+++ b/upgrade_test/sql/upgrade_extension_to_2X.sql
@@ -1,0 +1,1 @@
+alter extension diskquota update to '2.0';


### PR DESCRIPTION
the old process:
  - push to `gpdb` branch
  - run `diskquota_centos7_build_test`, after finished
  - upload `diskquota_centos7` to gcp
  - use gcp as trigger, run upgrade test

the new process:
  - push to `gpdb` branch
  - trigger upgrade test
  - build diskquota 2.X, download diskquota 1.X
  - run upgrade test