### PR TITLE
    Use ytt to create pipelines

### DIFF
--- a/concourse/fly.sh
+++ b/concourse/fly.sh
@@ -57,7 +57,7 @@ case ${pipeline_config} in
     ;;
   commit)
       if [ -z "${pipeline_name}" ]; then
-          pipeline_name="COMMIT:diskquota/gpdb"
+          pipeline_name="COMMIT:diskquota:gpdb"
       fi
       # Default branch is 'gpdb' as it is our main branch
       if [ -z "${branch}" ]; then

--- a/concourse/fly.sh
+++ b/concourse/fly.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -e
+
+workspace=${WORKSPACE:-"$HOME/workspace"}
+fly=${FLY:-"fly"}
+echo "'workspace' location: ${workspace}"
+echo "'fly' command: ${fly}"
+echo ""
+
+usage() {
+    echo "Usage: $0 -t <concourse_target> -c <pr|commit|dev> [-p <pipeline_name>] [-b branch]" 1>&2
+    if [ -n "$1" ]; then
+        echo "$1"
+    fi
+    exit 1
+}
+
+# Parse command line options
+while getopts ":c:t:p:b:" o; do
+    case "${o}" in
+        c)
+            # pipeline type/config. pr/commit/dev/release
+            pipeline_config=${OPTARG}
+            ;;
+        t)
+            # concourse target
+            target=${OPTARG}
+            ;;
+        p)
+            # pipeline name
+            pipeline_name=${OPTARG}
+            ;;
+        b)
+            # branch name
+            branch=${OPTARG}
+            ;;
+        *)
+            usage ""
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${target}" ] || [ -z "${pipeline_config}" ]; then
+    usage ""
+fi
+
+# Decide ytt options to generate pipeline
+case ${pipeline_config} in
+  pr)
+      if [ -z "${pipeline_name}" ]; then
+          pipeline_name="PR:diskquota"
+      fi
+      config_file="pr.yml"
+      hook_res="diskquota_pr"
+    ;;
+  commit)
+      if [ -z "${pipeline_name}" ]; then
+          pipeline_name="COMMIT:diskquota/gpdb"
+      fi
+      # Default branch is 'gpdb' as it is our main branch
+      if [ -z "${branch}" ]; then
+          branch="gpdb"
+      fi
+      config_file="commit.yml"
+      hook_res="diskquota_commit"
+    ;;
+  dev)
+      if [ -z "${pipeline_name}" ]; then
+          usage "'-p' needs to be supplied to specify the pipeline name for flying a 'dev' pipeline."
+      fi
+      pipeline_name="DEV:${pipeline_name}"
+      config_file="dev.yml"
+    ;;
+  *)
+      usage ""
+    ;;
+esac
+
+yml_path="/tmp/diskquota_pipeline.yml"
+my_path=$(realpath "${BASH_SOURCE[0]}")
+ytt_base=$(dirname "${my_path}")/pipeline
+
+ytt --data-values-file "${ytt_base}/res_def.yml" \
+    -f "${ytt_base}/base.lib.yml" \
+    -f "${ytt_base}/job_def.lib.yml" \
+    -f "${ytt_base}/trigger_def.lib.yml" \
+    -f "${ytt_base}/${config_file}" > "${yml_path}"
+echo "Generated pipeline yaml '${yml_path}'."
+
+echo ""
+echo "Fly the pipeline..."
+set -v
+"${fly}" \
+    -t "${target}" \
+    sp \
+    -p "${pipeline_name}" \
+    -c "${yml_path}" \
+    -l "${workspace}/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml" \
+    -l "${workspace}/gp-continuous-integration/secrets/gp-extensions-common.yml" \
+    -l "${workspace}/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml" \
+    -v "diskquota-branch=${branch}"
+set +v
+
+if [ "${pipeline_config}" == "dev" ]; then
+    exit 0
+fi
+
+echo ""
+echo "================================================================================"
+echo "Remeber to set the the webhook URL on GitHub:"
+echo "https://extensions.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/${pipeline_name}/resources/${hook_res}/check/webhook?webhook_token=<hook_token>"
+echo "You may need to change the base URL if a differnt concourse server is used."
+echo "================================================================================"

--- a/concourse/pipeline/README.md
+++ b/concourse/pipeline/README.md
@@ -3,7 +3,7 @@
 ## Naming Prefix Rule
 
 - `PR:<project_name>` for pull-request pipelines
-- `COMMIT:<project_name>/<branch_name>` for branch pipelines. It will be executed when a commit committed/merged into the branch.
+- `COMMIT:<project_name>:<branch_name>` for branch pipelines. It will be executed when a commit committed/merged into the branch.
 - `DEV:<your_name>_<project_name>[any_other_info]` for personal development usage. Put your name into the pipeline name so others can know who own it.
 
 ## Pipelines for daily work
@@ -15,7 +15,7 @@ https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/PR:diskquota
 ### Main Branch Pipeline
 
 The development happens on the `gpdb` branch. The commit pipeline for the `gpdb`
-https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/COMMIT:diskquota/gpdb
+https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/COMMIT:diskquota:gpdb
 
 
 # Fly a pipeline

--- a/concourse/pipeline/README.md
+++ b/concourse/pipeline/README.md
@@ -1,0 +1,65 @@
+# Pipelines
+
+## Naming Prefix Rule
+
+- `PR:<project_name>` for pull-request pipelines
+- `COMMIT:<project_name>/<branch_name>` for branch pipelines. It will be executed when a commit committed/merged into the branch.
+- `DEV:<your_name>_<project_name>[any_other_info]` for personal development usage. Put your name into the pipeline name so others can know who own it.
+
+## Pipelines for daily work
+
+### PR Pipeline
+
+https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/PR:diskquota
+
+### Main Branch Pipeline
+
+The development happens on the `gpdb` branch. The commit pipeline for the `gpdb`
+https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/COMMIT:diskquota/gpdb
+
+
+# Fly a pipeline
+
+## Prerequisite
+
+- Install [ytt](https://carvel.dev/ytt/). It's written in go. So just download the executable for your platform from the [release page](https://github.com/vmware-tanzu/carvel-ytt/releases).
+- Make the `fly` command in the `PATH` or export its location to `FLY` env.
+- Clone the `gp-continuous-integration` repo to `$HOME/workspace` or set its parent directory to `WORKSPACE` env.
+- Login with the `fly` command. Assume we are using `extension` as the target name.
+
+  ```
+  fly -t extension login -c https://extensions.ci.gpdb.pivotal.io
+  ```
+- `cd` to the `concourse` directory.
+
+## Fly the PR pipeline
+
+```
+./fly.sh -t extension -c pr
+```
+
+## Fly the commit pipeline
+
+```
+./fly.sh -t extension -c commit
+```
+
+## Fly the release pipeline
+
+TBD
+
+## Fly the dev pipeline
+
+```
+./fly.sh -t extension -c dev -p <your_name>_diskquota -b <your_branch>
+```
+
+## Webhook
+
+By default, the PR and commit pipelines are using webhook instead of polling to trigger a build. The webhook URL will be printed when flying such a pipeline by `fly.sh`. The webhook needs to be set in the `github repository` -> `Settings` -> `Webhooks` with push notification enabled.
+
+To test if the webhook works, use `curl` to send a `POST` request to the hook URL with some random data. If it is the right URL, the relevant resource will be refreshed on the Concourse UI. The command line looks like:
+
+```
+curl --data-raw "foo" <hook_url>
+```

--- a/concourse/pipeline/base.lib.yml
+++ b/concourse/pipeline/base.lib.yml
@@ -1,0 +1,34 @@
+#@ load("@ytt:data", "data")
+#! add_res_by_xxx is to solve the unused resources error for concourse
+#@ def add_res_by_conf(res_map, job_conf):
+#@   for key in job_conf:
+#@     if key.startswith("res_"):
+#@       res_name = job_conf[key]
+#@       res_map[res_name] = True
+#@     end
+#@   end
+#@ end
+#@
+#@ def add_res_by_name(res_map, res_name):
+#@   res_map[res_name] = True
+#@ end
+#@
+#@ def declare_res(res_type_map, res_map):
+#@   for val in data.values.resources:
+#@     res_name = val["name"]
+#@     res_type = val["type"]
+#@     if res_map.get(val["name"]):
+#@       res_type_map[res_type] = True
+  - #@ val
+#@     end
+#@   end
+#@ end
+#@
+#@ def declare_res_type(res_type_map):
+#@   for val in data.values.resource_types:
+#@     type_name = val["name"]
+#@     if res_type_map.get(type_name):
+  - #@ val
+#@     end
+#@   end
+#@ end

--- a/concourse/pipeline/commit.yml
+++ b/concourse/pipeline/commit.yml
@@ -1,0 +1,29 @@
+#@ load("job_def.lib.yml",
+#@   "build_test_job",
+#@   "centos6_gpdb6_conf",
+#@   "centos7_gpdb6_conf",
+#@   "rhel8_gpdb6_conf",
+#@   "ubuntu18_gpdb6_conf")
+#@ load("trigger_def.lib.yml",
+#@   "commit_trigger",
+#@ )
+#@
+#@ load("base.lib.yml", "declare_res", "declare_res_type")
+#@ res_map = {}
+#@ res_type_map = {}
+#@ job_param = {
+#@   "res_map": res_map,
+#@   "trigger": commit_trigger(res_map),
+#@   "gpdb_src": "gpdb6_src",
+#@   "confs": [
+#@     centos6_gpdb6_conf(),
+#@     centos7_gpdb6_conf(),
+#@     rhel8_gpdb6_conf(),
+#@     ubuntu18_gpdb6_conf()]
+#@ }
+jobs:
+- #@ build_test_job(job_param)
+
+resources: #@ declare_res(res_type_map, res_map)
+
+resource_types: #@ declare_res_type(res_type_map)

--- a/concourse/pipeline/dev.yml
+++ b/concourse/pipeline/dev.yml
@@ -1,0 +1,26 @@
+#@ load("job_def.lib.yml",
+#@   "build_test_job",
+#@   "centos6_gpdb6_conf",
+#@   "centos7_gpdb6_conf",
+#@   "rhel8_gpdb6_conf",
+#@   "ubuntu18_gpdb6_conf")
+#@ load("trigger_def.lib.yml",
+#@   "commit_dev_trigger",
+#@ )
+#@
+#@ load("base.lib.yml", "declare_res", "declare_res_type")
+#@ res_map = {}
+#@ res_type_map = {}
+#@ job_param = {
+#@   "res_map": res_map,
+#@   "trigger": commit_dev_trigger(res_map),
+#@   "gpdb_src": "gpdb6_src",
+#@   "confs": [
+#@     ubuntu18_gpdb6_conf()]
+#@ }
+jobs:
+- #@ build_test_job(job_param)
+
+resources: #@ declare_res(res_type_map, res_map)
+
+resource_types: #@ declare_res_type(res_type_map)

--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -1,0 +1,100 @@
+#@ load("base.lib.yml", "add_res_by_conf", "add_res_by_name")
+
+#! Job config for centos7
+#@ def centos6_gpdb6_conf():
+res_build_image: centos6-gpdb6-image-build
+res_test_image: centos6-gpdb6-image-test
+res_gpdb_bin: bin_gpdb6_centos6
+diskquota_os: rhel6
+#@ end
+
+#! Job config for centos7
+#@ def centos7_gpdb6_conf():
+res_build_image: centos7-gpdb6-image-build
+res_test_image: centos7-gpdb6-image-test
+res_gpdb_bin: bin_gpdb6_centos7
+diskquota_os: rhel7
+#@ end
+
+#! Job config for rhel8
+#@ def rhel8_gpdb6_conf():
+res_build_image: rhel8-gpdb6-image-build
+res_test_image: rhel8-gpdb6-image-test
+res_gpdb_bin: bin_gpdb6_rhel8
+diskquota_os: rhel8
+#@ end
+
+#! Job config for ubuntu18
+#@ def ubuntu18_gpdb6_conf():
+res_build_image: ubuntu18-gpdb6-image-build
+res_test_image: ubuntu18-gpdb6-image-test
+res_gpdb_bin: bin_gpdb6_ubuntu18
+diskquota_os: ubuntu18.04
+#@ end
+
+#@ def _build_task(conf):
+task: #@ "build_" + conf["diskquota_os"]
+file: diskquota_src/concourse/tasks/build_diskquota.yml
+image: #@ conf["res_build_image"]
+input_mapping:
+  bin_gpdb: #@ conf["res_gpdb_bin"]
+  diskquota_artifacts: diskquota_artifacts
+#! output_mapping is necessary. Otherwise we may use a wrong
+#! diskquota_bin in the test task.
+output_mapping:
+  "diskquota_artifacts": #@ "diskquota_artifacts_" + conf["diskquota_os"]
+params:
+  DISKQUOTA_OS: #@ conf["diskquota_os"]
+#@ end
+
+#@ def _test_task(conf):
+task: #@ "test_" + conf["diskquota_os"]
+timeout: 1h
+file: diskquota_src/concourse/tasks/test_diskquota.yml
+image: #@ conf["res_test_image"]
+input_mapping:
+  bin_gpdb: #@ conf["res_gpdb_bin"]
+  bin_diskquota: #@ "diskquota_artifacts_" + conf["diskquota_os"]
+params:
+  DISKQUOTA_OS: #@ conf["diskquota_os"]
+#@ end
+
+#@ def build_test_job(param):
+#@   res_map = param["res_map"]
+#@   trigger = param["trigger"]
+#@   confs = param["confs"]
+#@   add_res_by_name(res_map, param["gpdb_src"])
+name: build_test
+max_in_flight: 10
+on_success: #@ trigger["on_success"]
+on_failure: #@ trigger["on_failure"]
+on_error: #@ trigger["on_error"]
+plan:
+- #@ trigger["plan"]
+- in_parallel:
+  - get: gpdb_src
+    resource: #@ param["gpdb_src"]
+#@   for conf in confs:
+#@     add_res_by_conf(res_map, conf)
+#@     if conf["res_build_image"] == conf["res_test_image"]:
+  - get: #@ conf["res_build_image"]
+#@     else:
+  - get: #@ conf["res_build_image"]
+  - get: #@ conf["res_test_image"]
+#@     end
+  - get: #@ conf["res_gpdb_bin"]
+#@   end
+#@   if len(confs) == 1:
+#@     conf = confs[0]
+- #@ _build_task(conf)
+- #@ _test_task(conf)
+#@   else:
+- in_parallel:
+    steps:
+#@     for conf in confs:
+      - do:
+        - #@ _build_task(conf)
+        - #@ _test_task(conf)
+#@     end
+#@   end
+#@ end

--- a/concourse/pipeline/pr.yml
+++ b/concourse/pipeline/pr.yml
@@ -1,0 +1,24 @@
+#@ load("job_def.lib.yml",
+#@   "build_test_job",
+#@   "centos7_gpdb6_conf",
+#@ )
+#@ load("trigger_def.lib.yml",
+#@   "pr_trigger",
+#@ )
+#@ load("base.lib.yml",
+#@   "declare_res",
+#@  "declare_res_type")
+#@ res_map = {}
+#@ res_type_map = {}
+#@ job_param = {
+#@   "res_map": res_map,
+#@   "gpdb_src": "gpdb6_src",
+#@   "trigger": pr_trigger(res_map),
+#@   "confs": [centos7_gpdb6_conf()]
+#@ }
+jobs:
+- #@ build_test_job(job_param)
+
+resources: #@ declare_res(res_type_map, res_map)
+
+resource_types: #@ declare_res_type(res_type_map)

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -1,0 +1,129 @@
+resource_types:
+- name: gcs
+  type: registry-image
+  check_every: 1h
+  source:
+    repository: frodenas/gcs-resource
+
+- name: pull-request
+  type: docker-image
+  check_every: 1h
+  source:
+    repository: teliaoss/github-pr-resource
+
+resources:
+# Pull Request
+- name: diskquota_pr
+  type: pull-request
+  # We should rely on the webhook. See README if webhook doesn't work
+  webhook_token: ((diskquota-webhook-token))
+  check_every: 24h
+  source:
+    disable_forks: false
+    repository: greenplum-db/diskquota
+    access_token: ((github-access-token))
+    base_branch: gpdb
+# Commit trigger
+- name: diskquota_commit
+  type: git
+  # We should rely on the webhook. See README if webhook doesn't work
+  webhook_token: ((diskquota-webhook-token))
+  check_every: 24h
+  source:
+    branch: ((diskquota-branch))
+    uri: https://github.com/greenplum-db/diskquota.git
+    username: ((github-access-token))
+    password: x-oauth-basic
+# Commit dev trigger. Not using webhook
+- name: diskquota_commit_dev
+  type: git
+  check_every: 1m
+  source:
+    branch: ((diskquota-branch))
+    uri: https://github.com/greenplum-db/diskquota.git
+    username: ((github-access-token))
+    password: x-oauth-basic
+
+
+# Greenplum sources
+- name: gpdb6_src
+  type: git
+  source:
+    branch: 6X_STABLE
+    uri: https://github.com/greenplum-db/gpdb.git
+
+# Image Resources
+# centos6
+- name: centos6-gpdb6-image-build
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos6-build
+    tag: latest
+- name: centos6-gpdb6-image-test
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos6-test
+    tag: latest
+# centos7
+- name: centos7-gpdb6-image-build
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-build
+    tag: latest
+- name: centos7-gpdb6-image-test
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
+    tag: latest
+# rhel8
+- name: rhel8-gpdb6-image-build
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-private-images/gpdb6-rhel8-build
+    tag: latest
+    username: _json_key
+    password: ((container-registry-readonly-service-account-key))
+- name: rhel8-gpdb6-image-test
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-private-images/gpdb6-rhel8-test
+    tag: latest
+    username: _json_key
+    password: ((container-registry-readonly-service-account-key))
+# Ubuntu18
+- name: ubuntu18-gpdb6-image-build
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-build
+    tag: latest
+- name: ubuntu18-gpdb6-image-test
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test
+    tag: latest
+
+#! gpdb binary on gcs is located as different folder for different version
+- name: bin_gpdb6_centos6
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-intermediates))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    versioned_file: 6X_STABLE/bin_gpdb_centos6/bin_gpdb.tar.gz
+- name: bin_gpdb6_centos7
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-intermediates))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    versioned_file: 6X_STABLE/bin_gpdb_centos7/bin_gpdb.tar.gz
+- name: bin_gpdb6_ubuntu18
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-intermediates))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    versioned_file: 6X_STABLE/bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz
+- name: bin_gpdb6_rhel8
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-intermediates))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    versioned_file: 6X_STABLE/bin_gpdb_rhel8/bin_gpdb.tar.gz

--- a/concourse/pipeline/trigger_def.lib.yml
+++ b/concourse/pipeline/trigger_def.lib.yml
@@ -1,0 +1,56 @@
+#@ load("base.lib.yml", "add_res_by_name")
+
+#! PR trigger. For pull request pipelines
+#@ def pr_trigger(res_map):
+#@   add_res_by_name(res_map, "diskquota_pr")
+plan:
+  get: diskquota_src
+  resource: diskquota_pr
+  params:
+    fetch_tags: true
+  trigger: true
+on_failure:
+  put: diskquota_pr
+  params:
+    path: diskquota_src
+    status: failure
+on_error:
+  put: diskquota_pr
+  params:
+    path: diskquota_src
+    status: failure
+on_success:
+   put: diskquota_pr
+   params:
+     path: diskquota_src
+     status: success
+#@ end
+
+#! Commit trigger. For master pipelines
+#@ def commit_trigger(res_map):
+#@   add_res_by_name(res_map, "diskquota_commit")
+plan:
+  get: diskquota_src
+  resource: diskquota_commit
+  trigger: true
+#! To set the github commit status, https://github.com/Pix4D/cogito is a good choice.
+#! Unfortunately it doesn't work with Concourse 5.
+on_success:
+on_failure:
+on_error:
+#@ end
+
+#! Commit trigger. For dev pipelines. No webhook
+#@ def commit_dev_trigger(res_map):
+#@   add_res_by_name(res_map, "diskquota_commit_dev")
+plan:
+  get: diskquota_src
+  resource: diskquota_commit_dev
+  trigger: true
+#! To set the github commit status, https://github.com/Pix4D/cogito is a good choice.
+#! Unfortunately it doesn't work with Concourse 5.
+on_success:
+on_failure:
+on_error:
+#@ end
+

--- a/concourse/scripts/build_diskquota.sh
+++ b/concourse/scripts/build_diskquota.sh
@@ -20,43 +20,30 @@ function pkg() {
     pushd /usr/local/greenplum-db-devel/
     echo 'cp -r lib share $GPHOME || exit 1'> install_gpdb_component
     chmod a+x install_gpdb_component
+    install_files=( \
+        "lib/postgresql/diskquota.so" \
+        "share/postgresql/extension/diskquota.control" \
+        "share/postgresql/extension/diskquota--1.0.sql" \
+        "share/postgresql/extension/diskquota--2.0.sql" \
+        "share/postgresql/extension/diskquota--1.0--2.0.sql" \
+        "share/postgresql/extension/diskquota--2.0--1.0.sql" \
+        "install_gpdb_component")
     case "$DISKQUOTA_OS" in
     rhel6)
         tar -czf $TOP_DIR/diskquota_artifacts/diskquota-${DISKQUOTA_VERSION}-rhel6_x86_64.tar.gz \
-        lib/postgresql/diskquota.so \
-        share/postgresql/extension/diskquota.control \
-        share/postgresql/extension/diskquota--1.0.sql \
-        share/postgresql/extension/diskquota--2.0.sql \
-        share/postgresql/extension/diskquota--1.0--2.0.sql \
-        share/postgresql/extension/diskquota--2.0--1.0.sql \
-        install_gpdb_component
+            "${install_files[@]}"
       ;;
     rhel7)
         tar -czf $TOP_DIR/diskquota_artifacts/diskquota-${DISKQUOTA_VERSION}-rhel7_x86_64.tar.gz \
-        lib/postgresql/diskquota.so \
-        share/postgresql/extension/diskquota.control \
-        share/postgresql/extension/diskquota--1.0.sql \
-        share/postgresql/extension/diskquota--2.0.sql \
-        share/postgresql/extension/diskquota--1.0--2.0.sql \
-        share/postgresql/extension/diskquota--2.0--1.0.sql \
-        install_gpdb_component
+            "${install_files[@]}"
       ;;
     rhel8)
         tar -czf $TOP_DIR/diskquota_artifacts/diskquota-${DISKQUOTA_VERSION}-rhel8_x86_64.tar.gz \
-        lib/postgresql/diskquota.so \
-        share/postgresql/extension/diskquota.control \
-        share/postgresql/extension/diskquota--1.0.sql \
-        install_gpdb_component
+            "${install_files[@]}"
       ;;
     ubuntu18.04)
         tar -czf $TOP_DIR/diskquota_artifacts/diskquota-${DISKQUOTA_VERSION}-ubuntu18.04_x86_64.tar.gz \
-        lib/postgresql/diskquota.so \
-        share/postgresql/extension/diskquota.control \
-        share/postgresql/extension/diskquota--1.0.sql \
-        share/postgresql/extension/diskquota--2.0.sql \
-        share/postgresql/extension/diskquota--1.0--2.0.sql \
-        share/postgresql/extension/diskquota--2.0--1.0.sql \
-        install_gpdb_component
+            "${install_files[@]}"
       ;;
     *) echo "Unknown OS: $DISKQUOTA_OS"; exit 1 ;;
     esac

--- a/concourse/scripts/test_diskquota.sh
+++ b/concourse/scripts/test_diskquota.sh
@@ -17,7 +17,6 @@ source "${TOP_DIR}/diskquota_src/concourse/scripts/test_common.sh"
 function create_fake_gpdb_src() {
 	pushd gpdb_src
 	./configure --prefix=/usr/local/greenplum-db-devel \
-		    --with-perl --with-python --with-libxml \
 		    --without-zstd \
 		    --disable-orca --disable-gpcloud --enable-debug-extensions
 	popd


### PR DESCRIPTION
- Rewrite the pipelines by using ytt for code reuse.
- Add `fly.sh` for easier manipulating with pipelines.
- Create configs for pr, commit and dev pipelines.
- Fix the test task for rhel8.
- Use build/test images pair for all distros. And modify the
  `build_diskquota.sh` so it won't need `Python.h` during the configure
  stage.
- Fix the pipiline bug which a `ubuntu` test may use a `rhel6` diskquota
  binary to do the test. That is caused by the same name of the task
  output.

To replace #115 