### PR TITLE
cmake: also link RESULTS_DIR to working dir

### DIFF
--- a/cmake/Regress.cmake
+++ b/cmake/Regress.cmake
@@ -4,6 +4,7 @@
 # RegressTarget_Add(<name>
 #   SQL_DIR <sql_dir>
 #   EXPECTED_DIR <expected_dir>
+#   RESULTS_DIR <results_dir>
 #   [INIT_FILE <init_file_1> <init_file_2> ...]
 #   [SCHEDULE_FILE <schedule_file_1> <schedule_file_2> ...]
 #   [REGRESS <test1> <test2> ...]
@@ -48,7 +49,7 @@ function(RegressTarget_Add name)
     cmake_parse_arguments(
         arg
         ""
-        "SQL_DIR;EXPECTED_DIR;DATA_DIR;REGRESS_TYPE"
+        "SQL_DIR;EXPECTED_DIR;RESULTS_DIR;DATA_DIR;REGRESS_TYPE"
         "REGRESS;REGRESS_OPTS;INIT_FILE;SCHEDULE_FILE"
         ${ARGN})
     if (NOT arg_EXPECTED_DIR)
@@ -58,6 +59,9 @@ function(RegressTarget_Add name)
     if (NOT arg_SQL_DIR)
         message(FATAL_ERROR
             "'SQL_DIR' needs to be specified.")
+    endif()
+    if (NOT arg_RESULTS_DIR)
+        message(FATAL_ERROR "'RESULTS_DIR' needs to be specified")
     endif()
 
     set(working_DIR "${CMAKE_CURRENT_BINARY_DIR}/${name}")
@@ -95,6 +99,7 @@ function(RegressTarget_Add name)
 
     get_filename_component(sql_DIR ${arg_SQL_DIR} ABSOLUTE)
     get_filename_component(expected_DIR ${arg_EXPECTED_DIR} ABSOLUTE)
+    get_filename_component(results_DIR ${arg_RESULTS_DIR} ABSOLUTE)
     if (arg_DATA_DIR)
         get_filename_component(data_DIR ${arg_DATA_DIR} ABSOLUTE)
         set(ln_data_dir_CMD ln -s ${data_DIR} data)
@@ -108,6 +113,9 @@ function(RegressTarget_Add name)
         COMMAND ln -s ${sql_DIR} sql
         COMMAND rm -f expected
         COMMAND ln -s ${expected_DIR} expected
+        COMMAND rm -f results
+        COMMAND mkdir -p ${results_DIR}
+        COMMAND ln -s ${results_DIR} results
         COMMAND rm -f data
         COMMAND ${ln_data_dir_CMD}
         COMMAND

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ RegressTarget_Add(regress
     ${CMAKE_CURRENT_SOURCE_DIR}/regress/regress_init_file
     SQL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/sql
     EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/expected
+    RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/regress/diskquota_schedule
     REGRESS_OPTS
@@ -19,6 +20,7 @@ RegressTarget_Add(isolation2
     ${CMAKE_CURRENT_SOURCE_DIR}/init_file
     SQL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/sql
     EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/expected
+    RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/isolation2_schedule
     REGRESS_OPTS

--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -5,6 +5,7 @@ RegressTarget_Add(upgrade
     ${CMAKE_CURRENT_SOURCE_DIR}/init_file
     SQL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sql
     EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/expected
+    RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/results
     SCHEDULE_FILE
         ${CMAKE_CURRENT_SOURCE_DIR}/schedule_1.0--2.0
         ${CMAKE_CURRENT_SOURCE_DIR}/schedule_2.0--1.0


### PR DESCRIPTION
my workflow:
- write many new tests.
- find -name '*.sql' | sed 's/sql/out/g' | xargs touch
- run those tests.
- check the output, if satisfied
- cp from results to expected

if `expected` and `result` in the same folder will be better.