### PR TITLE
ci: add upgrade version naming convention check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.18)
-# include_guard()           need 3.10
 # file(ARCHIVE_EXTRACT foo) need 3.18
 
 project(diskquota)
@@ -72,7 +71,9 @@ list(
 add_library(diskquota MODULE ${diskquota_SRC})
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "${PG_HOME}" CACHE PATH "default install prefix" FORCE)
+  set(CMAKE_INSTALL_PREFIX
+      "${PG_HOME}"
+      CACHE PATH "default install prefix" FORCE)
 endif()
 
 set_target_properties(
@@ -81,10 +82,6 @@ set_target_properties(
              PREFIX ""
              C_STANDARD 99
              LINKER_LANGUAGE "CXX")
-
-# Add installcheck targets
-add_subdirectory(tests)
-add_subdirectory(upgrade_test)
 
 # packing part, move to a separate file if this part is too large
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Distro.cmake)
@@ -95,6 +92,26 @@ if(DEFINED DISKQUOTA_LAST_RELEASE_PATH)
   file(GLOB DISKQUOTA_PREVIOUS_LIBRARY
        "${CMAKE_BINARY_DIR}/lib/postgresql/*.so")
   install(PROGRAMS ${DISKQUOTA_PREVIOUS_LIBRARY} DESTINATION "lib/postgresql/")
+
+  get_filename_component(
+    DISKQUOTA_LAST_RELEASE_FILENAME ${DISKQUOTA_LAST_RELEASE_PATH} NAME CACHE
+    "last release installer name")
+  string(
+    REGEX
+    REPLACE "^diskquota-([0-9]+).[0-9]+.[0-9]+-.*$" "\\1"
+            DISKQUOTA_LAST_MAJOR_VERSION ${DISKQUOTA_LAST_RELEASE_FILENAME})
+  string(
+    REGEX
+    REPLACE "^diskquota-[0-9]+.([0-9]+).[0-9]+-.*$" "\\1"
+            DISKQUOTA_LAST_MINOR_VERSION ${DISKQUOTA_LAST_RELEASE_FILENAME})
+  string(
+    REGEX
+    REPLACE "^diskquota-[0-9]+.[0-9]+.([0-9]+)-.*$" "\\1"
+            DISKQUOTA_LAST_PATCH_VERSION ${DISKQUOTA_LAST_RELEASE_FILENAME})
+
+  set(DISKQUOTA_LAST_VERSION
+      "${DISKQUOTA_LAST_MAJOR_VERSION}.${DISKQUOTA_LAST_MINOR_VERSION}.${DISKQUOTA_LAST_PATCH_VERSION}"
+  )
 endif()
 
 set(CPACK_GENERATOR "TGZ")
@@ -116,6 +133,10 @@ BuildInfo_Create(${build_info_PATH}
   GP_MAJOR_VERSION
   GP_VERSION)
 # Create build-info end
+
+# Add installcheck targets
+add_subdirectory(tests)
+add_subdirectory(upgrade_test)
 
 # NOTE: keep install part at the end of file, to overwrite previous binary
 install(PROGRAMS "cmake/install_gpdb_component" DESTINATION ".")

--- a/cmake/Gpdb.cmake
+++ b/cmake/Gpdb.cmake
@@ -46,7 +46,7 @@ if (NOT PG_SRC_DIR)
     execute_process(
         COMMAND_ECHO STDOUT
         COMMAND
-        grep abs_top_builddir ${makefile_global}
+        grep "^abs_top_builddir" ${makefile_global}
         COMMAND
         sed s/.*abs_top_builddir.*=\\\(.*\\\)/\\1/
         OUTPUT_VARIABLE PG_SRC_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -1,18 +1,79 @@
 include(${CMAKE_SOURCE_DIR}/cmake/Regress.cmake)
 
-RegressTarget_Add(upgrade
-    INIT_FILE
-    ${CMAKE_CURRENT_SOURCE_DIR}/init_file
-    SQL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sql
-    EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/expected
-    RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/results
-    SCHEDULE_FILE
-        ${CMAKE_CURRENT_SOURCE_DIR}/schedule_1.0--2.0
-        ${CMAKE_CURRENT_SOURCE_DIR}/schedule_2.0--1.0
-    REGRESS_OPTS --dbname=contrib_regression)
+regresstarget_add(
+  upgradecheck
+  INIT_FILE
+  ${CMAKE_CURRENT_SOURCE_DIR}/init_file
+  SQL_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/sql
+  EXPECTED_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/expected
+  RESULTS_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/results
+  SCHEDULE_FILE
+  ${CMAKE_CURRENT_SOURCE_DIR}/schedule_1.0--2.0
+  ${CMAKE_CURRENT_SOURCE_DIR}/schedule_2.0--1.0
+  REGRESS_OPTS
+  --dbname=contrib_regression)
 
-# not use `installcheck` target on purpose.
+# check whether DDL file (*.sql) is modified
+file(GLOB ddl_files ${CMAKE_SOURCE_DIR}/*.sql)
+foreach(ddl IN LISTS ddl_files)
+  exec_program(
+    git ARGS
+    diff --exit-code ${ddl}
+    OUTPUT_VARIABLE NULL
+    RETURN_VALUE "${ddl}_modified")
+
+  if("${${ddl}_modified}")
+    message(
+      NOTICE
+      "detected DDL file ${ddl} is modified, checking if upgrade test is needed."
+    )
+    set(DISKQUOTA_DDL_MODIFIED TRUE)
+  endif()
+endforeach()
+
+# if DDL file modified, insure the last release file passed in
+if(DISKQUOTA_DDL_MODIFIED AND NOT DEFINED DISKQUOTA_LAST_RELEASE_PATH)
+  message(
+    FATAL_ERROR
+      "DDL file modify detected, upgrade test is required. Add -DDISKQUOTA_LAST_RELEASE_PATH=/<path>/diskquota-<version>-<os>_<arch>.tar.gz. And re-try the generation"
+  )
+endif()
+
+# check if current version is compatible with the upgrade strategy
+if(DISKQUOTA_DDL_MODIFIED AND DEFINED DISKQUOTA_LAST_RELEASE_PATH)
+  message(NOTICE "current version ${DISKQUOTA_VERSION}")
+  message(NOTICE "last    version ${DISKQUOTA_LAST_VERSION}")
+
+  # if 1.0.a = 1.0.b reject
+  if("${DISKQUOTA_MAJOR_VERSION}.${DISKQUOTA_MINOR_VERSION}" STREQUAL
+     "${DISKQUOTA_LAST_MAJOR_VERSION}.${DISKQUOTA_LAST_MINOR_VERSION}")
+    message(FATAL_ERROR "should bump at last one minor version")
+  endif()
+
+  # if 1.0.a to 1.2.b reject
+  math(EXPR DISKQUOTA_NEXT_MINOR_VERSION "${DISKQUOTA_LAST_MINOR_VERSION} + 1")
+  if(("${DISKQUOTA_MAJOR_VERSION}" STREQUAL "${DISKQUOTA_LAST_MAJOR_VERSION}")
+     AND (NOT "${DISKQUOTA_MINOR_VERSION}" STREQUAL
+          "${DISKQUOTA_NEXT_MINOR_VERSION}"))
+    message(FATAL_ERROR "should not skip any minor version")
+  endif()
+
+  # if 1.a.a to 3.a.a reject
+  math(EXPR DISKQUOTA_NEXT_MAJOR_VERSION "${DISKQUOTA_LAST_MAJOR_VERSION} + 1")
+  if((NOT "${DISKQUOTA_MAJOR_VERSION}" STREQUAL
+      "${DISKQUOTA_LAST_MAJOR_VERSION}")
+     AND (NOT "${DISKQUOTA_NEXT_MAJOR_VERSION}" STREQUAL
+          "${DISKQUOTA_MAJOR_VERSION}"))
+    message(FATAL_ERROR "should not skip any major version")
+  endif()
+
+  message(
+    NOTICE
+    "upgrade from ${DISKQUOTA_LAST_VERSION} to ${DISKQUOTA_VERSION} is available"
+  )
+endif()
+
 # upgrade test is not needed in feature development
-add_custom_target(upgradecheck)
-
-add_dependencies(upgradecheck upgrade)


### PR DESCRIPTION
read the last version from `-DDISKQUOTA_LAST_RELEASE_PATH`

```
🚫 1.a.a => 3.a.a
🚫 1.0.a => 1.2.b
🚫 1.0.a => 1.0.b
✅ 1.0.a => 1.1.a
✅ 1.0.a => 2.0.a
✅ 1.0.a => 2.1.a
```