### PR TITLE
Cache CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ list(
 add_library(diskquota MODULE ${diskquota_SRC})
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "${PG_HOME}")
+  set(CMAKE_INSTALL_PREFIX "${PG_HOME}" CACHE PATH "default install prefix" FORCE)
 endif()
 
 set_target_properties(


### PR DESCRIPTION
CMAKE_INSTALL_PREFIX needs to be set as CACHE FORCE. Otherwise, next
time call 'make install' without source greenplum_path.sh, it will be
reset to '/usr/local'

See the example of CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html
