### PR TITLE
CI test

### DIFF
--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -1357,6 +1357,11 @@ diskquota_relation_open(Oid relid, LOCKMODE mode)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
+
+	/* fix tablespace oid if the tablespace oid is default table oid */
+	if (success_open && rel->rd_node.spcNode == InvalidOid)
+		rel->rd_node.spcNode = MyDatabaseTableSpace;
+
 	return success_open ? rel : NULL;
 }
 

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -280,7 +280,7 @@ report_active_table_helper(const RelFileNodeBackend *relFileNode)
 	MemSet(&item, 0, sizeof(DiskQuotaActiveTableFileEntry));
 	item.dbid = relFileNode->node.dbNode;
 	item.relfilenode = relFileNode->node.relNode;
-	item.tablespaceoid = relFileNode->node.spcNode;
+	item.tablespaceoid = OidIsValid(relFileNode->node.spcNode) ? relFileNode->node.spcNode : MyDatabaseTableSpace;
 
 	LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
 	entry = hash_search(active_tables_map, &item, HASH_ENTER_NULL, &found);
@@ -347,7 +347,7 @@ gp_fetch_active_tables(bool is_init)
 }
 
 /*
- * Function to get the table size from each segments
+ * Function to get the table size from each segment
  * There are three mode:
  * 1. gather active table oid from all the segments, since table may only
  * be modified on a subset of the segments, we need to firstly gather the

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -300,7 +300,7 @@ add_quota_to_blacklist(QuotaType type, Oid targetOid, Oid tablespaceoid, bool se
 }
 
 /*
- * Check the quota map, if the entry doesn't exist any more,
+ * Check the quota map, if the entry doesn't exist anymore,
  * remove it from the map. Otherwise, check if it has hit
  * the quota limit, if it does, add it to the black list.
  */
@@ -332,11 +332,12 @@ check_quota_map(QuotaType type)
 			if (entry->size >= entry->limit)
 			{
 				Oid targetOid = entry->keys[0];
-				Oid tablespaceoid =
-					(type == NAMESPACE_TABLESPACE_QUOTA) || (type == ROLE_TABLESPACE_QUOTA) ? entry->keys[1] : InvalidOid;
 				/* when quota type is not NAMESPACE_TABLESPACE_QUOTA or ROLE_TABLESPACE_QUOTA, the tablespaceoid
 				 * is set to be InvalidOid, so when we get it from map, also set it to be InvalidOid
 				 */
+				Oid tablespaceoid =
+						(type == NAMESPACE_TABLESPACE_QUOTA) || (type == ROLE_TABLESPACE_QUOTA) ? entry->keys[1] : InvalidOid;
+
 				bool segmentExceeded = entry->segid == -1 ? false : true;
 				add_quota_to_blacklist(type, targetOid, tablespaceoid, segmentExceeded);
 			}
@@ -858,6 +859,11 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 			relnamespace = classForm->relnamespace;
 			relowner = classForm->relowner;
 			reltablespace = classForm->reltablespace;
+
+			if (!OidIsValid(reltablespace))
+			{
+				reltablespace = MyDatabaseTableSpace;
+			}
 		}
 		else
 		{
@@ -1453,6 +1459,12 @@ get_rel_owner_schema_tablespace(Oid relid, Oid *ownerOid, Oid *nsOid, Oid *table
 		*ownerOid = reltup->relowner;
 		*nsOid = reltup->relnamespace;
 		*tablespaceoid = reltup->reltablespace;
+
+		if (!OidIsValid(*tablespaceoid))
+		{
+			*tablespaceoid = MyDatabaseTableSpace;
+		}
+
 		ReleaseSysCache(tp);
 	}
 	return found;
@@ -1781,13 +1793,13 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 		keyitem.targettype    = DatumGetInt32(GetAttributeByNum(lt, 4, &isnull));
 		/*
 		 * If the current quota limit type is NAMESPACE_TABLESPACE_QUOTA or
-		 * ROLE_TABLESPACE_QUOTA, we should explicitly set DEFAULTTABLESPACE_OID
+		 * ROLE_TABLESPACE_QUOTA, we should explicitly set MyDatabaseTableSpace
 		 * for relations whose reltablespace is InvalidOid.
 		 */
 		if ((keyitem.targettype == NAMESPACE_TABLESPACE_QUOTA ||
 			 keyitem.targettype == ROLE_TABLESPACE_QUOTA) &&
 			!OidIsValid(keyitem.tablespaceoid))
-			keyitem.tablespaceoid = DEFAULTTABLESPACE_OID;
+			keyitem.tablespaceoid = MyDatabaseTableSpace;
 		segexceeded           = DatumGetBool(GetAttributeByNum(lt, 5, &isnull));
 
 		blackmapentry = hash_search(local_blackmap, &keyitem, HASH_ENTER_NULL, NULL);
@@ -1820,7 +1832,7 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 			Form_pg_class	form = (Form_pg_class) GETSTRUCT(tuple);
 			Oid				relnamespace = form->relnamespace;
 			Oid				reltablespace = OidIsValid(form->reltablespace) ?
-												form->reltablespace : DEFAULTTABLESPACE_OID;
+												form->reltablespace : MyDatabaseTableSpace;
 			Oid				relowner = form->relowner;
 			BlackMapEntry	keyitem;
 			bool			found;
@@ -1882,7 +1894,7 @@ refresh_blackmap(PG_FUNCTION_ARGS)
 							Form_pg_class				curr_form = (Form_pg_class) GETSTRUCT(curr_tuple);
 							Oid							curr_reltablespace =
 								OidIsValid(curr_form->reltablespace) ?
-								curr_form->reltablespace : DEFAULTTABLESPACE_OID;
+								curr_form->reltablespace : MyDatabaseTableSpace;
 							RelFileNode					relfilenode =
 								{ .dbNode = MyDatabaseId,
 								  .relNode = curr_form->relfilenode,

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -446,7 +446,7 @@ get_relation_entry_from_pg_class(Oid relid, DiskQuotaRelationCacheEntry* relatio
 	relation_entry->namespaceoid = classForm->relnamespace;
 	relation_entry->relstorage = classForm->relstorage;
 	relation_entry->rnode.node.spcNode = OidIsValid(classForm->reltablespace) ? 
-										 classForm->reltablespace : DEFAULTTABLESPACE_OID;
+										 classForm->reltablespace : MyDatabaseTableSpace;
 	relation_entry->rnode.node.dbNode = MyDatabaseId;
 	relation_entry->rnode.node.relNode = classForm->relfilenode;
 	relation_entry->rnode.backend = classForm->relpersistence == RELPERSISTENCE_TEMP ? 
@@ -537,7 +537,7 @@ get_relfilenode_by_relid(Oid relid, RelFileNodeBackend *rnode, char *relstorage)
 	{
 		classForm = (Form_pg_class) GETSTRUCT(classTup);
 		rnode->node.spcNode = OidIsValid(classForm->reltablespace) ? 
-							  classForm->reltablespace : DEFAULTTABLESPACE_OID;
+							  classForm->reltablespace : MyDatabaseTableSpace;
 		rnode->node.dbNode = MyDatabaseId;
 		rnode->node.relNode = classForm->relfilenode;
 		rnode->backend = classForm->relpersistence == RELPERSISTENCE_TEMP ? 

--- a/tests/isolation2/expected/test_blackmap.out
+++ b/tests/isolation2/expected/test_blackmap.out
@@ -44,7 +44,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
 
 -- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=25165)
 
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -83,7 +83,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
 
 -- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=25165)
 
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -122,7 +122,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
 
 -- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=25165)
 
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -163,7 +163,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
 
 -- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=25165)
 
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -195,7 +195,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  tablespace:1663 schema:2200 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  tablespace:1663 schema:2200 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=25165)
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
  refresh_blackmap 
@@ -226,7 +226,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  tablespace:1663 role:10 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  tablespace:1663 role:10 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=25165)
 -- Clean up the blackmap on seg0.
 SELECT diskquota.refresh_blackmap( ARRAY[]::diskquota.blackmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
  refresh_blackmap 
@@ -268,7 +268,7 @@ CREATE
 
 -- This function replaces the oid appears in the auxiliary relation's name
 -- with the corresponding relname of that oid.
-CREATE OR REPLACE FUNCTION replace_oid_with_relname(given_name text, filename text) RETURNS text AS $$                                                                      /*in func*/ BEGIN                                                                                   /*in func*/ RETURN COALESCE(                                                                      /*in func*/ REGEXP_REPLACE(given_name,                                                          /*in func*/ '^(pg_toast_|pg_aoseg_|pg_aovisimap_|pg_aoblkdir_|pg_aocsseg_)\d+',              /*in func*/ '\1' ||                                                                          /*in func*/ (SELECT DISTINCT relname FROM read_relation_cache_from_file(filename)            /*in func*/ WHERE reloid=REGEXP_REPLACE(given_name, '\D', '', 'g')::oid), 'g'), given_name);/*in func*/ END;                                                                                    /*in func*/ $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION replace_oid_with_relname(given_name text, filename text) RETURNS text AS $$                                                                      /*in func*/ BEGIN                                                                                   /*in func*/ RETURN COALESCE(                                                                      /*in func*/ REGEXP_REPLACE(given_name,                                                          /*in func*/ '^(pg_toast_|pg_aoseg_|pg_aovisimap_|pg_aoblkdir_|pg_aocsseg_)\d+',              /*in func*/ '\1' ||                                                                          /*in func*/ (SELECT DISTINCT relname FROM read_relation_cache_from_file(filename)            /*in func*/ WHERE  REGEXP_REPLACE(given_name, '\D', '', 'g') <> '' AND reloid=REGEXP_REPLACE(given_name, '\D', '', 'g')::oid), 'g'), given_name);/*in func*/ END;                                                                                    /*in func*/ $$ LANGUAGE plpgsql;
 CREATE
 
 -- This function helps dispatch blackmap for the given relation to seg0.
@@ -310,7 +310,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=25165)
 1: ABORT;
 ABORT
 -- Clean up the blackmap on seg0.
@@ -355,7 +355,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  role's disk space quota exceeded with name:10  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  role's disk space quota exceeded with name:10  (seg0 127.0.0.1:6002 pid=25165)
 1: ABORT;
 ABORT
 -- Clean up the blackmap on seg0.
@@ -400,7 +400,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  tablespace:1663 schema:2200 diskquota exceeded  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  tablespace:1663 schema:2200 diskquota exceeded  (seg0 127.0.0.1:6002 pid=25165)
 1: ABORT;
 ABORT
 -- Clean up the blackmap on seg0.
@@ -445,7 +445,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  tablespace:1663 role:10 diskquota exceeded  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  tablespace:1663 role:10 diskquota exceeded  (seg0 127.0.0.1:6002 pid=25165)
 1: ABORT;
 ABORT
 -- Clean up the blackmap on seg0.
@@ -490,7 +490,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  tablespace:1663 schema:2200 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  tablespace:1663 schema:2200 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=25165)
 1: ABORT;
 ABORT
 -- Clean up the blackmap on seg0.
@@ -535,7 +535,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  tablespace:1663 role:10 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  tablespace:1663 role:10 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=25165)
 1: ABORT;
 ABORT
 -- Clean up the blackmap on seg0.
@@ -582,7 +582,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=25165)
 1: ABORT;
 ABORT
 -- Clean up the blackmap on seg0.
@@ -630,7 +630,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=25165)
 1: ABORT;
 ABORT
 -- Clean up the blackmap on seg0.
@@ -678,7 +678,7 @@ SELECT gp_inject_fault_infinite('check_blackmap_by_relfilenode', 'reset', dbid) 
  Success:                 
 (1 row)
 1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=137774)
+ERROR:  schema's disk space quota exceeded with name:2200  (seg0 127.0.0.1:6002 pid=25165)
 1: ABORT;
 ABORT
 -- Clean up the blackmap on seg0.

--- a/tests/isolation2/sql/test_blackmap.sql
+++ b/tests/isolation2/sql/test_blackmap.sql
@@ -232,7 +232,8 @@ CREATE OR REPLACE FUNCTION replace_oid_with_relname(given_name text, filename te
          '^(pg_toast_|pg_aoseg_|pg_aovisimap_|pg_aoblkdir_|pg_aocsseg_)\d+',              /*in func*/
          '\1' ||                                                                          /*in func*/
 	 (SELECT DISTINCT relname FROM read_relation_cache_from_file(filename)            /*in func*/
-          WHERE reloid=REGEXP_REPLACE(given_name, '\D', '', 'g')::oid), 'g'), given_name);/*in func*/
+          WHERE  REGEXP_REPLACE(given_name, '\D', '', 'g') <> ''
+          AND reloid=REGEXP_REPLACE(given_name, '\D', '', 'g')::oid), 'g'), given_name);/*in func*/
   END;                                                                                    /*in func*/
 $$ LANGUAGE plpgsql;
 

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -7,7 +7,7 @@ test: test_pause_and_resume
 test: test_pause_and_resume_multiple_db
 test: test_drop_after_pause
 test: test_show_status
-# disable this tese due to GPDB behavior change
+# disable this test due to GPDB behavior change
 # test: test_table_size
 test: test_fast_disk_check
 #test: test_insert_after_drop
@@ -28,4 +28,5 @@ test: test_ctas_role
 test: test_ctas_schema
 test: test_ctas_tablespace_role
 test: test_ctas_tablespace_schema
+test: test_default_tablespace
 test: test_drop_extension

--- a/tests/regress/expected/test_default_tablespace.out
+++ b/tests/regress/expected/test_default_tablespace.out
@@ -1,0 +1,147 @@
+-- test role_tablespace_quota works with tables/databases in default tablespace
+-- test role_tablespace_quota works with tables/databases in non-default tablespace with hard limits on
+-- start_ignore
+\! mkdir -p /tmp/custom_tablespace
+-- end_ignore
+DROP ROLE if EXISTS role1;
+NOTICE:  role "role1" does not exist, skipping
+CREATE ROLE role1 SUPERUSER;
+SET ROLE role1;
+DROP TABLE if EXISTS t;
+NOTICE:  table "t" does not exist, skipping
+CREATE TABLE t (i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- with hard limits off
+SELECT diskquota.disable_hardlimit();
+ disable_hardlimit 
+-------------------
+ 
+(1 row)
+
+SELECT diskquota.set_role_tablespace_quota('role1', 'pg_default', '1 MB');
+ set_role_tablespace_quota 
+---------------------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+-- expect insert to success
+INSERT INTO t SELECT generate_series(1, 100);
+INSERT INTO t SELECT generate_series(1, 1000000);
+-- expect insert to fail
+INSERT INTO t SELECT generate_series(1, 1000000);
+ERROR:  tablespace:pg_default role:role1 diskquota exceeded
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- with hard limits on
+SELECT diskquota.enable_hardlimit();
+ enable_hardlimit 
+------------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+-- expect insert to fail
+INSERT INTO t SELECT generate_series(1, 1000000);
+ERROR:  tablespace:1663 role:3891527 diskquota exceeded  (seg1 127.0.0.1:6003 pid=8480)
+DROP TABLE IF EXISTS t;
+-- database in customized tablespace
+CREATE TABLESPACE custom_tablespace LOCATION '/tmp/custom_tablespace';
+CREATE DATABASE db_with_tablespace TABLESPACE custom_tablespace;
+\c db_with_tablespace;
+SET ROLE role1;
+CREATE EXTENSION diskquota;
+-- with hard limits off
+SELECT diskquota.disable_hardlimit();
+ disable_hardlimit 
+-------------------
+ 
+(1 row)
+
+SELECT diskquota.set_role_tablespace_quota('role1', 'custom_tablespace', '1 MB');
+ set_role_tablespace_quota 
+---------------------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+-- expect insert to success
+CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 100);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
+ rolname |      spcname      |      target_type      
+---------+-------------------+-----------------------
+ gpadmin | pg_default        | ROLE_TABLESPACE_QUOTA
+ role1   | custom_tablespace | ROLE_TABLESPACE_QUOTA
+(2 rows)
+
+-- expect insert to fail
+INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+ERROR:  tablespace:custom_tablespace role:role1 diskquota exceeded
+-- with hard limits on
+SELECT diskquota.enable_hardlimit();
+ enable_hardlimit 
+------------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+DROP TABLE IF EXISTS t_in_custom_tablespace;
+-- expect create table to fail
+CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 1000000);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  tablespace:custom_tablespace role:role1 diskquota exceeded
+select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
+ rolname |      spcname      |      target_type      
+---------+-------------------+-----------------------
+ gpadmin | pg_default        | ROLE_TABLESPACE_QUOTA
+ role1   | custom_tablespace | ROLE_TABLESPACE_QUOTA
+(2 rows)
+
+-- clean up
+DROP TABLE IF EXISTS t_in_custom_tablespace;
+NOTICE:  table "t_in_custom_tablespace" does not exist, skipping
+SELECT diskquota.disable_hardlimit();
+ disable_hardlimit 
+-------------------
+ 
+(1 row)
+
+DROP EXTENSION IF EXISTS diskquota;
+\c contrib_regression;
+DROP DATABASE IF EXISTS db_with_tablespace;
+DROP TABLESPACE IF EXISTS custom_tablespace;
+RESET ROLE;
+DROP ROLE IF EXISTS role1;
+SELECT diskquota.disable_hardlimit();
+ disable_hardlimit 
+-------------------
+ 
+(1 row)
+

--- a/tests/regress/expected/test_default_tablespace.out
+++ b/tests/regress/expected/test_default_tablespace.out
@@ -5,7 +5,10 @@
 -- end_ignore
 DROP ROLE if EXISTS role1;
 NOTICE:  role "role1" does not exist, skipping
+DROP ROLE if EXISTS role2;
+NOTICE:  role "role2" does not exist, skipping
 CREATE ROLE role1 SUPERUSER;
+CREATE ROLE role2 SUPERUSER;
 SET ROLE role1;
 DROP TABLE if EXISTS t;
 NOTICE:  table "t" does not exist, skipping
@@ -47,6 +50,13 @@ ORDER BY r.rolname, t.spcname, b.target_type;
 (1 row)
 
 DROP TABLE IF EXISTS t;
+SELECT diskquota.set_role_tablespace_quota('role1', 'pg_default', '-1');
+ set_role_tablespace_quota 
+---------------------------
+ 
+(1 row)
+
+SET ROLE role2;
 CREATE TABLE t (i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -57,16 +67,23 @@ SELECT diskquota.enable_hardlimit();
  
 (1 row)
 
+SELECT diskquota.set_role_tablespace_quota('role2', 'pg_default', '1 MB');
+ set_role_tablespace_quota 
+---------------------------
+ 
+(1 row)
+
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
  t
 (1 row)
 
--- expect insert to fail
-INSERT INTO t SELECT generate_series(1, 1000000);
-ERROR:  tablespace:1663 role:40553 diskquota exceeded  (seg0 127.0.0.1:6002 pid=13871)
+-- expect insert to fail because of hard limits
+INSERT INTO t SELECT generate_series(1, 50000000);
+ERROR:  tablespace:1663 role:414749 diskquota exceeded  (seg1 127.0.0.1:6003 pid=30142)
 DROP TABLE IF EXISTS t;
+SET ROLE role1;
 -- database in customized tablespace
 CREATE TABLESPACE custom_tablespace LOCATION '/tmp/custom_tablespace';
 CREATE DATABASE db_with_tablespace TABLESPACE custom_tablespace;
@@ -109,10 +126,30 @@ ORDER BY r.rolname, t.spcname, b.target_type;
  role1   | custom_tablespace | ROLE_TABLESPACE_QUOTA
 (1 row)
 
+DROP TABLE IF EXISTS t_in_custom_tablespace;
+SELECT diskquota.set_role_tablespace_quota('role1', 'custom_tablespace', '-1');
+ set_role_tablespace_quota 
+---------------------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SET ROLE role2;
 -- with hard limits on
 SELECT diskquota.enable_hardlimit();
  enable_hardlimit 
 ------------------
+ 
+(1 row)
+
+SELECT diskquota.set_role_tablespace_quota('role2', 'custom_tablespace', '1 MB');
+ set_role_tablespace_quota 
+---------------------------
  
 (1 row)
 
@@ -123,11 +160,12 @@ SELECT diskquota.wait_for_worker_new_epoch();
 (1 row)
 
 DROP TABLE IF EXISTS t_in_custom_tablespace;
--- expect create table to fail
-CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 1000000);
+NOTICE:  table "t_in_custom_tablespace" does not exist, skipping
+-- expect insert to fail because of hard limits
+CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 50000000);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  tablespace:custom_tablespace role:role1 diskquota exceeded
+ERROR:  tablespace:414756 role:414749 diskquota exceeded  (seg2 127.0.0.1:6004 pid=30156)
 -- clean up
 DROP TABLE IF EXISTS t_in_custom_tablespace;
 NOTICE:  table "t_in_custom_tablespace" does not exist, skipping
@@ -143,6 +181,7 @@ DROP DATABASE IF EXISTS db_with_tablespace;
 DROP TABLESPACE IF EXISTS custom_tablespace;
 RESET ROLE;
 DROP ROLE IF EXISTS role1;
+DROP ROLE IF EXISTS role2;
 SELECT diskquota.disable_hardlimit();
  disable_hardlimit 
 -------------------

--- a/tests/regress/expected/test_default_tablespace.out
+++ b/tests/regress/expected/test_default_tablespace.out
@@ -37,6 +37,19 @@ INSERT INTO t SELECT generate_series(1, 1000000);
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
 ERROR:  tablespace:pg_default role:role1 diskquota exceeded
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
+ rolname |  spcname   |      target_type      
+---------+------------+-----------------------
+ role1   | pg_default | ROLE_TABLESPACE_QUOTA
+ gpadmin | pg_default | ROLE_TABLESPACE_QUOTA
+(2 rows)
+
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
@@ -56,7 +69,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
-ERROR:  tablespace:1663 role:3891527 diskquota exceeded  (seg1 127.0.0.1:6003 pid=8480)
+ERROR:  tablespace:1663 role:4034486 diskquota exceeded  (seg1 127.0.0.1:6003 pid=32001)
 DROP TABLE IF EXISTS t;
 -- database in customized tablespace
 CREATE TABLESPACE custom_tablespace LOCATION '/tmp/custom_tablespace';
@@ -88,6 +101,15 @@ CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 100);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+-- expect insert to fail
+INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+ERROR:  tablespace:custom_tablespace role:role1 diskquota exceeded
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
  rolname |      spcname      |      target_type      
 ---------+-------------------+-----------------------
@@ -95,9 +117,6 @@ select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tabl
  role1   | custom_tablespace | ROLE_TABLESPACE_QUOTA
 (2 rows)
 
--- expect insert to fail
-INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
-ERROR:  tablespace:custom_tablespace role:role1 diskquota exceeded
 -- with hard limits on
 SELECT diskquota.enable_hardlimit();
  enable_hardlimit 
@@ -117,13 +136,6 @@ CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 1000000);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  tablespace:custom_tablespace role:role1 diskquota exceeded
-select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
- rolname |      spcname      |      target_type      
----------+-------------------+-----------------------
- gpadmin | pg_default        | ROLE_TABLESPACE_QUOTA
- role1   | custom_tablespace | ROLE_TABLESPACE_QUOTA
-(2 rows)
-
 -- clean up
 DROP TABLE IF EXISTS t_in_custom_tablespace;
 NOTICE:  table "t_in_custom_tablespace" does not exist, skipping

--- a/tests/regress/expected/test_default_tablespace.out
+++ b/tests/regress/expected/test_default_tablespace.out
@@ -37,17 +37,14 @@ INSERT INTO t SELECT generate_series(1, 1000000);
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
 ERROR:  tablespace:pg_default role:role1 diskquota exceeded
-SELECT diskquota.wait_for_worker_new_epoch();
- wait_for_worker_new_epoch 
----------------------------
- t
-(1 row)
-
-select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
+SELECT r.rolname, t.spcname, b.target_type
+FROM diskquota.blackmap AS b, pg_tablespace AS t, pg_roles AS r
+WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid
+ORDER BY r.rolname, t.spcname, b.target_type;
  rolname |  spcname   |      target_type      
 ---------+------------+-----------------------
- role1   | pg_default | ROLE_TABLESPACE_QUOTA
  gpadmin | pg_default | ROLE_TABLESPACE_QUOTA
+ role1   | pg_default | ROLE_TABLESPACE_QUOTA
 (2 rows)
 
 DROP TABLE IF EXISTS t;
@@ -69,7 +66,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
-ERROR:  tablespace:1663 role:4034486 diskquota exceeded  (seg1 127.0.0.1:6003 pid=32001)
+ERROR:  tablespace:1663 role:4104732 diskquota exceeded  (seg0 127.0.0.1:6002 pid=9481)
 DROP TABLE IF EXISTS t;
 -- database in customized tablespace
 CREATE TABLESPACE custom_tablespace LOCATION '/tmp/custom_tablespace';
@@ -104,13 +101,10 @@ INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
 -- expect insert to fail
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
 ERROR:  tablespace:custom_tablespace role:role1 diskquota exceeded
-SELECT diskquota.wait_for_worker_new_epoch();
- wait_for_worker_new_epoch 
----------------------------
- t
-(1 row)
-
-select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
+SELECT r.rolname, t.spcname, b.target_type
+FROM diskquota.blackmap AS b, pg_tablespace AS t, pg_roles AS r
+WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid
+ORDER BY r.rolname, t.spcname, b.target_type;
  rolname |      spcname      |      target_type      
 ---------+-------------------+-----------------------
  gpadmin | pg_default        | ROLE_TABLESPACE_QUOTA

--- a/tests/regress/expected/test_default_tablespace.out
+++ b/tests/regress/expected/test_default_tablespace.out
@@ -39,13 +39,12 @@ INSERT INTO t SELECT generate_series(1, 1000000);
 ERROR:  tablespace:pg_default role:role1 diskquota exceeded
 SELECT r.rolname, t.spcname, b.target_type
 FROM diskquota.blackmap AS b, pg_tablespace AS t, pg_roles AS r
-WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid
+WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid AND r.rolname = 'role1'
 ORDER BY r.rolname, t.spcname, b.target_type;
  rolname |  spcname   |      target_type      
 ---------+------------+-----------------------
- gpadmin | pg_default | ROLE_TABLESPACE_QUOTA
  role1   | pg_default | ROLE_TABLESPACE_QUOTA
-(2 rows)
+(1 row)
 
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (i int);
@@ -66,7 +65,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
-ERROR:  tablespace:1663 role:4104732 diskquota exceeded  (seg0 127.0.0.1:6002 pid=9481)
+ERROR:  tablespace:1663 role:40553 diskquota exceeded  (seg0 127.0.0.1:6002 pid=13871)
 DROP TABLE IF EXISTS t;
 -- database in customized tablespace
 CREATE TABLESPACE custom_tablespace LOCATION '/tmp/custom_tablespace';
@@ -103,13 +102,12 @@ INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
 ERROR:  tablespace:custom_tablespace role:role1 diskquota exceeded
 SELECT r.rolname, t.spcname, b.target_type
 FROM diskquota.blackmap AS b, pg_tablespace AS t, pg_roles AS r
-WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid
+WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid AND r.rolname = 'role1'
 ORDER BY r.rolname, t.spcname, b.target_type;
  rolname |      spcname      |      target_type      
 ---------+-------------------+-----------------------
- gpadmin | pg_default        | ROLE_TABLESPACE_QUOTA
  role1   | custom_tablespace | ROLE_TABLESPACE_QUOTA
-(2 rows)
+(1 row)
 
 -- with hard limits on
 SELECT diskquota.enable_hardlimit();

--- a/tests/regress/expected/test_tablespace_role.out
+++ b/tests/regress/expected/test_tablespace_role.out
@@ -8,9 +8,7 @@ CREATE TABLESPACE rolespc LOCATION '/tmp/rolespc';
 CREATE SCHEMA rolespcrole;
 SET search_path TO rolespcrole;
 DROP ROLE IF EXISTS rolespcu1;
-NOTICE:  role "rolespcu1" does not exist, skipping
 DROP ROLE IF EXISTS rolespcu2;
-NOTICE:  role "rolespcu2" does not exist, skipping
 CREATE ROLE rolespcu1 NOLOGIN;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE rolespcu2 NOLOGIN;
@@ -52,7 +50,7 @@ ERROR:  tablespace:rolespc role:rolespcu1 diskquota exceeded
 -- expect insert fail
 INSERT INTO b2 SELECT generate_series(1,100);
 ERROR:  tablespace:rolespc role:rolespcu1 diskquota exceeded
--- Test show_fast_schema_tablespace_quota_view
+-- Test show_fast_role_tablespace_quota_view
 SELECT role_name, tablespace_name, quota_in_mb, rolsize_tablespace_in_bytes FROM diskquota.show_fast_role_tablespace_quota_view WHERE role_name = 'rolespcu1' and tablespace_name = 'rolespc';
  role_name | tablespace_name | quota_in_mb | rolsize_tablespace_in_bytes 
 -----------+-----------------+-------------+-----------------------------

--- a/tests/regress/sql/test_default_tablespace.sql
+++ b/tests/regress/sql/test_default_tablespace.sql
@@ -19,6 +19,8 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to success
 INSERT INTO t SELECT generate_series(1, 100);
 INSERT INTO t SELECT generate_series(1, 1000000);
+SELECT diskquota.wait_for_worker_new_epoch();
+select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
 
@@ -46,6 +48,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to success
 CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 100);
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+SELECT diskquota.wait_for_worker_new_epoch();
 select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
 -- expect insert to fail
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
@@ -57,7 +60,6 @@ SELECT diskquota.wait_for_worker_new_epoch();
 DROP TABLE IF EXISTS t_in_custom_tablespace;
 -- expect create table to fail
 CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 1000000);
-select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
 
 -- clean up
 DROP TABLE IF EXISTS t_in_custom_tablespace;

--- a/tests/regress/sql/test_default_tablespace.sql
+++ b/tests/regress/sql/test_default_tablespace.sql
@@ -24,7 +24,7 @@ INSERT INTO t SELECT generate_series(1, 1000000);
 
 SELECT r.rolname, t.spcname, b.target_type
 FROM diskquota.blackmap AS b, pg_tablespace AS t, pg_roles AS r
-WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid
+WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid AND r.rolname = 'role1'
 ORDER BY r.rolname, t.spcname, b.target_type;
 
 DROP TABLE IF EXISTS t;
@@ -56,7 +56,7 @@ INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
 
 SELECT r.rolname, t.spcname, b.target_type
 FROM diskquota.blackmap AS b, pg_tablespace AS t, pg_roles AS r
-WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid
+WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid AND r.rolname = 'role1'
 ORDER BY r.rolname, t.spcname, b.target_type;
 
 -- with hard limits on

--- a/tests/regress/sql/test_default_tablespace.sql
+++ b/tests/regress/sql/test_default_tablespace.sql
@@ -19,10 +19,10 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to success
 INSERT INTO t SELECT generate_series(1, 100);
 INSERT INTO t SELECT generate_series(1, 1000000);
-SELECT diskquota.wait_for_worker_new_epoch();
-select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
+SELECT diskquota.wait_for_worker_new_epoch();
+select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
 
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (i int);
@@ -48,10 +48,10 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to success
 CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 100);
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
-SELECT diskquota.wait_for_worker_new_epoch();
-select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
 -- expect insert to fail
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+SELECT diskquota.wait_for_worker_new_epoch();
+select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
 
 -- with hard limits on
 SELECT diskquota.enable_hardlimit();

--- a/tests/regress/sql/test_default_tablespace.sql
+++ b/tests/regress/sql/test_default_tablespace.sql
@@ -21,8 +21,11 @@ INSERT INTO t SELECT generate_series(1, 100);
 INSERT INTO t SELECT generate_series(1, 1000000);
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
-SELECT diskquota.wait_for_worker_new_epoch();
-select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
+
+SELECT r.rolname, t.spcname, b.target_type
+FROM diskquota.blackmap AS b, pg_tablespace AS t, pg_roles AS r
+WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid
+ORDER BY r.rolname, t.spcname, b.target_type;
 
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (i int);
@@ -50,8 +53,11 @@ CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 100);
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
 -- expect insert to fail
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
-SELECT diskquota.wait_for_worker_new_epoch();
-select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
+
+SELECT r.rolname, t.spcname, b.target_type
+FROM diskquota.blackmap AS b, pg_tablespace AS t, pg_roles AS r
+WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid
+ORDER BY r.rolname, t.spcname, b.target_type;
 
 -- with hard limits on
 SELECT diskquota.enable_hardlimit();

--- a/tests/regress/sql/test_default_tablespace.sql
+++ b/tests/regress/sql/test_default_tablespace.sql
@@ -1,0 +1,73 @@
+-- test role_tablespace_quota works with tables/databases in default tablespace
+-- test role_tablespace_quota works with tables/databases in non-default tablespace with hard limits on
+
+-- start_ignore
+\! mkdir -p /tmp/custom_tablespace
+-- end_ignore
+
+DROP ROLE if EXISTS role1;
+CREATE ROLE role1 SUPERUSER;
+SET ROLE role1;
+
+DROP TABLE if EXISTS t;
+CREATE TABLE t (i int);
+
+-- with hard limits off
+SELECT diskquota.disable_hardlimit();
+SELECT diskquota.set_role_tablespace_quota('role1', 'pg_default', '1 MB');
+SELECT diskquota.wait_for_worker_new_epoch();
+-- expect insert to success
+INSERT INTO t SELECT generate_series(1, 100);
+INSERT INTO t SELECT generate_series(1, 1000000);
+-- expect insert to fail
+INSERT INTO t SELECT generate_series(1, 1000000);
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (i int);
+
+-- with hard limits on
+SELECT diskquota.enable_hardlimit();
+SELECT diskquota.wait_for_worker_new_epoch();
+-- expect insert to fail
+INSERT INTO t SELECT generate_series(1, 1000000);
+DROP TABLE IF EXISTS t;
+
+-- database in customized tablespace
+CREATE TABLESPACE custom_tablespace LOCATION '/tmp/custom_tablespace';
+CREATE DATABASE db_with_tablespace TABLESPACE custom_tablespace;
+\c db_with_tablespace;
+SET ROLE role1;
+CREATE EXTENSION diskquota;
+
+-- with hard limits off
+SELECT diskquota.disable_hardlimit();
+SELECT diskquota.set_role_tablespace_quota('role1', 'custom_tablespace', '1 MB');
+SELECT diskquota.wait_for_worker_new_epoch();
+-- expect insert to success
+CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 100);
+INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
+-- expect insert to fail
+INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+
+-- with hard limits on
+SELECT diskquota.enable_hardlimit();
+SELECT diskquota.wait_for_worker_new_epoch();
+
+DROP TABLE IF EXISTS t_in_custom_tablespace;
+-- expect create table to fail
+CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 1000000);
+select r.rolname, t.spcname, b.target_type from diskquota.blackmap as b, pg_tablespace as t, pg_roles as r where b.tablespace_oid = t.oid and b.target_oid = r.oid;
+
+-- clean up
+DROP TABLE IF EXISTS t_in_custom_tablespace;
+SELECT diskquota.disable_hardlimit();
+DROP EXTENSION IF EXISTS diskquota;
+\c contrib_regression;
+DROP DATABASE IF EXISTS db_with_tablespace;
+DROP TABLESPACE IF EXISTS custom_tablespace;
+
+RESET ROLE;
+DROP ROLE IF EXISTS role1;
+
+SELECT diskquota.disable_hardlimit();

--- a/tests/regress/sql/test_default_tablespace.sql
+++ b/tests/regress/sql/test_default_tablespace.sql
@@ -69,7 +69,7 @@ ORDER BY r.rolname, t.spcname, b.target_type;
 DROP TABLE IF EXISTS t_in_custom_tablespace;
 SELECT diskquota.set_role_tablespace_quota('role1', 'custom_tablespace', '-1');
 SELECT diskquota.wait_for_worker_new_epoch();
-
+-- change to another role
 SET ROLE role2;
 
 -- with hard limits on

--- a/tests/regress/sql/test_default_tablespace.sql
+++ b/tests/regress/sql/test_default_tablespace.sql
@@ -6,7 +6,9 @@
 -- end_ignore
 
 DROP ROLE if EXISTS role1;
+DROP ROLE if EXISTS role2;
 CREATE ROLE role1 SUPERUSER;
+CREATE ROLE role2 SUPERUSER;
 SET ROLE role1;
 
 DROP TABLE if EXISTS t;
@@ -28,15 +30,20 @@ WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid AND r.rolname = 'role1'
 ORDER BY r.rolname, t.spcname, b.target_type;
 
 DROP TABLE IF EXISTS t;
+SELECT diskquota.set_role_tablespace_quota('role1', 'pg_default', '-1');
+
+SET ROLE role2;
 CREATE TABLE t (i int);
 
 -- with hard limits on
 SELECT diskquota.enable_hardlimit();
+SELECT diskquota.set_role_tablespace_quota('role2', 'pg_default', '1 MB');
 SELECT diskquota.wait_for_worker_new_epoch();
--- expect insert to fail
-INSERT INTO t SELECT generate_series(1, 1000000);
+-- expect insert to fail because of hard limits
+INSERT INTO t SELECT generate_series(1, 50000000);
 DROP TABLE IF EXISTS t;
 
+SET ROLE role1;
 -- database in customized tablespace
 CREATE TABLESPACE custom_tablespace LOCATION '/tmp/custom_tablespace';
 CREATE DATABASE db_with_tablespace TABLESPACE custom_tablespace;
@@ -59,13 +66,20 @@ FROM diskquota.blackmap AS b, pg_tablespace AS t, pg_roles AS r
 WHERE b.tablespace_oid = t.oid AND b.target_oid = r.oid AND r.rolname = 'role1'
 ORDER BY r.rolname, t.spcname, b.target_type;
 
+DROP TABLE IF EXISTS t_in_custom_tablespace;
+SELECT diskquota.set_role_tablespace_quota('role1', 'custom_tablespace', '-1');
+SELECT diskquota.wait_for_worker_new_epoch();
+
+SET ROLE role2;
+
 -- with hard limits on
 SELECT diskquota.enable_hardlimit();
+SELECT diskquota.set_role_tablespace_quota('role2', 'custom_tablespace', '1 MB');
 SELECT diskquota.wait_for_worker_new_epoch();
 
 DROP TABLE IF EXISTS t_in_custom_tablespace;
--- expect create table to fail
-CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 1000000);
+-- expect insert to fail because of hard limits
+CREATE TABLE t_in_custom_tablespace AS SELECT generate_series(1, 50000000);
 
 -- clean up
 DROP TABLE IF EXISTS t_in_custom_tablespace;
@@ -77,5 +91,6 @@ DROP TABLESPACE IF EXISTS custom_tablespace;
 
 RESET ROLE;
 DROP ROLE IF EXISTS role1;
+DROP ROLE IF EXISTS role2;
 
 SELECT diskquota.disable_hardlimit();

--- a/tests/regress/sql/test_tablespace_role.sql
+++ b/tests/regress/sql/test_tablespace_role.sql
@@ -29,7 +29,7 @@ INSERT INTO b SELECT generate_series(1,100);
 -- expect insert fail
 INSERT INTO b2 SELECT generate_series(1,100);
 
--- Test show_fast_schema_tablespace_quota_view
+-- Test show_fast_role_tablespace_quota_view
 SELECT role_name, tablespace_name, quota_in_mb, rolsize_tablespace_in_bytes FROM diskquota.show_fast_role_tablespace_quota_view WHERE role_name = 'rolespcu1' and tablespace_name = 'rolespc';
 
 -- Test alter owner


### PR DESCRIPTION
- Make diskquota work for "pg_default" tablespace (#133)
- trigger CI
- trigger CI
- only check blackmap with hardlimits off
- update expected output for test_default_tablespace
- remove redundant wait_for_worker_new_epoch and sort blackmap output
- only show blackmap we care
- add another role to test hardlimit
- trigger CI
- trigger CI
- trigger CI
- trigger CI
- trigger CI
- trigger CI
- trigger CI
- add an useless comment to test_default_tablespace.sql
