### PR TITLE
Install the latest cmake on CI

### DIFF
--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -64,6 +64,7 @@ params:
 #@   trigger = param["trigger"]
 #@   confs = param["confs"]
 #@   add_res_by_name(res_map, param["gpdb_src"])
+#@   add_res_by_name(res_map, "bin_cmake")
 name: build_test
 max_in_flight: 10
 on_success: #@ trigger["on_success"]
@@ -76,6 +77,7 @@ plan:
 - in_parallel:
   - get: gpdb_src
     resource: #@ param["gpdb_src"]
+  - get: bin_cmake
 #@   for conf in confs:
 #@     add_res_by_conf(res_map, conf)
 #@     if conf["res_build_image"] == conf["res_test_image"]:

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -102,7 +102,7 @@ resources:
     repository: gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test
     tag: latest
 
-#! gpdb binary on gcs is located as different folder for different version
+# gpdb binary on gcs is located as different folder for different version
 - name: bin_gpdb6_centos6
   type: gcs
   source:
@@ -127,3 +127,11 @@ resources:
     bucket: ((gcs-bucket-intermediates))
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: 6X_STABLE/bin_gpdb_rhel8/bin_gpdb.tar.gz
+
+# Other dependencies
+- name: bin_cmake
+  type: gcs
+  source:
+    bucket: gpdb-extensions-concourse-resources
+    json_key: ((extensions-gcs-service-account-key))
+    regexp: dependencies/cmake-(.*)-linux-x86_64.sh

--- a/concourse/scripts/build_diskquota.sh
+++ b/concourse/scripts/build_diskquota.sh
@@ -5,6 +5,7 @@ set -exo pipefail
 CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_DIR=${CWDIR}/../../../
 
+source "${TOP_DIR}/diskquota_src/concourse/scripts/install_dep.sh"
 source "${TOP_DIR}/gpdb_src/concourse/scripts/common.bash"
 function pkg() {
     [ -f /opt/gcc_env.sh ] && source /opt/gcc_env.sh

--- a/concourse/scripts/install_dep.sh
+++ b/concourse/scripts/install_dep.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Script to install build & test dependencies
+# Ideally all dependencies should exist in the docker image. Use this script to install them only
+# if it is more difficult to change it in the image side.
+# Download the dependencies with concourse resources as much as possible, then we could benifit from
+# concourse's resource cache system.
+
+set -eox
+
+_install_cmake() {
+    # cmake_new to avoid name collision with the docker image.
+    local cmake_home="/opt/cmake_new"
+    if [ -e "${cmake_home}" ]; then
+        echo "cmake might have been installed in ${cmake_home}"
+        return
+    fi
+    echo "Installing cmake to ${cmake_home}..."
+    pushd bin_cmake
+    mkdir -p "${cmake_home}"
+    sh cmake-*-linux-x86_64.sh --skip-license --prefix="${cmake_home}"
+    popd
+    export PATH="${cmake_home}/bin":"$PATH"
+}
+
+_install_cmake

--- a/concourse/scripts/test_diskquota.sh
+++ b/concourse/scripts/test_diskquota.sh
@@ -7,6 +7,7 @@ TOP_DIR=${CWDIR}/../../../
 GPDB_CONCOURSE_DIR=${TOP_DIR}/gpdb_src/concourse/scripts
 CUT_NUMBER=6
 
+source "${TOP_DIR}/diskquota_src/concourse/scripts/install_dep.sh"
 source "${GPDB_CONCOURSE_DIR}/common.bash"
 source "${TOP_DIR}/diskquota_src/concourse/scripts/test_common.sh"
 

--- a/concourse/tasks/build_diskquota.yml
+++ b/concourse/tasks/build_diskquota.yml
@@ -5,6 +5,7 @@ inputs:
   - name: bin_gpdb
   - name: diskquota_src
   - name: gpdb_src
+  - name: bin_cmake
 
 outputs:
   - name: diskquota_artifacts

--- a/concourse/tasks/test_diskquota.yml
+++ b/concourse/tasks/test_diskquota.yml
@@ -6,6 +6,7 @@ inputs:
   - name: diskquota_src
   - name: bin_diskquota
   - name: gpdb_src
+  - name: bin_cmake
 
 run:
   path: diskquota_src/concourse/scripts/test_diskquota.sh


### PR DESCRIPTION
We need the archive extrace feature from cmake 3.18.
Before the new version landing to the test/build images, install them in
our ci scripts.
A cmake binary has been uploaded to the concourse gcs for faster
downloading.
