### PR TITLE
Fix memory leak when refresh_blackmap()

### DIFF
--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1259,6 +1259,7 @@ dispatch_blackmap(HTAB *local_active_table_stat_map)
 	pfree(rows.data);
 	pfree(active_oids.data);
 	pfree(sql.data);
+	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 }
 
 /*


### PR DESCRIPTION
The ever growing part of memory contains the following pattern:

refresh_blackmap.*<segment_name><ip_address>:<port> pid=< pid>

The pattern contains info of segemnts. This indicates that the results
of dispatching refresh_blackmap() might not be freed properly.