### PR TITLE
Use guc for hardlimit

### DIFF
--- a/diskquota--1.0--2.0.sql
+++ b/diskquota--1.0--2.0.sql
@@ -32,16 +32,6 @@ RETURNS void STRICT
 AS 'MODULE_PATHNAME', 'diskquota_resume'
 LANGUAGE C;
 
-CREATE OR REPLACE FUNCTION diskquota.enable_hardlimit()
-RETURNS void STRICT
-AS 'MODULE_PATHNAME', 'diskquota_enable_hardlimit'
-LANGUAGE C;
-
-CREATE OR REPLACE FUNCTION diskquota.disable_hardlimit()
-RETURNS void STRICT
-AS 'MODULE_PATHNAME', 'diskquota_disable_hardlimit'
-LANGUAGE C;
-
 CREATE TYPE diskquota.blackmap_entry AS
   (target_oid oid, database_oid oid, tablespace_oid oid, target_type integer, seg_exceeded boolean);
 CREATE FUNCTION diskquota.refresh_blackmap(diskquota.blackmap_entry[], oid[])

--- a/diskquota--2.0--1.0.sql
+++ b/diskquota--2.0--1.0.sql
@@ -8,10 +8,6 @@ DROP FUNCTION IF EXISTS diskquota.pause();
 
 DROP FUNCTION IF EXISTS diskquota.resume();
 
-DROP FUNCTION IF EXISTS diskquota.disable_hardlimit();
-
-DROP FUNCTION IF EXISTS diskquota.enable_hardlimit();
-
 DROP FUNCTION IF EXISTS diskquota.refresh_blackmap(diskquota.blackmap_entry[], oid[]);
 
 DROP FUNCTION IF EXISTS diskquota.status();

--- a/diskquota--2.0.sql
+++ b/diskquota--2.0.sql
@@ -93,16 +93,6 @@ RETURNS void STRICT
 AS 'MODULE_PATHNAME', 'diskquota_resume'
 LANGUAGE C;
 
-CREATE OR REPLACE FUNCTION diskquota.enable_hardlimit()
-RETURNS void STRICT
-AS 'MODULE_PATHNAME', 'diskquota_enable_hardlimit'
-LANGUAGE C;
-
-CREATE OR REPLACE FUNCTION diskquota.disable_hardlimit()
-RETURNS void STRICT
-AS 'MODULE_PATHNAME', 'diskquota_disable_hardlimit'
-LANGUAGE C;
-
 CREATE VIEW diskquota.show_fast_schema_quota_view AS
 select pgns.nspname as schema_name, pgc.relnamespace as schema_oid, qc.quotalimitMB as quota_in_mb, sum(ts.size) as nspsize_in_bytes
 from diskquota.table_size as ts,

--- a/diskquota.c
+++ b/diskquota.c
@@ -50,6 +50,7 @@ static volatile sig_atomic_t got_sigusr1 = false;
 int			diskquota_naptime = 0;
 int			diskquota_max_active_tables = 0;
 int	        diskquota_worker_timeout = 60; /* default timeout is 60 seconds */
+bool		diskquota_hardlimit = false;
 
 DiskQuotaLocks diskquota_locks;
 ExtensionDDLMessage *extension_ddl_message = NULL;
@@ -229,7 +230,7 @@ define_guc_variables(void)
 							NULL);
 
 	DefineCustomIntVariable("diskquota.max_active_tables",
-							"max number of active tables monitored by disk-quota",
+							"Max number of active tables monitored by disk-quota.",
 							NULL,
 							&diskquota_max_active_tables,
 							1 * 1024 * 1024,
@@ -248,6 +249,16 @@ define_guc_variables(void)
 							60,
 							1,
 							INT_MAX,
+							PGC_SIGHUP,
+							0,
+							NULL,
+							NULL,
+							NULL);
+	DefineCustomBoolVariable("diskquota.hard_limit",
+							"Set this to 'true' to enable disk-quota hardlimit.",
+							NULL,
+							&diskquota_hardlimit,
+							false,
 							PGC_SIGHUP,
 							0,
 							NULL,
@@ -1130,7 +1141,7 @@ static const char* diskquota_status_check_hard_limit()
 	// should run on coordinator only.
 	Assert(IS_QUERY_DISPATCHER());
 
-	bool hardlimit = pg_atomic_read_u32(diskquota_hardlimit);
+	bool hardlimit = diskquota_hardlimit;
 
 	bool found, paused;
 	LWLockAcquire(diskquota_locks.worker_map_lock, LW_SHARED);

--- a/diskquota.c
+++ b/diskquota.c
@@ -255,7 +255,7 @@ define_guc_variables(void)
 							NULL,
 							NULL);
 	DefineCustomBoolVariable("diskquota.hard_limit",
-							"Set this to 'on' to enable disk-quota hardlimit.",
+							"Set this to 'true' to enable disk-quota hardlimit.",
 							NULL,
 							&diskquota_hardlimit,
 							false,

--- a/diskquota.c
+++ b/diskquota.c
@@ -255,7 +255,7 @@ define_guc_variables(void)
 							NULL,
 							NULL);
 	DefineCustomBoolVariable("diskquota.hard_limit",
-							"Set this to 'true' to enable disk-quota hardlimit.",
+							"Set this to 'on' to enable disk-quota hardlimit.",
 							NULL,
 							&diskquota_hardlimit,
 							false,

--- a/diskquota.h
+++ b/diskquota.h
@@ -106,7 +106,6 @@ typedef enum MessageResult MessageResult;
 
 extern DiskQuotaLocks diskquota_locks;
 extern ExtensionDDLMessage *extension_ddl_message;
-extern pg_atomic_uint32 *diskquota_hardlimit;
 
 typedef struct DiskQuotaWorkerEntry DiskQuotaWorkerEntry;
 
@@ -142,6 +141,7 @@ extern void init_disk_quota_hook(void);
 extern Datum diskquota_fetch_table_stat(PG_FUNCTION_ARGS);
 extern int	diskquota_naptime;
 extern int	diskquota_max_active_tables;
+extern bool	diskquota_hardlimit;
 
 extern int 	SEGCOUNT;
 extern int  get_ext_major_version(void);

--- a/tests/regress/expected/config.out
+++ b/tests/regress/expected/config.out
@@ -18,3 +18,9 @@ SHOW diskquota.worker_timeout;
  60
 (1 row)
 
+SHOW diskquota.hard_limit;
+ diskquota.hard_limit 
+----------------------
+ off
+(1 row)
+

--- a/tests/regress/expected/test_ctas_pause.out
+++ b/tests/regress/expected/test_ctas_pause.out
@@ -1,11 +1,7 @@
 CREATE SCHEMA hardlimit_s;
 SET search_path TO hardlimit_s;
-SELECT diskquota.enable_hardlimit();
- enable_hardlimit 
-------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
  set_schema_quota 
 ------------------
@@ -33,12 +29,8 @@ CREATE TABLE t1 AS SELECT generate_series(1,1000000); -- expect succeed
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- disable hardlimit and do some clean-ups.
-SELECT diskquota.disable_hardlimit();
- disable_hardlimit 
--------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 SELECT diskquota.resume();
  resume 
 --------

--- a/tests/regress/expected/test_ctas_pause.out
+++ b/tests/regress/expected/test_ctas_pause.out
@@ -1,6 +1,6 @@
 CREATE SCHEMA hardlimit_s;
 SET search_path TO hardlimit_s;
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
  set_schema_quota 

--- a/tests/regress/expected/test_ctas_pause.out
+++ b/tests/regress/expected/test_ctas_pause.out
@@ -1,6 +1,6 @@
 CREATE SCHEMA hardlimit_s;
 SET search_path TO hardlimit_s;
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
  set_schema_quota 
@@ -29,7 +29,7 @@ CREATE TABLE t1 AS SELECT generate_series(1,1000000); -- expect succeed
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- disable hardlimit and do some clean-ups.
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.resume();
  resume 

--- a/tests/regress/expected/test_ctas_pause.out
+++ b/tests/regress/expected/test_ctas_pause.out
@@ -1,6 +1,6 @@
 CREATE SCHEMA hardlimit_s;
 SET search_path TO hardlimit_s;
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
  set_schema_quota 

--- a/tests/regress/expected/test_ctas_role.out
+++ b/tests/regress/expected/test_ctas_role.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 CREATE ROLE hardlimit_r;
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/tests/regress/expected/test_ctas_role.out
+++ b/tests/regress/expected/test_ctas_role.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 CREATE ROLE hardlimit_r;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
@@ -81,5 +81,5 @@ NOTICE:  table "aocs_table" does not exist, skipping
 RESET ROLE;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null

--- a/tests/regress/expected/test_ctas_role.out
+++ b/tests/regress/expected/test_ctas_role.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 CREATE ROLE hardlimit_r;
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/tests/regress/expected/test_ctas_role.out
+++ b/tests/regress/expected/test_ctas_role.out
@@ -1,10 +1,6 @@
 -- Test that diskquota is able to cancel a running CTAS query by the role quota.
-SELECT diskquota.enable_hardlimit();
- enable_hardlimit 
-------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 CREATE ROLE hardlimit_r;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT diskquota.set_role_quota('hardlimit_r', '1MB');
@@ -85,9 +81,5 @@ NOTICE:  table "aocs_table" does not exist, skipping
 RESET ROLE;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
-SELECT diskquota.disable_hardlimit();
- disable_hardlimit 
--------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null

--- a/tests/regress/expected/test_ctas_schema.out
+++ b/tests/regress/expected/test_ctas_schema.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 CREATE SCHEMA hardlimit_s;
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');

--- a/tests/regress/expected/test_ctas_schema.out
+++ b/tests/regress/expected/test_ctas_schema.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 CREATE SCHEMA hardlimit_s;
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');

--- a/tests/regress/expected/test_ctas_schema.out
+++ b/tests/regress/expected/test_ctas_schema.out
@@ -1,10 +1,6 @@
 -- Test that diskquota is able to cancel a running CTAS query by the schema quota.
-SELECT diskquota.enable_hardlimit();
- enable_hardlimit 
-------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 CREATE SCHEMA hardlimit_s;
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
  set_schema_quota 
@@ -60,12 +56,8 @@ SELECT diskquota.wait_for_worker_new_epoch();
 (1 row)
 
 -- disable hardlimit and do some clean-ups.
-SELECT diskquota.disable_hardlimit();
- disable_hardlimit 
--------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 DROP TABLE IF EXISTS t1;
 NOTICE:  table "t1" does not exist, skipping
 DROP TABLE IF EXISTS toast_table;

--- a/tests/regress/expected/test_ctas_schema.out
+++ b/tests/regress/expected/test_ctas_schema.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 CREATE SCHEMA hardlimit_s;
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
@@ -56,7 +56,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 (1 row)
 
 -- disable hardlimit and do some clean-ups.
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 DROP TABLE IF EXISTS t1;
 NOTICE:  table "t1" does not exist, skipping

--- a/tests/regress/expected/test_ctas_tablespace_role.out
+++ b/tests/regress/expected/test_ctas_tablespace_role.out
@@ -1,10 +1,6 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace role quota.
-SELECT diskquota.enable_hardlimit();
- enable_hardlimit 
-------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_rolespc
 -- end_ignore
@@ -86,9 +82,5 @@ RESET default_tablespace;
 DROP TABLESPACE ctas_rolespc;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
-SELECT diskquota.disable_hardlimit();
- disable_hardlimit 
--------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null

--- a/tests/regress/expected/test_ctas_tablespace_role.out
+++ b/tests/regress/expected/test_ctas_tablespace_role.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_rolespc

--- a/tests/regress/expected/test_ctas_tablespace_role.out
+++ b/tests/regress/expected/test_ctas_tablespace_role.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_rolespc

--- a/tests/regress/expected/test_ctas_tablespace_role.out
+++ b/tests/regress/expected/test_ctas_tablespace_role.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_rolespc
@@ -82,5 +82,5 @@ RESET default_tablespace;
 DROP TABLESPACE ctas_rolespc;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null

--- a/tests/regress/expected/test_ctas_tablespace_schema.out
+++ b/tests/regress/expected/test_ctas_tablespace_schema.out
@@ -1,10 +1,6 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace schema quota.
-SELECT diskquota.enable_hardlimit();
- enable_hardlimit 
-------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_schemaspc
 -- end_ignore
@@ -82,9 +78,5 @@ RESET search_path;
 RESET default_tablespace;
 DROP SCHEMA hardlimit_s;
 DROP TABLESPACE ctas_schemaspc;
-SELECT diskquota.disable_hardlimit();
- disable_hardlimit 
--------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null

--- a/tests/regress/expected/test_ctas_tablespace_schema.out
+++ b/tests/regress/expected/test_ctas_tablespace_schema.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_schemaspc

--- a/tests/regress/expected/test_ctas_tablespace_schema.out
+++ b/tests/regress/expected/test_ctas_tablespace_schema.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_schemaspc
@@ -78,5 +78,5 @@ RESET search_path;
 RESET default_tablespace;
 DROP SCHEMA hardlimit_s;
 DROP TABLESPACE ctas_schemaspc;
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null

--- a/tests/regress/expected/test_ctas_tablespace_schema.out
+++ b/tests/regress/expected/test_ctas_tablespace_schema.out
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_schemaspc

--- a/tests/regress/expected/test_drop_after_pause.out
+++ b/tests/regress/expected/test_drop_after_pause.out
@@ -27,7 +27,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t
 (1 row)
 
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);

--- a/tests/regress/expected/test_drop_after_pause.out
+++ b/tests/regress/expected/test_drop_after_pause.out
@@ -27,12 +27,8 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t
 (1 row)
 
-SELECT diskquota.enable_hardlimit();
- enable_hardlimit 
-------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
@@ -51,12 +47,8 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 INSERT INTO SX.a SELECT generate_series(1,1000000); -- expect insert fail
 ERROR:  schema's disk space quota exceeded with name:16933  (seg2 127.0.0.1:6004 pid=24622)
-SELECT diskquota.disable_hardlimit();
- disable_hardlimit 
--------------------
- 
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 SELECT diskquota.pause();
  pause 
 -------

--- a/tests/regress/expected/test_drop_after_pause.out
+++ b/tests/regress/expected/test_drop_after_pause.out
@@ -27,7 +27,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t
 (1 row)
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -47,7 +47,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 INSERT INTO SX.a SELECT generate_series(1,1000000); -- expect insert fail
 ERROR:  schema's disk space quota exceeded with name:16933  (seg2 127.0.0.1:6004 pid=24622)
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.pause();
  pause 

--- a/tests/regress/expected/test_drop_after_pause.out
+++ b/tests/regress/expected/test_drop_after_pause.out
@@ -27,7 +27,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t
 (1 row)
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);

--- a/tests/regress/expected/test_show_status.out
+++ b/tests/regress/expected/test_show_status.out
@@ -5,7 +5,7 @@ select * from diskquota.status();
  hard limits | disabled
 (2 rows)
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
     name     | status  
@@ -34,7 +34,7 @@ select * from diskquota.status();
  hard limits | disabled
 (2 rows)
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
     name     | status 

--- a/tests/regress/expected/test_show_status.out
+++ b/tests/regress/expected/test_show_status.out
@@ -5,10 +5,8 @@ select * from diskquota.status();
  hard limits | disabled
 (2 rows)
 
-select from diskquota.enable_hardlimit();
---
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();
     name     | status  
 -------------+---------
@@ -16,10 +14,8 @@ select * from diskquota.status();
  hard limits | enabled
 (2 rows)
 
-select from diskquota.disable_hardlimit();
---
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();
     name     |  status  
 -------------+----------
@@ -38,10 +34,8 @@ select * from diskquota.status();
  hard limits | disabled
 (2 rows)
 
-select from diskquota.enable_hardlimit();
---
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();
     name     | status 
 -------------+--------
@@ -49,10 +43,8 @@ select * from diskquota.status();
  hard limits | paused
 (2 rows)
 
-select from diskquota.disable_hardlimit();
---
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();
     name     |  status  
 -------------+----------
@@ -64,10 +56,8 @@ select from diskquota.resume();
 --
 (1 row)
 
-select from diskquota.disable_hardlimit();
---
-(1 row)
-
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();
     name     |  status  
 -------------+----------

--- a/tests/regress/expected/test_show_status.out
+++ b/tests/regress/expected/test_show_status.out
@@ -5,7 +5,7 @@ select * from diskquota.status();
  hard limits | disabled
 (2 rows)
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
     name     | status  
@@ -14,7 +14,7 @@ select * from diskquota.status();
  hard limits | enabled
 (2 rows)
 
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
     name     |  status  
@@ -34,7 +34,7 @@ select * from diskquota.status();
  hard limits | disabled
 (2 rows)
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
     name     | status 
@@ -43,7 +43,7 @@ select * from diskquota.status();
  hard limits | paused
 (2 rows)
 
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
     name     |  status  
@@ -56,7 +56,7 @@ select from diskquota.resume();
 --
 (1 row)
 
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
     name     |  status  

--- a/tests/regress/expected/test_show_status.out
+++ b/tests/regress/expected/test_show_status.out
@@ -5,7 +5,7 @@ select * from diskquota.status();
  hard limits | disabled
 (2 rows)
 
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
     name     | status  
@@ -34,7 +34,7 @@ select * from diskquota.status();
  hard limits | disabled
 (2 rows)
 
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
     name     | status 

--- a/tests/regress/sql/config.sql
+++ b/tests/regress/sql/config.sql
@@ -1,11 +1,12 @@
 --start_ignore
 CREATE DATABASE diskquota;
 
-\! gpconfig -c shared_preload_libraries -v diskquota 
+\! gpconfig -c shared_preload_libraries -v diskquota
 \! gpstop -raf
 
-\! gpconfig -c diskquota.naptime -v 0 
+\! gpconfig -c diskquota.naptime -v 0
 \! gpconfig -c max_worker_processes -v 20
+\! gpconfig -c diskquota.hard_limit -v "false"
 \! gpstop -raf
 --end_ignore
 
@@ -14,3 +15,4 @@ CREATE DATABASE diskquota;
 SHOW diskquota.naptime;
 SHOW diskquota.max_active_tables;
 SHOW diskquota.worker_timeout;
+SHOW diskquota.hard_limit;

--- a/tests/regress/sql/config.sql
+++ b/tests/regress/sql/config.sql
@@ -6,7 +6,7 @@ CREATE DATABASE diskquota;
 
 \! gpconfig -c diskquota.naptime -v 0
 \! gpconfig -c max_worker_processes -v 20
-\! gpconfig -c diskquota.hard_limit -v "false"
+\! gpconfig -c diskquota.hard_limit -v "off"
 \! gpstop -raf
 --end_ignore
 

--- a/tests/regress/sql/test_ctas_pause.sql
+++ b/tests/regress/sql/test_ctas_pause.sql
@@ -1,7 +1,7 @@
 CREATE SCHEMA hardlimit_s;
 SET search_path TO hardlimit_s;
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
 SELECT diskquota.wait_for_worker_new_epoch();
@@ -14,7 +14,7 @@ SELECT diskquota.pause();
 CREATE TABLE t1 AS SELECT generate_series(1,1000000); -- expect succeed
 
 -- disable hardlimit and do some clean-ups.
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.resume();
 

--- a/tests/regress/sql/test_ctas_pause.sql
+++ b/tests/regress/sql/test_ctas_pause.sql
@@ -1,7 +1,7 @@
 CREATE SCHEMA hardlimit_s;
 SET search_path TO hardlimit_s;
 
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
 SELECT diskquota.wait_for_worker_new_epoch();

--- a/tests/regress/sql/test_ctas_pause.sql
+++ b/tests/regress/sql/test_ctas_pause.sql
@@ -1,7 +1,7 @@
 CREATE SCHEMA hardlimit_s;
 SET search_path TO hardlimit_s;
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
 SELECT diskquota.wait_for_worker_new_epoch();

--- a/tests/regress/sql/test_ctas_pause.sql
+++ b/tests/regress/sql/test_ctas_pause.sql
@@ -1,7 +1,8 @@
 CREATE SCHEMA hardlimit_s;
 SET search_path TO hardlimit_s;
 
-SELECT diskquota.enable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
 SELECT diskquota.wait_for_worker_new_epoch();
 
@@ -13,7 +14,8 @@ SELECT diskquota.pause();
 CREATE TABLE t1 AS SELECT generate_series(1,1000000); -- expect succeed
 
 -- disable hardlimit and do some clean-ups.
-SELECT diskquota.disable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 SELECT diskquota.resume();
 
 DROP SCHEMA hardlimit_s CASCADE;

--- a/tests/regress/sql/test_ctas_role.sql
+++ b/tests/regress/sql/test_ctas_role.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 CREATE ROLE hardlimit_r;
 SELECT diskquota.set_role_quota('hardlimit_r', '1MB');

--- a/tests/regress/sql/test_ctas_role.sql
+++ b/tests/regress/sql/test_ctas_role.sql
@@ -1,5 +1,6 @@
 -- Test that diskquota is able to cancel a running CTAS query by the role quota.
-SELECT diskquota.enable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 CREATE ROLE hardlimit_r;
 SELECT diskquota.set_role_quota('hardlimit_r', '1MB');
 GRANT USAGE ON SCHEMA diskquota TO hardlimit_r;
@@ -35,4 +36,5 @@ DROP TABLE IF EXISTS aocs_table;
 RESET ROLE;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
-SELECT diskquota.disable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null

--- a/tests/regress/sql/test_ctas_role.sql
+++ b/tests/regress/sql/test_ctas_role.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 CREATE ROLE hardlimit_r;
 SELECT diskquota.set_role_quota('hardlimit_r', '1MB');
@@ -36,5 +36,5 @@ DROP TABLE IF EXISTS aocs_table;
 RESET ROLE;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null

--- a/tests/regress/sql/test_ctas_role.sql
+++ b/tests/regress/sql/test_ctas_role.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 CREATE ROLE hardlimit_r;
 SELECT diskquota.set_role_quota('hardlimit_r', '1MB');

--- a/tests/regress/sql/test_ctas_schema.sql
+++ b/tests/regress/sql/test_ctas_schema.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 
 CREATE SCHEMA hardlimit_s;

--- a/tests/regress/sql/test_ctas_schema.sql
+++ b/tests/regress/sql/test_ctas_schema.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 
 CREATE SCHEMA hardlimit_s;

--- a/tests/regress/sql/test_ctas_schema.sql
+++ b/tests/regress/sql/test_ctas_schema.sql
@@ -1,5 +1,7 @@
 -- Test that diskquota is able to cancel a running CTAS query by the schema quota.
-SELECT diskquota.enable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
+
 CREATE SCHEMA hardlimit_s;
 SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
 SET search_path TO hardlimit_s;
@@ -23,7 +25,8 @@ CREATE TABLE aocs_table WITH (appendonly=true, orientation=column)
 SELECT diskquota.wait_for_worker_new_epoch();
 
 -- disable hardlimit and do some clean-ups.
-SELECT diskquota.disable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS toast_table;
 DROP TABLE IF EXISTS ao_table;

--- a/tests/regress/sql/test_ctas_schema.sql
+++ b/tests/regress/sql/test_ctas_schema.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 
 CREATE SCHEMA hardlimit_s;
@@ -25,7 +25,7 @@ CREATE TABLE aocs_table WITH (appendonly=true, orientation=column)
 SELECT diskquota.wait_for_worker_new_epoch();
 
 -- disable hardlimit and do some clean-ups.
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS toast_table;

--- a/tests/regress/sql/test_ctas_tablespace_role.sql
+++ b/tests/regress/sql/test_ctas_tablespace_role.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_rolespc

--- a/tests/regress/sql/test_ctas_tablespace_role.sql
+++ b/tests/regress/sql/test_ctas_tablespace_role.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_rolespc

--- a/tests/regress/sql/test_ctas_tablespace_role.sql
+++ b/tests/regress/sql/test_ctas_tablespace_role.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace role quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_rolespc
@@ -44,5 +44,5 @@ RESET default_tablespace;
 DROP TABLESPACE ctas_rolespc;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null

--- a/tests/regress/sql/test_ctas_tablespace_role.sql
+++ b/tests/regress/sql/test_ctas_tablespace_role.sql
@@ -1,5 +1,6 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace role quota.
-SELECT diskquota.enable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 -- start_ignore
 \! mkdir -p /tmp/ctas_rolespc
 -- end_ignore
@@ -43,4 +44,5 @@ RESET default_tablespace;
 DROP TABLESPACE ctas_rolespc;
 REVOKE USAGE ON SCHEMA diskquota FROM hardlimit_r;
 DROP ROLE hardlimit_r;
-SELECT diskquota.disable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null

--- a/tests/regress/sql/test_ctas_tablespace_schema.sql
+++ b/tests/regress/sql/test_ctas_tablespace_schema.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 
 -- start_ignore

--- a/tests/regress/sql/test_ctas_tablespace_schema.sql
+++ b/tests/regress/sql/test_ctas_tablespace_schema.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 
 -- start_ignore
@@ -42,5 +42,5 @@ RESET search_path;
 RESET default_tablespace;
 DROP SCHEMA hardlimit_s;
 DROP TABLESPACE ctas_schemaspc;
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null

--- a/tests/regress/sql/test_ctas_tablespace_schema.sql
+++ b/tests/regress/sql/test_ctas_tablespace_schema.sql
@@ -1,5 +1,5 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace schema quota.
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 
 -- start_ignore

--- a/tests/regress/sql/test_ctas_tablespace_schema.sql
+++ b/tests/regress/sql/test_ctas_tablespace_schema.sql
@@ -1,5 +1,6 @@
 -- Test that diskquota is able to cancel a running CTAS query by the tablespace schema quota.
-SELECT diskquota.enable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 
 -- start_ignore
 \! mkdir -p /tmp/ctas_schemaspc
@@ -41,4 +42,5 @@ RESET search_path;
 RESET default_tablespace;
 DROP SCHEMA hardlimit_s;
 DROP TABLESPACE ctas_schemaspc;
-SELECT diskquota.disable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null

--- a/tests/regress/sql/test_drop_after_pause.sql
+++ b/tests/regress/sql/test_drop_after_pause.sql
@@ -11,7 +11,8 @@ DROP EXTENSION diskquota;
 CREATE EXTENSION diskquota;
 SELECT diskquota.wait_for_worker_new_epoch();
 
-SELECT diskquota.enable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 
 CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int);
@@ -19,7 +20,8 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
 SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO SX.a SELECT generate_series(1,1000000); -- expect insert fail
 
-SELECT diskquota.disable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 SELECT diskquota.pause();
 SELECT diskquota.wait_for_worker_new_epoch();
 DROP EXTENSION diskquota;

--- a/tests/regress/sql/test_drop_after_pause.sql
+++ b/tests/regress/sql/test_drop_after_pause.sql
@@ -11,7 +11,7 @@ DROP EXTENSION diskquota;
 CREATE EXTENSION diskquota;
 SELECT diskquota.wait_for_worker_new_epoch();
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 
 CREATE SCHEMA SX;
@@ -20,7 +20,7 @@ SELECT diskquota.set_schema_quota('SX', '1MB');
 SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO SX.a SELECT generate_series(1,1000000); -- expect insert fail
 
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.pause();
 SELECT diskquota.wait_for_worker_new_epoch();

--- a/tests/regress/sql/test_drop_after_pause.sql
+++ b/tests/regress/sql/test_drop_after_pause.sql
@@ -11,7 +11,7 @@ DROP EXTENSION diskquota;
 CREATE EXTENSION diskquota;
 SELECT diskquota.wait_for_worker_new_epoch();
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 
 CREATE SCHEMA SX;

--- a/tests/regress/sql/test_drop_after_pause.sql
+++ b/tests/regress/sql/test_drop_after_pause.sql
@@ -11,7 +11,7 @@ DROP EXTENSION diskquota;
 CREATE EXTENSION diskquota;
 SELECT diskquota.wait_for_worker_new_epoch();
 
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 
 CREATE SCHEMA SX;

--- a/tests/regress/sql/test_show_status.sql
+++ b/tests/regress/sql/test_show_status.sql
@@ -1,25 +1,25 @@
 select * from diskquota.status();
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
 
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
 
 select from diskquota.pause();
 select * from diskquota.status();
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
 
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
 
 select from diskquota.resume();
-\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();

--- a/tests/regress/sql/test_show_status.sql
+++ b/tests/regress/sql/test_show_status.sql
@@ -1,20 +1,25 @@
 select * from diskquota.status();
 
-select from diskquota.enable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();
 
-select from diskquota.disable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();
 
 select from diskquota.pause();
 select * from diskquota.status();
 
-select from diskquota.enable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();
 
-select from diskquota.disable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();
 
 select from diskquota.resume();
-select from diskquota.disable_hardlimit();
+\! gpconfig -c "diskquota.hard_limit" -v "false" > /dev/null
+\! gpstop -u > /dev/null
 select * from diskquota.status();

--- a/tests/regress/sql/test_show_status.sql
+++ b/tests/regress/sql/test_show_status.sql
@@ -1,6 +1,6 @@
 select * from diskquota.status();
 
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
 
@@ -11,7 +11,7 @@ select * from diskquota.status();
 select from diskquota.pause();
 select * from diskquota.status();
 
-\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
 

--- a/tests/regress/sql/test_show_status.sql
+++ b/tests/regress/sql/test_show_status.sql
@@ -1,6 +1,6 @@
 select * from diskquota.status();
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
 
@@ -11,7 +11,7 @@ select * from diskquota.status();
 select from diskquota.pause();
 select * from diskquota.status();
 
-\! gpconfig -c "diskquota.hard_limit" -v "true" > /dev/null
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 select * from diskquota.status();
 


### PR DESCRIPTION
- Change to use GUC to set hardlimit instead of udf. Since the hardlimit
  setting needs to be persistent after postmaster restarting.
- Fix relevant test cases.
