### PR TITLE
Extend fetch_table_stat() to update db cache v2 (#151)

### DIFF
--- a/diskquota--1.0.sql
+++ b/diskquota--1.0.sql
@@ -21,6 +21,9 @@ RETURNS void STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
+-- This UDF won't be used. But we keep it here so that it would be the same with
+-- 1.0.3. Easier for 2.x upgrade design. Be notice that, the C function is not
+-- there anymore, calling this UDF will report an error
 CREATE FUNCTION diskquota.update_diskquota_db_list(oid, int4)
 RETURNS void STRICT
 AS 'MODULE_PATHNAME'

--- a/diskquota.c
+++ b/diskquota.c
@@ -133,14 +133,14 @@ _PG_init(void)
 	init_disk_quota_enforcement();
 	init_active_table_hook();
 
+	/* Add dq_object_access_hook to handle drop extension event. */
+	register_diskquota_object_access_hook();
+
 	/* start disk quota launcher only on master */
 	if (!IS_QUERY_DISPATCHER())
 	{
 		return;
 	}
-
-	/* Add dq_object_access_hook to handle drop extension event. */
-	register_diskquota_object_access_hook();
 
 	/* set up common data for diskquota launcher worker */
 	worker.bgw_flags = BGWORKER_SHMEM_ACCESS |
@@ -538,10 +538,7 @@ create_monitor_db_table(void)
 	bool		ret = true;
 
 	sql = "create schema if not exists diskquota_namespace;"
-		"create table if not exists diskquota_namespace.database_list(dbid oid not null unique);"
-		"create schema if not exists diskquota;"
-		"create or replace function diskquota.update_diskquota_db_list(oid, int4) returns void "
-		"strict as '$libdir/diskquota' language C;";
+		"create table if not exists diskquota_namespace.database_list(dbid oid not null unique);";
 
 	StartTransactionCommand();
 
@@ -889,15 +886,6 @@ del_dbid_from_database_list(Oid dbid)
 	{
 		ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute sql:'%s', errno:%d", str.data, errno)));
 	}
-	pfree(str.data);
-
-	/* clean the dbid from shared memory*/
-	initStringInfo(&str);
-	appendStringInfo(&str, "select gp_segment_id, diskquota.update_diskquota_db_list(%u, 1)"
-			" from gp_dist_random('gp_id');", dbid);
-	ret = SPI_execute(str.data, true, 0);
-	if (ret != SPI_OK_SELECT)
-		ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute sql:'%s', errno:%d", str.data, errno)));
 	pfree(str.data);
 }
 

--- a/diskquota.h
+++ b/diskquota.h
@@ -15,7 +15,9 @@ typedef enum
 typedef enum
 {
 	FETCH_ACTIVE_OID,			/* fetch active table list */
-	FETCH_ACTIVE_SIZE			/* fetch size for active tables */
+	FETCH_ACTIVE_SIZE,			/* fetch size for active tables */
+	ADD_DB_TO_MONITOR,
+	REMOVE_DB_FROM_BEING_MONITORED,
 }			FetchTableStatType;
 
 typedef enum

--- a/diskquota_schedule
+++ b/diskquota_schedule
@@ -1,5 +1,6 @@
 test: init
 test: prepare
+test: test_update_db_cache
 # disable this tese due to GPDB behavior change
 # test: test_table_size
 test: test_fast_disk_check

--- a/expected/test_primary_failure.out
+++ b/expected/test_primary_failure.out
@@ -280,3 +280,12 @@ DROP SCHEMA ftsr CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to function pg_ctl(text,text,text)
 drop cascades to function pg_recoverseg(text,text)
+-- FIXME: The dbid cache won't be dispatched automatically while switching mirrors.
+-- Do a ADD_DB_TO_MONITOR manually here, otherwise warning:
+-- "cannot remove the database from db list, dbid not found"
+-- will be emitted in the clean test.
+SELECT diskquota.diskquota_fetch_table_stat(2, ARRAY[]::oid[]) FROM gp_dist_random('gp_id');
+ diskquota_fetch_table_stat 
+----------------------------
+(0 rows)
+

--- a/expected/test_update_db_cache.out
+++ b/expected/test_update_db_cache.out
@@ -1,0 +1,56 @@
+--start_ignore
+CREATE DATABASE test_db_cache;
+--end_ignore
+\c test_db_cache
+CREATE EXTENSION diskquota;
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+CREATE TABLE t(i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+SELECT pg_sleep(10);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT tableid::regclass, size
+FROM diskquota.table_size
+WHERE tableid = 't'::regclass;
+ tableid |  size   
+---------+---------
+ t       | 3637248
+(1 row)
+
+DROP EXTENSION diskquota;
+-- Create table without extension
+CREATE TABLE t_no_extension(i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+CREATE EXTENSION diskquota;
+WARNING:  database is not empty, please run `select diskquota.init_table_size_table()` to initialize table_size information for diskquota extension. Note that for large database, this function may take a long time.
+-- Sleep until the worker adds the current db to cache so that it can be found 
+-- when DROP EXTENSION.
+-- FIXME: We cannot use wait_for_worker_new_epoch() here because 
+-- diskquota.state is not clean. Change sleep() to wait() after removing
+-- diskquota.state
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- Should find nothing since t_no_extension is not recorded.
+SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
+FROM gp_dist_random('gp_id');
+ diskquota_fetch_table_stat 
+----------------------------
+(0 rows)
+
+DROP TABLE t;
+DROP TABLE t_no_extension;
+DROP EXTENSION diskquota;
+\c contrib_regression
+DROP DATABASE test_db_cache;

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -253,11 +253,22 @@ gp_fetch_active_tables(bool is_init)
 
 /*
  * Function to get the table size from each segments
- * There are three mode:
- * 1. gather active table oid from all the segments, since table may only
- * be modified on a subset of the segments, we need to firstly gather the
- * active table oid list from all the segments.
- * 2. calculate the active table size based on the active table oid list.
+ * There are 4 modes:
+ * 
+ * - FETCH_ACTIVE_OID: gather active table oid from all the segments, since 
+ * table may only be modified on a subset of the segments, we need to firstly
+ * gather the active table oid list from all the segments.
+ * 
+ * - FETCH_ACTIVE_SIZE: calculate the active table size based on the active
+ * table oid list.
+ * 
+ * - ADD_DB_TO_MONITOR: add MyDatabaseId to the monitored db cache so that 
+ * active tables in the current database will be recorded. This is used each
+ * time a worker starts.
+ * 
+ * - REMOVE_DB_FROM_BEING_MONITORED: remove MyDatabaseId from the monitored 
+ * db cache so that active tables in the current database will be recorded. 
+ * This is used when DROP EXTENSION. 
  */
 Datum
 diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
@@ -296,6 +307,12 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 			case FETCH_ACTIVE_SIZE:
 				localCacheTable = get_active_tables_stats(PG_GETARG_ARRAYTYPE_P(1));
 				break;
+			case ADD_DB_TO_MONITOR:
+				update_diskquota_db_list(MyDatabaseId, HASH_ENTER);
+				break;
+			case REMOVE_DB_FROM_BEING_MONITORED:
+				update_diskquota_db_list(MyDatabaseId, HASH_REMOVE);
+				break;
 			default:
 				ereport(ERROR, (errmsg("Unused mode number, transaction will be aborted")));
 				break;
@@ -306,7 +323,7 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 		 * total number of active tables to be returned, each tuple contains
 		 * one active table stat
 		 */
-		funcctx->max_calls = (uint32) hash_get_num_entries(localCacheTable);
+		funcctx->max_calls = localCacheTable ? (uint32) hash_get_num_entries(localCacheTable) : 0;
 
 		/*
 		 * prepare attribute metadata for next calls that generate the tuple

--- a/gp_activetable.h
+++ b/gp_activetable.h
@@ -22,6 +22,7 @@ extern HTAB *gp_fetch_active_tables(bool force);
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
+extern void update_diskquota_db_list(Oid dbid, HASHACTION action);
 
 extern HTAB *active_tables_map;
 extern HTAB *monitoring_dbid_cache;

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -412,15 +412,20 @@ do_check_diskquota_state_is_ready(void)
 	int			i;
 	StringInfoData sql_command;
 
-	/* Add the dbid to watching list, so the hook can catch the table change*/
 	initStringInfo(&sql_command);
-	appendStringInfo(&sql_command, "select gp_segment_id, diskquota.update_diskquota_db_list(%u, 0) from gp_dist_random('gp_id');",
-				MyDatabaseId);
+	/* Add current database to the monitored db cache on all segments */
+	appendStringInfo(&sql_command, 
+					"SELECT diskquota.diskquota_fetch_table_stat(%d, ARRAY[]::oid[]) "
+					"FROM gp_dist_random('gp_id');", ADD_DB_TO_MONITOR);
 	ret = SPI_execute(sql_command.data, true, 0);
-        if (ret != SPI_OK_SELECT)
-                ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-                                                errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
+	if (ret != SPI_OK_SELECT) {
+		pfree(sql_command.data);
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+				errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
+	}
 	pfree(sql_command.data);
+	/* Add current database to the monitored db cache on coordinator */
+	update_diskquota_db_list(MyDatabaseId, HASH_ENTER);
 	/*
 	 * check diskquota state from table diskquota.state errors will be catch
 	 * at upper level function.

--- a/sql/test_primary_failure.sql
+++ b/sql/test_primary_failure.sql
@@ -60,7 +60,7 @@ select pg_sleep(10);
 select pg_recoverseg((select datadir from gp_segment_configuration c where c.role='p' and c.content=-1), 'ar');
 select pg_sleep(10);
 -- check GPDB status
-select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0;
+select content, preferred_role, role, status, mode from gp_segment_configuration;
 SELECT pg_sleep(10);
 -- end_ignore
 
@@ -69,3 +69,9 @@ INSERT INTO a SELECT generate_series(1,100);
 
 DROP TABLE a;
 DROP SCHEMA ftsr CASCADE;
+
+-- FIXME: The dbid cache won't be dispatched automatically while switching mirrors.
+-- Do a ADD_DB_TO_MONITOR manually here, otherwise warning:
+-- "cannot remove the database from db list, dbid not found"
+-- will be emitted in the clean test.
+SELECT diskquota.diskquota_fetch_table_stat(2, ARRAY[]::oid[]) FROM gp_dist_random('gp_id');

--- a/sql/test_update_db_cache.sql
+++ b/sql/test_update_db_cache.sql
@@ -1,0 +1,44 @@
+--start_ignore
+CREATE DATABASE test_db_cache;
+--end_ignore
+
+\c test_db_cache
+CREATE EXTENSION diskquota;
+SELECT pg_sleep(5);
+
+
+CREATE TABLE t(i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+
+SELECT pg_sleep(10);
+
+SELECT tableid::regclass, size
+FROM diskquota.table_size
+WHERE tableid = 't'::regclass;
+
+DROP EXTENSION diskquota;
+
+-- Create table without extension
+CREATE TABLE t_no_extension(i) AS SELECT generate_series(1, 100000)
+DISTRIBUTED BY (i);
+
+CREATE EXTENSION diskquota;
+
+-- Sleep until the worker adds the current db to cache so that it can be found 
+-- when DROP EXTENSION.
+-- FIXME: We cannot use wait_for_worker_new_epoch() here because 
+-- diskquota.state is not clean. Change sleep() to wait() after removing
+-- diskquota.state
+SELECT pg_sleep(5);
+
+-- Should find nothing since t_no_extension is not recorded.
+SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])
+FROM gp_dist_random('gp_id');
+
+DROP TABLE t;
+DROP TABLE t_no_extension;
+
+DROP EXTENSION diskquota;
+
+\c contrib_regression
+DROP DATABASE test_db_cache;


### PR DESCRIPTION
The db cache stores which databases enables diskquota. Active tables
will be recorded only if they are in those databases. Previously,
we created a new UDF update_diskquota_db_list() to add the current db
to the cache. However, the UDF is install in a wrong database. As a
result, after the user upgrade from a previous version to 1.0.3, the
bgworker does not find the UDF and can do nothing.

This patch fixes the issue by removing update_diskquota_db_list() and
using fetch_table_stat() to update db cache. fetch_table_stat() already
exists since version 1.0.0 so that no new UDF is needed.

This PR is a revision of PR #138 , and depends on #130 to fix a race
condition that occurs after CREATE EXTENSION.

---

Compared to 9684b635, the test has been modified to use pg_sleep()
instead of wait_for_worker_new_epoch() since 1.x doesn't support it.

The extension created by 1.0.3 will still work with new the new so as
long as the UDF update_diskquota_db_list() is not called. (And it won't
be called in the new so.)

Keep the UDF to make the sql the same with 1.0.3. For an easier 2.x
upgrade design.

A FIXE is added to work around the dbid not found

Co-authored-by: Chen Mulong <chenmulong@gmail.com>
(cherry picked from commit 9684b6350deb0a7d3849cf4cd202cd97c9b14882)
