### PR TITLE
Extend fetch_table_stat() to update db cache v2

### DIFF
--- a/diskquota--1.0.sql
+++ b/diskquota--1.0.sql
@@ -21,11 +21,6 @@ RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE FUNCTION diskquota.update_diskquota_db_list(oid, int4)
-RETURNS void STRICT
-AS 'MODULE_PATHNAME'
-LANGUAGE C;
-
 CREATE TABLE diskquota.table_size (tableid oid, size bigint, PRIMARY KEY(tableid));
 
 CREATE TABLE diskquota.state (state int, PRIMARY KEY(state));

--- a/diskquota--1.0.sql
+++ b/diskquota--1.0.sql
@@ -21,6 +21,11 @@ RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
+CREATE FUNCTION diskquota.update_diskquota_db_list(oid, int4)
+RETURNS void STRICT
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
 CREATE TABLE diskquota.table_size (tableid oid, size bigint, PRIMARY KEY(tableid));
 
 CREATE TABLE diskquota.state (state int, PRIMARY KEY(state));

--- a/diskquota--2.0.sql
+++ b/diskquota--2.0.sql
@@ -43,11 +43,6 @@ RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE FUNCTION diskquota.update_diskquota_db_list(oid, int4)
-RETURNS void STRICT
-AS 'MODULE_PATHNAME'
-LANGUAGE C;
-
 CREATE TYPE diskquota.blackmap_entry AS
   (target_oid oid, database_oid oid, tablespace_oid oid, target_type integer, seg_exceeded boolean);
 CREATE FUNCTION diskquota.refresh_blackmap(diskquota.blackmap_entry[], oid[])

--- a/diskquota.c
+++ b/diskquota.c
@@ -129,14 +129,14 @@ _PG_init(void)
 	init_disk_quota_enforcement();
 	init_active_table_hook();
 
+	/* Add dq_object_access_hook to handle drop extension event. */
+	register_diskquota_object_access_hook();
+
 	/* start disk quota launcher only on master */
 	if (!IS_QUERY_DISPATCHER())
 	{
 		return;
 	}
-
-	/* Add dq_object_access_hook to handle drop extension event. */
-	register_diskquota_object_access_hook();
 
 	/* set up common data for diskquota launcher worker */
 	worker.bgw_flags = BGWORKER_SHMEM_ACCESS |

--- a/diskquota.c
+++ b/diskquota.c
@@ -523,10 +523,7 @@ create_monitor_db_table(void)
 	bool		ret = true;
 
 	sql = "create schema if not exists diskquota_namespace;"
-		"create table if not exists diskquota_namespace.database_list(dbid oid not null unique);"
-		"create schema if not exists diskquota;"
-		"create or replace function diskquota.update_diskquota_db_list(oid, int4) returns void "
-		"strict as '$libdir/diskquota' language C;";
+		"create table if not exists diskquota_namespace.database_list(dbid oid not null unique);";
 
 	StartTransactionCommand();
 
@@ -891,15 +888,6 @@ del_dbid_from_database_list(Oid dbid)
 	{
 		ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute sql:'%s', errno:%d", str.data, errno)));
 	}
-	pfree(str.data);
-
-	/* clean the dbid from shared memory*/
-	initStringInfo(&str);
-	appendStringInfo(&str, "select gp_segment_id, diskquota.update_diskquota_db_list(%u, 1)"
-			" from gp_dist_random('gp_id');", dbid);
-	ret = SPI_execute(str.data, true, 0);
-	if (ret != SPI_OK_SELECT)
-		ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute sql:'%s', errno:%d", str.data, errno)));
 	pfree(str.data);
 }
 

--- a/diskquota.h
+++ b/diskquota.h
@@ -32,7 +32,9 @@ typedef enum
 typedef enum
 {
 	FETCH_ACTIVE_OID,			/* fetch active table list */
-	FETCH_ACTIVE_SIZE			/* fetch size for active tables */
+	FETCH_ACTIVE_SIZE,			/* fetch size for active tables */
+	ADD_DB_TO_MONITOR,
+	REMOVE_MONITORED_DB,
 }			FetchTableStatType;
 
 typedef enum

--- a/diskquota.h
+++ b/diskquota.h
@@ -34,7 +34,7 @@ typedef enum
 	FETCH_ACTIVE_OID,			/* fetch active table list */
 	FETCH_ACTIVE_SIZE,			/* fetch size for active tables */
 	ADD_DB_TO_MONITOR,
-	REMOVE_MONITORED_DB,
+	REMOVE_DB_FROM_BEING_MONITORED,
 }			FetchTableStatType;
 
 typedef enum

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -505,6 +505,11 @@ dq_object_access_hook(ObjectAccessType access, Oid classId,
 	 */
 	update_diskquota_db_list(MyDatabaseId, HASH_REMOVE);
 
+	if (!IS_QUERY_DISPATCHER())
+	{
+		return;
+	}
+
 	/*
 	 * Lock on extension_ddl_lock to avoid multiple backend create diskquota
 	 * extension at the same time.

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -1039,8 +1039,7 @@ update_diskquota_db_list(Oid dbid, HASHACTION action)
 	{	
 		Oid *entry = NULL;
 		entry = hash_search(monitoring_dbid_cache, &dbid, HASH_ENTER_NULL, &found);
-		elog(WARNING, "add dbid %u into SHM", dbid);
-		if (!found && entry == NULL)
+		if (entry == NULL)
 		{
 			ereport(WARNING,
 				(errmsg("can't alloc memory on dbid cache, there ary too many databases to monitor")));

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -361,9 +361,9 @@ gp_fetch_active_tables(bool is_init)
  * active tables in the current database will be recorded. This is used each
  * time a worker starts.
  * 
- * - REMOVE_MONITORED_DB: remove MyDatabaseId from the monitored db cache so 
- * that active tables in the current database will be recorded. This is used
- * when DROP EXTENSION. 
+ * - REMOVE_DB_FROM_BEING_MONITORED: remove MyDatabaseId from the monitored 
+ * db cache so that active tables in the current database will be recorded. 
+ * This is used when DROP EXTENSION. 
  */
 Datum
 diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
@@ -414,7 +414,7 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 			case ADD_DB_TO_MONITOR:
 				update_diskquota_db_list(MyDatabaseId, HASH_ENTER);
 				break;
-			case REMOVE_MONITORED_DB:
+			case REMOVE_DB_FROM_BEING_MONITORED:
 				update_diskquota_db_list(MyDatabaseId, HASH_REMOVE);
 				break;
 			default:

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -348,11 +348,22 @@ gp_fetch_active_tables(bool is_init)
 
 /*
  * Function to get the table size from each segments
- * There are three mode:
- * 1. gather active table oid from all the segments, since table may only
- * be modified on a subset of the segments, we need to firstly gather the
- * active table oid list from all the segments.
- * 2. calculate the active table size based on the active table oid list.
+ * There are 4 modes:
+ * 
+ * - FETCH_ACTIVE_OID: gather active table oid from all the segments, since 
+ * table may only be modified on a subset of the segments, we need to firstly
+ * gather the active table oid list from all the segments.
+ * 
+ * - FETCH_ACTIVE_SIZE: calculate the active table size based on the active
+ * table oid list.
+ * 
+ * - ADD_DB_TO_MONITOR: add MyDatabaseId to the monitored db cache so that 
+ * active tables in the current database will be recorded. This is used each
+ * time a worker starts.
+ * 
+ * - REMOVE_MONITORED_DB: remove MyDatabaseId from the monitored db cache so 
+ * that active tables in the current database will be recorded. This is used
+ * when DROP EXTENSION. 
  */
 Datum
 diskquota_fetch_table_stat(PG_FUNCTION_ARGS)

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -400,6 +400,12 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 			case FETCH_ACTIVE_SIZE:
 				localCacheTable = get_active_tables_stats(PG_GETARG_ARRAYTYPE_P(1));
 				break;
+			case ADD_DB_TO_MONITOR:
+				update_diskquota_db_list(MyDatabaseId, HASH_ENTER);
+				break;
+			case REMOVE_MONITORED_DB:
+				update_diskquota_db_list(MyDatabaseId, HASH_REMOVE);
+				break;
 			default:
 				ereport(ERROR, (errmsg("Unused mode number, transaction will be aborted")));
 				break;
@@ -410,7 +416,7 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 		 * total number of active tables to be returned, each tuple contains
 		 * one active table stat
 		 */
-		funcctx->max_calls = (uint32) hash_get_num_entries(localCacheTable);
+		funcctx->max_calls = localCacheTable ? (uint32) hash_get_num_entries(localCacheTable) : 0;
 
 		/*
 		 * prepare attribute metadata for next calls that generate the tuple

--- a/gp_activetable.h
+++ b/gp_activetable.h
@@ -29,7 +29,7 @@ extern HTAB *gp_fetch_active_tables(bool force);
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
-extern bool update_diskquota_db_list(Oid dbid, HASHACTION action);
+extern void update_diskquota_db_list(Oid dbid, HASHACTION action);
 
 extern HTAB *active_tables_map;
 extern HTAB *monitoring_dbid_cache;

--- a/gp_activetable.h
+++ b/gp_activetable.h
@@ -29,6 +29,7 @@ extern HTAB *gp_fetch_active_tables(bool force);
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
+extern bool update_diskquota_db_list(Oid dbid, HASHACTION action);
 
 extern HTAB *active_tables_map;
 extern HTAB *monitoring_dbid_cache;

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -627,9 +627,11 @@ do_check_diskquota_state_is_ready(void)
 					"SELECT diskquota.diskquota_fetch_table_stat(%d, ARRAY[]::oid[]) "
 					"FROM gp_dist_random('gp_id');", ADD_DB_TO_MONITOR);
 	ret = SPI_execute(sql_command.data, true, 0);
-    if (ret != SPI_OK_SELECT)
-        ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-            	errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
+	if (ret != SPI_OK_SELECT) {
+		pfree(sql_command.data);
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+				errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
+    }
 	pfree(sql_command.data);
 	/* Add current database to the monitored db cache on coordinator */
 	update_diskquota_db_list(MyDatabaseId, HASH_ENTER);

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -631,7 +631,7 @@ do_check_diskquota_state_is_ready(void)
 		pfree(sql_command.data);
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 				errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
-    }
+	}
 	pfree(sql_command.data);
 	/* Add current database to the monitored db cache on coordinator */
 	update_diskquota_db_list(MyDatabaseId, HASH_ENTER);

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -623,13 +623,15 @@ do_check_diskquota_state_is_ready(void)
 
 	/* Add the dbid to watching list, so the hook can catch the table change*/
 	initStringInfo(&sql_command);
-	appendStringInfo(&sql_command, "select gp_segment_id, diskquota.update_diskquota_db_list(%u, 0) from gp_dist_random('gp_id')  UNION ALL select -1, diskquota.update_diskquota_db_list(%u, 0);",
-				MyDatabaseId, MyDatabaseId);
+	appendStringInfo(&sql_command, 
+					"SELECT diskquota.diskquota_fetch_table_stat(%d, ARRAY[]::oid[]) "
+					"FROM gp_dist_random('gp_id');", ADD_DB_TO_MONITOR);
 	ret = SPI_execute(sql_command.data, true, 0);
-        if (ret != SPI_OK_SELECT)
-                ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-                                                errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
+    if (ret != SPI_OK_SELECT)
+        ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+            	errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
 	pfree(sql_command.data);
+	update_diskquota_db_list(MyDatabaseId, HASH_ENTER);
 	/*
 	 * check diskquota state from table diskquota.state errors will be catch
 	 * at upper level function.

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -621,8 +621,8 @@ do_check_diskquota_state_is_ready(void)
 	int			i;
 	StringInfoData sql_command;
 
-	/* Add the dbid to watching list, so the hook can catch the table change*/
 	initStringInfo(&sql_command);
+	/* Add current database to the monitored db cache on all segments */
 	appendStringInfo(&sql_command, 
 					"SELECT diskquota.diskquota_fetch_table_stat(%d, ARRAY[]::oid[]) "
 					"FROM gp_dist_random('gp_id');", ADD_DB_TO_MONITOR);
@@ -631,6 +631,7 @@ do_check_diskquota_state_is_ready(void)
         ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
             	errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
 	pfree(sql_command.data);
+	/* Add current database to the monitored db cache on coordinator */
 	update_diskquota_db_list(MyDatabaseId, HASH_ENTER);
 	/*
 	 * check diskquota state from table diskquota.state errors will be catch

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -7,6 +7,7 @@ test: test_pause_and_resume
 test: test_pause_and_resume_multiple_db
 test: test_drop_after_pause
 test: test_show_status
+test: test_update_db_cache
 # disable this tese due to GPDB behavior change
 # test: test_table_size
 test: test_fast_disk_check

--- a/tests/regress/expected/test_update_db_cache.out
+++ b/tests/regress/expected/test_update_db_cache.out
@@ -1,0 +1,43 @@
+--start_ignore
+CREATE DATABASE test_db_cache;
+--end_ignore
+\c test_db_cache
+CREATE EXTENSION diskquota;
+CREATE TABLE t(i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size
+WHERE tableid = 't'::regclass
+ORDER BY segid;
+ tableid |  size   | segid 
+---------+---------+-------
+ t       | 3637248 |    -1
+ t       | 1212416 |     0
+ t       | 1212416 |     1
+ t       | 1212416 |     2
+(4 rows)
+
+DROP EXTENSION diskquota;
+-- Create table without extension
+CREATE TABLE t_no_extension(i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+CREATE EXTENSION diskquota;
+WARNING:  database is not empty, please run `select diskquota.init_table_size_table()` to initialize table_size information for diskquota extension. Note that for large database, this function may take a long time.
+-- Should find nothing since t_no_extension is not recorded.
+SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
+FROM gp_dist_random('gp_id');
+ diskquota_fetch_table_stat 
+----------------------------
+(0 rows)
+
+DROP TABLE t;
+DROP TABLE t_no_extension;
+DROP EXTENSION diskquota;
+\c contrib_regression
+DROP DATABASE test_db_cache;

--- a/tests/regress/expected/test_update_db_cache.out
+++ b/tests/regress/expected/test_update_db_cache.out
@@ -29,6 +29,17 @@ CREATE TABLE t_no_extension(i) AS SELECT generate_series(1, 100000)
 DISTRIBUTED BY (i);
 CREATE EXTENSION diskquota;
 WARNING:  database is not empty, please run `select diskquota.init_table_size_table()` to initialize table_size information for diskquota extension. Note that for large database, this function may take a long time.
+-- Sleep until the worker adds the current db to cache so that it can be found 
+-- when DROP EXTENSION.
+-- FIXME: We cannot use wait_for_worker_new_epoch() here because 
+-- diskquota.state is not clean. Change sleep() to wait() after removing
+-- diskquota.state
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 -- Should find nothing since t_no_extension is not recorded.
 SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
 FROM gp_dist_random('gp_id');

--- a/tests/regress/sql/test_update_db_cache.sql
+++ b/tests/regress/sql/test_update_db_cache.sql
@@ -23,6 +23,13 @@ DISTRIBUTED BY (i);
 
 CREATE EXTENSION diskquota;
 
+-- Sleep until the worker adds the current db to cache so that it can be found 
+-- when DROP EXTENSION.
+-- FIXME: We cannot use wait_for_worker_new_epoch() here because 
+-- diskquota.state is not clean. Change sleep() to wait() after removing
+-- diskquota.state
+SELECT pg_sleep(1);
+
 -- Should find nothing since t_no_extension is not recorded.
 SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
 FROM gp_dist_random('gp_id');

--- a/tests/regress/sql/test_update_db_cache.sql
+++ b/tests/regress/sql/test_update_db_cache.sql
@@ -1,0 +1,36 @@
+--start_ignore
+CREATE DATABASE test_db_cache;
+--end_ignore
+
+\c test_db_cache
+CREATE EXTENSION diskquota;
+
+CREATE TABLE t(i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+
+SELECT diskquota.wait_for_worker_new_epoch();
+
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size
+WHERE tableid = 't'::regclass
+ORDER BY segid;
+
+DROP EXTENSION diskquota;
+
+-- Create table without extension
+CREATE TABLE t_no_extension(i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+
+CREATE EXTENSION diskquota;
+
+-- Should find nothing since t_no_extension is not recorded.
+SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
+FROM gp_dist_random('gp_id');
+
+DROP TABLE t;
+DROP TABLE t_no_extension;
+
+DROP EXTENSION diskquota;
+
+\c contrib_regression
+DROP DATABASE test_db_cache;


### PR DESCRIPTION
The db cache stores which databases enables diskquota. Active tables
will be recorded only if they are in those databases. Previously,
we created a new UDF update_diskquota_db_list() to add the current db
to the cache. However, the UDF is install in a wrong database. As a
result, after the user upgrade from a previous version to 1.0.3, the
bgworker does not find the UDF and can do nothing.

This patch fixes the issue by removing update_diskquota_db_list() and
using fetch_table_stat() to update db cache. fetch_table_stat() already
exists since version 1.0.0 so that no new UDF is needed.

This PR is a revision of PR #138  , and depends on #130 to fix a race
condition that occurs after CREATE EXTENSION.