### PR TITLE
Pack the last released so in the pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,9 +84,9 @@ add_subdirectory(tests)
 # packing part, move to a separate file if this part is too large
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Distro.cmake)
 
-if(DEFINED DISKQUOTA_PREVIOUS_INSTALLER)
-  message(STATUS "Copy pervious installer from ${DISKQUOTA_PREVIOUS_INSTALLER}")
-  file(ARCHIVE_EXTRACT INPUT ${DISKQUOTA_PREVIOUS_INSTALLER} PATTERNS "*.so")
+if(DEFINED DISKQUOTA_LAST_RELEASE_PATH)
+    message(STATUS "Copy pervious installer from ${DISKQUOTA_LAST_RELEASE_PATH}")
+  file(ARCHIVE_EXTRACT INPUT ${DISKQUOTA_LAST_RELEASE_PATH} PATTERNS "*.so")
   file(GLOB DISKQUOTA_PREVIOUS_LIBRARY
        "${CMAKE_BINARY_DIR}/lib/postgresql/*.so")
   install(PROGRAMS ${DISKQUOTA_PREVIOUS_LIBRARY} DESTINATION "lib/postgresql/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ add_subdirectory(tests)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Distro.cmake)
 
 if(DEFINED DISKQUOTA_LAST_RELEASE_PATH)
-    message(STATUS "Copy pervious installer from ${DISKQUOTA_LAST_RELEASE_PATH}")
+  message(STATUS "Copy pervious installer from ${DISKQUOTA_LAST_RELEASE_PATH}")
   file(ARCHIVE_EXTRACT INPUT ${DISKQUOTA_LAST_RELEASE_PATH} PATTERNS "*.so")
   file(GLOB DISKQUOTA_PREVIOUS_LIBRARY
        "${CMAKE_BINARY_DIR}/lib/postgresql/*.so")

--- a/concourse/fly.sh
+++ b/concourse/fly.sh
@@ -99,7 +99,6 @@ set -v
     -c "${yml_path}" \
     -l "${workspace}/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml" \
     -l "${workspace}/gp-continuous-integration/secrets/gp-extensions-common.yml" \
-    -l "${workspace}/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml" \
     -l "${workspace}/gp-continuous-integration/secrets/gpdb_6X_STABLE-ci-secrets.prod.yml" \
     -v "diskquota-branch=${branch}"
 set +v

--- a/concourse/fly.sh
+++ b/concourse/fly.sh
@@ -100,6 +100,7 @@ set -v
     -l "${workspace}/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml" \
     -l "${workspace}/gp-continuous-integration/secrets/gp-extensions-common.yml" \
     -l "${workspace}/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml" \
+    -l "${workspace}/gp-continuous-integration/secrets/gpdb_6X_STABLE-ci-secrets.prod.yml" \
     -v "diskquota-branch=${branch}"
 set +v
 

--- a/concourse/pipeline/commit.yml
+++ b/concourse/pipeline/commit.yml
@@ -1,4 +1,5 @@
 #@ load("job_def.lib.yml",
+#@   "gate_job",
 #@   "build_test_job",
 #@   "centos6_gpdb6_conf",
 #@   "centos7_gpdb6_conf",
@@ -11,18 +12,24 @@
 #@ load("base.lib.yml", "declare_res", "declare_res_type")
 #@ res_map = {}
 #@ res_type_map = {}
-#@ job_param = {
-#@   "res_map": res_map,
-#@   "trigger": commit_trigger(res_map),
-#@   "gpdb_src": "gpdb6_src",
-#@   "confs": [
-#@     centos6_gpdb6_conf(),
-#@     centos7_gpdb6_conf(),
-#@     rhel8_gpdb6_conf(),
-#@     ubuntu18_gpdb6_conf()]
-#@ }
+#@ trigger = commit_trigger(res_map)
+#@ confs = [
+#@   centos6_gpdb6_conf(),
+#@   centos7_gpdb6_conf(),
+#@   rhel8_gpdb6_conf(),
+#@   ubuntu18_gpdb6_conf()
+#@ ]
 jobs:
-- #@ build_test_job(job_param)
+- #@ gate_job(trigger)
+#@ for conf in confs:
+#@   param = {
+#@     "res_map": res_map,
+#@     "trigger": trigger,
+#@     "gpdb_src": "gpdb6_src",
+#@     "conf": conf
+#@   }
+- #@ build_test_job(param)
+#@ end
 
 resources: #@ declare_res(res_type_map, res_map)
 

--- a/concourse/pipeline/dev.yml
+++ b/concourse/pipeline/dev.yml
@@ -1,4 +1,5 @@
 #@ load("job_def.lib.yml",
+#@   "gate_job",
 #@   "build_test_job",
 #@   "centos6_gpdb6_conf",
 #@   "centos7_gpdb6_conf",
@@ -11,15 +12,20 @@
 #@ load("base.lib.yml", "declare_res", "declare_res_type")
 #@ res_map = {}
 #@ res_type_map = {}
-#@ job_param = {
-#@   "res_map": res_map,
-#@   "trigger": commit_dev_trigger(res_map),
-#@   "gpdb_src": "gpdb6_src",
-#@   "confs": [
-#@     ubuntu18_gpdb6_conf()]
-#@ }
+#@ trigger = commit_dev_trigger(res_map)
+#@ confs= [
+#@   ubuntu18_gpdb6_conf()]
 jobs:
-- #@ build_test_job(job_param)
+- #@ gate_job(trigger)
+#@ for conf in confs:
+#@   param = {
+#@     "res_map": res_map,
+#@     "trigger": trigger,
+#@     "gpdb_src": "gpdb6_src",
+#@     "conf": conf
+#@   }
+- #@ build_test_job(param)
+#@ end
 
 resources: #@ declare_res(res_type_map, res_map)
 

--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -1,11 +1,13 @@
 #@ load("base.lib.yml", "add_res_by_conf", "add_res_by_name")
+#@ load("@ytt:template", "template")
 
 #! Job config for centos7
 #@ def centos6_gpdb6_conf():
 res_build_image: centos6-gpdb6-image-build
 res_test_image: centos6-gpdb6-image-test
 res_gpdb_bin: bin_gpdb6_centos6
-diskquota_os: rhel6
+res_diskquota_bin: bin_diskquota_gpdb6_rhel6
+os: rhel6
 #@ end
 
 #! Job config for centos7
@@ -13,7 +15,8 @@ diskquota_os: rhel6
 res_build_image: centos7-gpdb6-image-build
 res_test_image: centos7-gpdb6-image-test
 res_gpdb_bin: bin_gpdb6_centos7
-diskquota_os: rhel7
+res_diskquota_bin: bin_diskquota_gpdb6_rhel7
+os: rhel7
 #@ end
 
 #! Job config for rhel8
@@ -21,7 +24,8 @@ diskquota_os: rhel7
 res_build_image: rhel8-gpdb6-image-build
 res_test_image: rhel8-gpdb6-image-test
 res_gpdb_bin: bin_gpdb6_rhel8
-diskquota_os: rhel8
+res_diskquota_bin: bin_diskquota_gpdb6_rhel8
+os: rhel8
 #@ end
 
 #! Job config for ubuntu18
@@ -29,11 +33,23 @@ diskquota_os: rhel8
 res_build_image: ubuntu18-gpdb6-image-build
 res_test_image: ubuntu18-gpdb6-image-test
 res_gpdb_bin: bin_gpdb6_ubuntu18
-diskquota_os: ubuntu18.04
+res_diskquota_bin: bin_diskquota_gpdb6_ubuntu18
+os: ubuntu18.04
+#@ end
+
+#@ def gate_job(trigger):
+name: gate
+on_failure: #@ trigger["on_failure"]
+on_error: #@ trigger["on_error"]
+plan:
+#@   for to_get in trigger["to_get"]:
+- trigger: true
+  _: #@ template.replace(to_get)
+#@   end
 #@ end
 
 #@ def _build_task(conf):
-task: #@ "build_" + conf["diskquota_os"]
+task: #@ "build_" + conf["os"]
 file: diskquota_src/concourse/tasks/build_diskquota.yml
 image: #@ conf["res_build_image"]
 input_mapping:
@@ -42,63 +58,53 @@ input_mapping:
 #! output_mapping is necessary. Otherwise we may use a wrong
 #! diskquota_bin in the test task.
 output_mapping:
-  "diskquota_artifacts": #@ "diskquota_artifacts_" + conf["diskquota_os"]
+  "diskquota_artifacts": #@ "diskquota_artifacts_" + conf["os"]
 params:
-  DISKQUOTA_OS: #@ conf["diskquota_os"]
+  DISKQUOTA_OS: #@ conf["os"]
 #@ end
 
 #@ def _test_task(conf):
-task: #@ "test_" + conf["diskquota_os"]
+task: #@ "test_" + conf["os"]
 timeout: 1h
 file: diskquota_src/concourse/tasks/test_diskquota.yml
 image: #@ conf["res_test_image"]
 input_mapping:
   bin_gpdb: #@ conf["res_gpdb_bin"]
-  bin_diskquota: #@ "diskquota_artifacts_" + conf["diskquota_os"]
+  bin_diskquota: #@ "diskquota_artifacts_" + conf["os"]
 params:
-  DISKQUOTA_OS: #@ conf["diskquota_os"]
+  DISKQUOTA_OS: #@ conf["os"]
 #@ end
 
 #@ def build_test_job(param):
 #@   res_map = param["res_map"]
 #@   trigger = param["trigger"]
-#@   confs = param["confs"]
+#@   conf = param["conf"]
 #@   add_res_by_name(res_map, param["gpdb_src"])
 #@   add_res_by_name(res_map, "bin_cmake")
-name: build_test
+#@   add_res_by_conf(res_map, conf)
+name: #@ "build_test_" + conf["os"]
 max_in_flight: 10
 on_success: #@ trigger["on_success"]
 on_failure: #@ trigger["on_failure"]
 on_error: #@ trigger["on_error"]
 plan:
-#@   for trigger_plan in trigger["plans"]:
-- #@ trigger_plan
+#@   for to_get in trigger["to_get"]:
+- passed: [gate]
+  trigger: true
+  _: #@ template.replace(to_get)
+#@   end
+#@   for to_put in trigger["to_put"]:
+- #@ to_put
 #@   end
 - in_parallel:
   - get: gpdb_src
     resource: #@ param["gpdb_src"]
   - get: bin_cmake
-#@   for conf in confs:
-#@     add_res_by_conf(res_map, conf)
-#@     if conf["res_build_image"] == conf["res_test_image"]:
-  - get: #@ conf["res_build_image"]
-#@     else:
   - get: #@ conf["res_build_image"]
   - get: #@ conf["res_test_image"]
-#@     end
   - get: #@ conf["res_gpdb_bin"]
-#@   end
-#@   if len(confs) == 1:
-#@     conf = confs[0]
+  - get: last_released_diskquota_bin
+    resource: #@ conf["res_diskquota_bin"]
 - #@ _build_task(conf)
 - #@ _test_task(conf)
-#@   else:
-- in_parallel:
-    steps:
-#@     for conf in confs:
-      - do:
-        - #@ _build_task(conf)
-        - #@ _test_task(conf)
-#@     end
-#@   end
 #@ end

--- a/concourse/pipeline/pr.yml
+++ b/concourse/pipeline/pr.yml
@@ -1,4 +1,5 @@
 #@ load("job_def.lib.yml",
+#@   "gate_job",
 #@   "build_test_job",
 #@   "centos6_gpdb6_conf",
 #@   "centos7_gpdb6_conf",
@@ -13,19 +14,24 @@
 #@  "declare_res_type")
 #@ res_map = {}
 #@ res_type_map = {}
-#@ job_param = {
-#@   "res_map": res_map,
-#@   "gpdb_src": "gpdb6_src",
-#@   "trigger": pr_trigger(res_map),
-#@   "confs": [
-#@     centos6_gpdb6_conf(),
-#@     centos7_gpdb6_conf(),
-#@     rhel8_gpdb6_conf(),
-#@     ubuntu18_gpdb6_conf()
-#@   ]
-#@ }
+#@ trigger = pr_trigger(res_map)
+#@ confs = [
+#@   centos6_gpdb6_conf(),
+#@   centos7_gpdb6_conf(),
+#@   rhel8_gpdb6_conf(),
+#@   ubuntu18_gpdb6_conf()
+#@ ]
 jobs:
-- #@ build_test_job(job_param)
+- #@ gate_job(trigger)
+#@ for conf in confs:
+#@   param = {
+#@     "res_map": res_map,
+#@     "trigger": trigger,
+#@     "gpdb_src": "gpdb6_src",
+#@     "conf": conf
+#@   }
+- #@ build_test_job(param)
+#@ end
 
 resources: #@ declare_res(res_type_map, res_map)
 

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -128,6 +128,35 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: 6X_STABLE/bin_gpdb_rhel8/bin_gpdb.tar.gz
 
+# Diskquota releases
+- name: bin_diskquota_gpdb6_rhel6
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: diskquota/released/gpdb6/diskquota-(.*)-rhel6_x86_64.tar.gz
+
+- name: bin_diskquota_gpdb6_rhel7
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: diskquota/released/gpdb6/diskquota-(.*)-rhel7_x86_64.tar.gz
+
+- name: bin_diskquota_gpdb6_rhel8
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: diskquota/released/gpdb6/diskquota-(.*)-rhel8_x86_64.tar.gz
+
+- name: bin_diskquota_gpdb6_ubuntu18
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: diskquota/released/gpdb6/diskquota-(.*)-ubuntu18.04_x86_64.tar.gz
+
 # Other dependencies
 - name: bin_cmake
   type: gcs

--- a/concourse/pipeline/trigger_def.lib.yml
+++ b/concourse/pipeline/trigger_def.lib.yml
@@ -3,11 +3,6 @@
 #! PR trigger. For pull request pipelines
 #@ def pr_trigger(res_map):
 #@   add_res_by_name(res_map, "diskquota_pr")
-to_get_gate:
-  - get: diskquota_src
-    resource: diskquota_pr
-    params:
-      fetch_tags: true
 to_get:
   - get: diskquota_src
     resource: diskquota_pr

--- a/concourse/pipeline/trigger_def.lib.yml
+++ b/concourse/pipeline/trigger_def.lib.yml
@@ -3,16 +3,21 @@
 #! PR trigger. For pull request pipelines
 #@ def pr_trigger(res_map):
 #@   add_res_by_name(res_map, "diskquota_pr")
-plans:
-- get: diskquota_src
-  resource: diskquota_pr
-  params:
-    fetch_tags: true
-  trigger: true
-- put: diskquota_pr
-  params:
-    path: diskquota_src
-    status: pending
+to_get_gate:
+  - get: diskquota_src
+    resource: diskquota_pr
+    params:
+      fetch_tags: true
+to_get:
+  - get: diskquota_src
+    resource: diskquota_pr
+    params:
+      fetch_tags: true
+to_put:
+  - put: diskquota_pr
+    params:
+      path: diskquota_src
+      status: pending
 on_failure:
   put: diskquota_pr
   params:
@@ -33,10 +38,10 @@ on_success:
 #! Commit trigger. For master pipelines
 #@ def commit_trigger(res_map):
 #@   add_res_by_name(res_map, "diskquota_commit")
-plans:
+to_get:
 - get: diskquota_src
   resource: diskquota_commit
-  trigger: true
+to_put: #@ []
 #! To set the github commit status, https://github.com/Pix4D/cogito is a good choice.
 #! Unfortunately it doesn't work with Concourse 5.
 on_success:
@@ -47,10 +52,10 @@ on_error:
 #! Commit trigger. For dev pipelines. No webhook
 #@ def commit_dev_trigger(res_map):
 #@   add_res_by_name(res_map, "diskquota_commit_dev")
-plans:
+to_get:
 - get: diskquota_src
   resource: diskquota_commit_dev
-  trigger: true
+to_put: #@ []
 #! To set the github commit status, https://github.com/Pix4D/cogito is a good choice.
 #! Unfortunately it doesn't work with Concourse 5.
 on_success:

--- a/concourse/scripts/build_diskquota.sh
+++ b/concourse/scripts/build_diskquota.sh
@@ -11,9 +11,9 @@ function pkg() {
     fi
 
     pushd /home/gpadmin/diskquota_artifacts
-    local last_release_diskquota
-    last_release_diskquota=$(readlink -e /home/gpadmin/last_released_diskquota_bin/diskquota-*.tar.gz)
-    cmake /home/gpadmin/diskquota_src -DDISKQUOTA_PREVIOUS_INSTALLER="${last_release_diskquota}"
+    local last_release_path
+    last_release_path=$(readlink -e /home/gpadmin/last_released_diskquota_bin/diskquota-*.tar.gz)
+    cmake /home/gpadmin/diskquota_src -DDISKQUOTA_LAST_RELEASE_PATH="${last_release_path}"
     cmake --build . --target package
     popd
 }

--- a/concourse/scripts/build_diskquota.sh
+++ b/concourse/scripts/build_diskquota.sh
@@ -11,7 +11,9 @@ function pkg() {
     fi
 
     pushd /home/gpadmin/diskquota_artifacts
-    cmake /home/gpadmin/diskquota_src
+    local last_release_diskquota
+    last_release_diskquota=$(realpath /home/gpadmin/last_released_diskquota_bin/diskquota-*.tar.gz)
+    cmake /home/gpadmin/diskquota_src -DDISKQUOTA_PREVIOUS_INSTALLER="${last_release_diskquota}"
     cmake --build . --target package
     popd
 }

--- a/concourse/scripts/build_diskquota.sh
+++ b/concourse/scripts/build_diskquota.sh
@@ -12,7 +12,7 @@ function pkg() {
 
     pushd /home/gpadmin/diskquota_artifacts
     local last_release_diskquota
-    last_release_diskquota=$(realpath /home/gpadmin/last_released_diskquota_bin/diskquota-*.tar.gz)
+    last_release_diskquota=$(readlink -e /home/gpadmin/last_released_diskquota_bin/diskquota-*.tar.gz)
     cmake /home/gpadmin/diskquota_src -DDISKQUOTA_PREVIOUS_INSTALLER="${last_release_diskquota}"
     cmake --build . --target package
     popd

--- a/concourse/tasks/build_diskquota.yml
+++ b/concourse/tasks/build_diskquota.yml
@@ -6,6 +6,7 @@ inputs:
   - name: diskquota_src
   - name: gpdb_src
   - name: bin_cmake
+  - name: last_released_diskquota_bin
 
 outputs:
   - name: diskquota_artifacts


### PR DESCRIPTION
Due to our upgrade design, the newly released diskquota should contain
all the so file of every latest minor release. The packaging system has
been implemented by cmake DISKQUOTA_PREVIOUS_INSTALLER.
This commit get the latest release through gcs regexp and pass it to the
build script.

The pipeline has been split into different jobs based on the OS type
because of:
- Easier to use the common resource name for build_diskquota.yml
- job_def.lib.yml becomes shorter
- Can span jobs into different concourse workers, which may bring some
  better performance.
- Running flaky test again is easier.

Also a gate job has been added which is the main entrance for all
pipelines. In the future, we may want to have different gate job for
different pipelines, like a clang-format checking gate for the PR
pipeline.
