### PR TITLE
Keep the 1.0 sql the same with 1.x branch

### DIFF
--- a/diskquota--1.0.sql
+++ b/diskquota--1.0.sql
@@ -9,7 +9,7 @@ CREATE TABLE diskquota.quota_config(
     quotatype int,
     quotalimitMB int8,
     PRIMARY KEY(targetOid, quotatype)
-) DISTRIBUTED BY (targetOid, quotatype);
+);
 
 CREATE TABLE diskquota.table_size(
     tableid oid,
@@ -20,7 +20,7 @@ CREATE TABLE diskquota.table_size(
 CREATE TABLE diskquota.state(
     state int,
     PRIMARY KEY(state)
-) DISTRIBUTED BY (state);
+);
 
 -- only diskquota.quota_config is dump-able, other table can be generate on fly
 SELECT pg_catalog.pg_extension_config_dump('diskquota.quota_config', '');


### PR DESCRIPTION
The added 'DISTRIBUTED BY' clause should have no impact on 1.x.
