### PR TITLE
ci: speed up the test

### DIFF
--- a/tests/isolation2/expected/config.out
+++ b/tests/isolation2/expected/config.out
@@ -1,13 +1,11 @@
 
 !\retcode gpconfig -c shared_preload_libraries -v $(./data/current_binary_name);
 (exited with code 0)
-!\retcode gpstop -raf;
+!\retcode gpconfig -c diskquota.naptime -v 0 --skipvalidation;
+(exited with code 0)
+!\retcode gpconfig -c max_worker_processes -v 20 --skipvalidation;
 (exited with code 0)
 
-!\retcode gpconfig -c diskquota.naptime -v 0;
-(exited with code 0)
-!\retcode gpconfig -c max_worker_processes -v 20;
-(exited with code 0)
 !\retcode gpstop -raf;
 (exited with code 0)
 

--- a/tests/isolation2/sql/config.sql
+++ b/tests/isolation2/sql/config.sql
@@ -3,10 +3,9 @@ CREATE DATABASE diskquota;
 --end_ignore
 
 !\retcode gpconfig -c shared_preload_libraries -v $(./data/current_binary_name);
-!\retcode gpstop -raf;
+!\retcode gpconfig -c diskquota.naptime -v 0 --skipvalidation;
+!\retcode gpconfig -c max_worker_processes -v 20 --skipvalidation;
 
-!\retcode gpconfig -c diskquota.naptime -v 0;
-!\retcode gpconfig -c max_worker_processes -v 20;
 !\retcode gpstop -raf;
 
 -- Show the values of all GUC variables

--- a/tests/regress/sql/config.sql
+++ b/tests/regress/sql/config.sql
@@ -2,11 +2,10 @@
 CREATE DATABASE diskquota;
 
 \! gpconfig -c shared_preload_libraries -v $(./data/current_binary_name);
-\! gpstop -raf
+\! gpconfig -c diskquota.naptime -v 0 --skipvalidation
+\! gpconfig -c max_worker_processes -v 20 --skipvalidation
+\! gpconfig -c diskquota.hard_limit -v "off" --skipvalidation
 
-\! gpconfig -c diskquota.naptime -v 0
-\! gpconfig -c max_worker_processes -v 20
-\! gpconfig -c diskquota.hard_limit -v "off"
 \! gpstop -raf
 --end_ignore
 

--- a/upgrade_test/sql/downgrade_extension.sql
+++ b/upgrade_test/sql/downgrade_extension.sql
@@ -1,2 +1,0 @@
-\set old_version `echo $OLD_VERSION`
-alter extension diskquota update to :'old_version';

--- a/upgrade_test/sql/upgrade_extension.sql
+++ b/upgrade_test/sql/upgrade_extension.sql
@@ -1,2 +1,0 @@
-\set new_version `echo $NEW_VERSION`
-alter extension diskquota update to :'new_version';


### PR DESCRIPTION
the old:

- set `shared_preload_libraries`
- reboot, load library to load GUC name
- set other GUC for diskquota
- reboot to make GUC take effect

the new one:
- set `shared_preload_libraries`
- set other GUC with `--skipvalidation`
- reboot to load library

remove one reboot step.

there is one GUC (diskquota.max_active_tables) related to shared memory, gpstop -u not work.
(maybe work but the test did not use gpstop -u)