### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
-*.o
-*.so
-build
+# Build directory
+build*/
 
-regression.out
-regression.diffs
+# The tests results
 /results/
 
+# For IDE/Editors
 .vscode
-upgrade_test/regression.out
-upgrade_test/regression.diffs
-upgrade_test/results
+.idea
+tags
+cscope*
+.ccls-cache/
+compile_commands.json


### PR DESCRIPTION
- The build objects should always exist in build* directories now.
- Add ignore pattern for idea, LSP and dinosaur developpers.
