### PR TITLE
Wait after CREATE EXTENSION

### DIFF
--- a/tests/regress/expected/test_update_db_cache.out
+++ b/tests/regress/expected/test_update_db_cache.out
@@ -3,6 +3,13 @@ CREATE DATABASE test_db_cache;
 --end_ignore
 \c test_db_cache
 CREATE EXTENSION diskquota;
+-- Wait until the db cache gets updated 
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 CREATE TABLE t(i) AS SELECT generate_series(1, 100000)
 DISTRIBUTED BY (i);
 SELECT diskquota.wait_for_worker_new_epoch();

--- a/tests/regress/sql/test_update_db_cache.sql
+++ b/tests/regress/sql/test_update_db_cache.sql
@@ -5,6 +5,9 @@ CREATE DATABASE test_db_cache;
 \c test_db_cache
 CREATE EXTENSION diskquota;
 
+-- Wait until the db cache gets updated 
+SELECT diskquota.wait_for_worker_new_epoch();
+
 CREATE TABLE t(i) AS SELECT generate_series(1, 100000)
 DISTRIBUTED BY (i);
 


### PR DESCRIPTION
Each time after CREATE EXTENSION, we need to wait until the db cache
gets updated. Otherwise no active table will be recorded.