### PR TITLE
Support release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ cmake_minimum_required(VERSION 3.18)
 
 project(diskquota)
 
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "Setting build type to 'Debug' as none was specified.")
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+      STRING "Choose the type of build." FORCE)
+endif()
+
 # generate 'compile_commands.json'
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -17,6 +23,13 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Gpdb.cmake)
 # set include directories for all sub-projects
 include_directories(${PG_INCLUDE_DIR_SERVER})
 include_directories(${PG_INCLUDE_DIR}) # for libpq
+# Overwrite the default build type flags set by cmake.
+# We don't want the '-O3 -DNDEBUG' from cmake. Instead, those will be set by the CFLAGS from pg_config.
+# And, the good news is, GPDB release always have '-g'.
+set(CMAKE_C_FLAGS_RELEASE "" CACHE
+    STRING "Flags for RELEASE build" FORCE)
+set(CMAKE_C_FLAGS_DEBUG "-DDISKQUOTA_DEBUG"
+    CACHE STRING "Flags for DEBUG build" FORCE)
 # set link flags for all sub-projects
 set(CMAKE_SHARED_LINKER_FLAGS "${PG_LD_FLAGS}")
 # set c and ld flags for all projects
@@ -114,7 +127,8 @@ BuildInfo_Create(${build_info_PATH}
   DISKQUOTA_GIT_HASH
   DISKQUOTA_VERSION
   GP_MAJOR_VERSION
-  GP_VERSION)
+  GP_VERSION
+  CMAKE_BUILD_TYPE)
 # Create build-info end
 
 # NOTE: keep install part at the end of file, to overwrite previous binary

--- a/cmake/Regress.cmake
+++ b/cmake/Regress.cmake
@@ -8,6 +8,7 @@
 #   [INIT_FILE <init_file_1> <init_file_2> ...]
 #   [SCHEDULE_FILE <schedule_file_1> <schedule_file_2> ...]
 #   [REGRESS <test1> <test2> ...]
+#   [EXCLUDE <test1> <test2> ...]
 #   [REGRESS_OPTS <opt1> <opt2> ...]
 #   [REGRESS_TYPE isolation2/regress]
 # )
@@ -50,7 +51,7 @@ function(RegressTarget_Add name)
         arg
         ""
         "SQL_DIR;EXPECTED_DIR;RESULTS_DIR;DATA_DIR;REGRESS_TYPE"
-        "REGRESS;REGRESS_OPTS;INIT_FILE;SCHEDULE_FILE"
+        "REGRESS;EXCLUDE;REGRESS_OPTS;INIT_FILE;SCHEDULE_FILE"
         ${ARGN})
     if (NOT arg_EXPECTED_DIR)
         message(FATAL_ERROR
@@ -93,6 +94,14 @@ function(RegressTarget_Add name)
         get_filename_component(schedule_file_PATH ${o} ABSOLUTE)
         list(APPEND arg_REGRESS_OPTS "--schedule=${schedule_file_PATH}")
     endforeach()
+    foreach(o IN LISTS arg_EXCLUDE)
+        list(APPEND to_exclude ${o})
+    endforeach()
+    if (to_exclude)
+        set(exclude_arg "--exclude-tests=${to_exclude}")
+        string(REPLACE ";" "," exclude_arg "${exclude_arg}")
+        set(regress_opts_arg ${regress_opts_arg} ${exclude_arg})
+    endif()
     foreach(o IN LISTS arg_REGRESS_OPTS)
         set(regress_opts_arg ${regress_opts_arg} ${o})
     endforeach()

--- a/concourse/pipeline/dev.yml
+++ b/concourse/pipeline/dev.yml
@@ -14,7 +14,11 @@
 #@ res_type_map = {}
 #@ trigger = commit_dev_trigger(res_map)
 #@ confs= [
-#@   ubuntu18_gpdb6_conf()]
+#@   centos6_gpdb6_conf(release_build=True),
+#@   centos7_gpdb6_conf(release_build=True),
+#@   rhel8_gpdb6_conf(release_build=True),
+#@   ubuntu18_gpdb6_conf(release_build=True)
+#@ ]
 jobs:
 #@ param = {
 #@     "res_map": res_map,

--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -2,43 +2,48 @@
 #@ load("@ytt:template", "template")
 
 #! Job config for centos6
-#@ def centos6_gpdb6_conf():
+#! Use bin_gpdb_postfix="" to use a release version of gpdb binary
+#@ def centos6_gpdb6_conf(release_build=False):
 res_build_image: centos6-gpdb6-image-build
 res_test_image: centos6-gpdb6-image-test
-res_gpdb_bin: bin_gpdb6_centos6
+res_gpdb_bin: #@ "bin_gpdb6_centos6" + ("" if release_build else "_debug")
 res_diskquota_bin: bin_diskquota_gpdb6_rhel6
 res_intermediates_bin: bin_diskquota_gpdb6_rhel6_intermediates
 os: rhel6
+build_type: #@ "Release" if release_build else "Debug"
 #@ end
 
 #! Job config for centos7
-#@ def centos7_gpdb6_conf():
+#@ def centos7_gpdb6_conf(release_build=False):
 res_build_image: centos7-gpdb6-image-build
 res_test_image: centos7-gpdb6-image-test
-res_gpdb_bin: bin_gpdb6_centos7
+res_gpdb_bin: #@ "bin_gpdb6_centos7" + ("" if release_build else "_debug")
 res_diskquota_bin: bin_diskquota_gpdb6_rhel7
 res_intermediates_bin: bin_diskquota_gpdb6_rhel7_intermediates
 os: rhel7
+build_type: #@ "Release" if release_build else "Debug"
 #@ end
 
 #! Job config for rhel8
-#@ def rhel8_gpdb6_conf():
+#@ def rhel8_gpdb6_conf(release_build=False):
 res_build_image: rhel8-gpdb6-image-build
 res_test_image: rhel8-gpdb6-image-test
-res_gpdb_bin: bin_gpdb6_rhel8
+res_gpdb_bin: #@ "bin_gpdb6_rhel8" + ("" if release_build else "_debug")
 res_diskquota_bin: bin_diskquota_gpdb6_rhel8
 res_intermediates_bin: bin_diskquota_gpdb6_rhel8_intermediates
 os: rhel8
+build_type: #@ "Release" if release_build else "Debug"
 #@ end
 
 #! Job config for ubuntu18
-#@ def ubuntu18_gpdb6_conf():
+#@ def ubuntu18_gpdb6_conf(release_build=False):
 res_build_image: ubuntu18-gpdb6-image-build
 res_test_image: ubuntu18-gpdb6-image-test
-res_gpdb_bin: bin_gpdb6_ubuntu18
+res_gpdb_bin: #@ "bin_gpdb6_ubuntu18" + ("" if release_build else "_debug")
 res_diskquota_bin: bin_diskquota_gpdb6_ubuntu18
 res_intermediates_bin: bin_diskquota_gpdb6_ubuntu18_intermediates
 os: ubuntu18.04
+build_type: #@ "Release" if release_build else "Debug"
 #@ end
 
 #! The entry point of a pipeline. The job name must be 'entrance'.
@@ -85,6 +90,7 @@ input_mapping:
   bin_gpdb: #@ conf["res_gpdb_bin"]
 params:
   DISKQUOTA_OS: #@ conf["os"]
+  BUILD_TYPE: #@ conf["build_type"]
 #@ end
 
 #@ def _test_task(conf):

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -111,30 +111,58 @@ resources:
     password: ((extensions-gcs-service-account-key))
 
 # gpdb binary on gcs is located as different folder for different version
+# Latest build with assertion enabled:
+# --enable-cassert --enable-tap-tests --enable-debug-extensions
+- name: bin_gpdb6_centos6_debug
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel6_x86_64.debug.tar.gz
+- name: bin_gpdb6_centos7_debug
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
+- name: bin_gpdb6_rhel8_debug
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.debug.tar.gz
+- name: bin_gpdb6_ubuntu18_debug
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.debug.tar.gz
+# Latest release candidates, no fault-injector, no assertion:
+# --disable-debug-extensions --disable-tap-tests --enable-ic-proxy
 - name: bin_gpdb6_centos6
   type: gcs
   source:
-    bucket: ((gcs-bucket-intermediates))
+    bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: 6X_STABLE/bin_gpdb_centos6/bin_gpdb.tar.gz
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-centos6.tar.gz
 - name: bin_gpdb6_centos7
   type: gcs
   source:
-    bucket: ((gcs-bucket-intermediates))
+    bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: 6X_STABLE/bin_gpdb_centos7/bin_gpdb.tar.gz
-- name: bin_gpdb6_ubuntu18
-  type: gcs
-  source:
-    bucket: ((gcs-bucket-intermediates))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: 6X_STABLE/bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-centos7.04.tar.gz
 - name: bin_gpdb6_rhel8
   type: gcs
   source:
-    bucket: ((gcs-bucket-intermediates))
+    bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: 6X_STABLE/bin_gpdb_rhel8/bin_gpdb.tar.gz
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-rhel8.04.tar.gz
+- name: bin_gpdb6_ubuntu18
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-ubuntu18.04.tar.gz
 
 # Diskquota releases
 - name: bin_diskquota_gpdb6_rhel6

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -150,13 +150,13 @@ resources:
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-centos7.04.tar.gz
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-centos7.tar.gz
 - name: bin_gpdb6_rhel8
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-rhel8.04.tar.gz
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-rhel8.tar.gz
 - name: bin_gpdb6_ubuntu18
   type: gcs
   source:

--- a/concourse/scripts/build_diskquota.sh
+++ b/concourse/scripts/build_diskquota.sh
@@ -13,7 +13,9 @@ function pkg() {
     pushd /home/gpadmin/diskquota_artifacts
     local last_release_path
     last_release_path=$(readlink -e /home/gpadmin/last_released_diskquota_bin/diskquota-*.tar.gz)
-    cmake /home/gpadmin/diskquota_src -DDISKQUOTA_LAST_RELEASE_PATH="${last_release_path}"
+    cmake /home/gpadmin/diskquota_src \
+        -DDISKQUOTA_LAST_RELEASE_PATH="${last_release_path}" \
+        -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
     cmake --build . --target package
     popd
 }

--- a/concourse/scripts/entry.sh
+++ b/concourse/scripts/entry.sh
@@ -117,7 +117,7 @@ setup_gpadmin() {
 # Extract gpdb binary
 function install_gpdb() {
     [ ! -d /usr/local/greenplum-db-devel ] && mkdir -p /usr/local/greenplum-db-devel
-    tar -xzf "${CONCOURSE_WORK_DIR}/bin_gpdb/bin_gpdb.tar.gz" -C /usr/local/greenplum-db-devel
+    tar -xzf "${CONCOURSE_WORK_DIR}"/bin_gpdb/*.tar.gz -C /usr/local/greenplum-db-devel
     chown -R gpadmin:gpadmin /usr/local/greenplum-db-devel
 }
 
@@ -127,9 +127,9 @@ function install_gpdb() {
 ## location, we fixes this issue by creating a symbolic link for it.
 function create_fake_gpdb_src() {
     local fake_gpdb_src
-    fake_gpdb_src=/tmp/build/"$(\
-        grep -rnw '/usr/local/greenplum-db-devel' -e 'abs_top_srcdir = .*' |\
-        head -n 1 | awk -F"/" '{print $(NF-1)}')"
+    fake_gpdb_src="$(\
+        grep -rhw '/usr/local/greenplum-db-devel' -e 'abs_top_srcdir = .*' |\
+        head -n 1 | awk '{ print $NF; }')"
 
     if [ -d "${fake_gpdb_src}" ]; then
         echo "Fake gpdb source directory has been configured."
@@ -142,8 +142,10 @@ function create_fake_gpdb_src() {
         --disable-orca --disable-gpcloud --enable-debug-extensions
     popd
 
-    mkdir -p "${fake_gpdb_src}"
-    ln -s /home/gpadmin/gpdb_src "${fake_gpdb_src}/gpdb_src"
+    local fake_root
+    fake_root=$(dirname "${fake_gpdb_src}")
+    mkdir -p "${fake_root}"
+    ln -s /home/gpadmin/gpdb_src "${fake_gpdb_src}"
 }
 
 # Setup common environment

--- a/concourse/tasks/build_diskquota.yml
+++ b/concourse/tasks/build_diskquota.yml
@@ -17,3 +17,4 @@ run:
     - build
 params:
   DISKQUOTA_OS:
+  BUILD_TYPE:

--- a/diskquota.c
+++ b/diskquota.c
@@ -226,8 +226,14 @@ disk_quota_sigusr1(SIGNAL_ARGS)
 static void
 define_guc_variables(void)
 {
+#if DISKQUOTA_DEBUG
+	const int min_naptime = 0;
+#else
+	const int min_naptime = 1;
+#endif
+
 	DefineCustomIntVariable("diskquota.naptime", "Duration between each check (in seconds).", NULL, &diskquota_naptime,
-	                        2, 0, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);
+	                        2, min_naptime, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);
 
 	DefineCustomIntVariable("diskquota.max_active_tables", "Max number of active tables monitored by disk-quota.", NULL,
 	                        &diskquota_max_active_tables, 1 * 1024 * 1024, 1, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,20 @@
 include(${CMAKE_SOURCE_DIR}/cmake/Regress.cmake)
 
+# Test cases need fault injector needs to be excluded from release build.
+# GPDB release build doesn't support fault injector
+list(APPEND exclude_regress_for_release
+    test_fetch_table_stat)
+list(APPEND exclude_isolation2_for_release
+    test_relation_size
+    test_blackmap
+    test_vacuum
+    test_truncate
+    test_worker_timeout)
+if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(load_inject_fault_opts
+        --dbname=contrib_regression)
+endif()
+
 RegressTarget_Add(regress
     INIT_FILE
     ${CMAKE_CURRENT_SOURCE_DIR}/init_file
@@ -8,8 +23,10 @@ RegressTarget_Add(regress
     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/regress/diskquota_schedule
+    EXCLUDE
+    ${exclude_regress_for_release}
     REGRESS_OPTS
-    --load-extension=gp_inject_fault
+    ${load_inject_fault_opts}
     --dbname=contrib_regression)
 
 RegressTarget_Add(isolation2
@@ -22,8 +39,10 @@ RegressTarget_Add(isolation2
     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/isolation2_schedule
+    EXCLUDE
+    ${exclude_isolation2_for_release}
     REGRESS_OPTS
-    --load-extension=gp_inject_fault
+    ${load_inject_fault_opts}
     --dbname=isolation2test)
 
 add_custom_target(installcheck)

--- a/tests/isolation2/expected/config.out
+++ b/tests/isolation2/expected/config.out
@@ -10,11 +10,14 @@
 (exited with code 0)
 
 -- Show the values of all GUC variables
+--start_ignore
+-- naptime cannot be 0 for release build
 1: SHOW diskquota.naptime;
  diskquota.naptime 
 -------------------
  0                 
 (1 row)
+--end_ignore
 1: SHOW diskquota.max_active_tables;
  diskquota.max_active_tables 
 -----------------------------

--- a/tests/isolation2/expected/reset_config.out
+++ b/tests/isolation2/expected/reset_config.out
@@ -1,4 +1,4 @@
-!\retcode gpconfig -c diskquota.naptime -v 10;
+!\retcode gpconfig -c diskquota.naptime -v 2;
 (exited with code 0)
 !\retcode gpstop -u;
 (exited with code 0)
@@ -6,5 +6,5 @@
 1: SHOW diskquota.naptime;
  diskquota.naptime 
 -------------------
- 10                
+ 2                 
 (1 row)

--- a/tests/isolation2/expected/test_postmaster_restart.out
+++ b/tests/isolation2/expected/test_postmaster_restart.out
@@ -26,7 +26,7 @@ SET
 (1 row)
 
 -- expect fail
-1: CREATE TABLE t1 AS SELECT generate_series(1,1000000);
+1: CREATE TABLE t1 AS SELECT generate_series(1,10000000);
 ERROR:  schema's disk space quota exceeded with name:157893  (seg0 127.0.0.1:6002 pid=1025673)
 1q: ... <quitting>
 
@@ -112,7 +112,7 @@ SET
  t                         
 (1 row)
 -- expect fail
-1: CREATE TABLE t2 AS SELECT generate_series(1,1000000);
+1: CREATE TABLE t2 AS SELECT generate_series(1,10000000);
 ERROR:  schema's disk space quota exceeded with name:158089  (seg0 127.0.0.1:6002 pid=1027799)
 -- enlarge the quota limits
 1: SELECT diskquota.set_schema_quota('postmaster_restart_s', '100 MB');

--- a/tests/isolation2/sql/config.sql
+++ b/tests/isolation2/sql/config.sql
@@ -9,6 +9,9 @@ CREATE DATABASE diskquota;
 !\retcode gpstop -raf;
 
 -- Show the values of all GUC variables
+--start_ignore
+-- naptime cannot be 0 for release build
 1: SHOW diskquota.naptime;
+--end_ignore
 1: SHOW diskquota.max_active_tables;
 1: SHOW diskquota.worker_timeout;

--- a/tests/isolation2/sql/reset_config.sql
+++ b/tests/isolation2/sql/reset_config.sql
@@ -1,4 +1,4 @@
-!\retcode gpconfig -c diskquota.naptime -v 10;
+!\retcode gpconfig -c diskquota.naptime -v 2;
 !\retcode gpstop -u;
 
 1: SHOW diskquota.naptime;

--- a/tests/isolation2/sql/test_postmaster_restart.sql
+++ b/tests/isolation2/sql/test_postmaster_restart.sql
@@ -8,7 +8,7 @@
 1: SELECT diskquota.wait_for_worker_new_epoch();
 
 -- expect fail
-1: CREATE TABLE t1 AS SELECT generate_series(1,1000000);
+1: CREATE TABLE t1 AS SELECT generate_series(1,10000000);
 1q:
 
 -- launcher should exist
@@ -40,7 +40,7 @@
 1: SET search_path TO postmaster_restart_s;
 1: SELECT diskquota.wait_for_worker_new_epoch();
 -- expect fail
-1: CREATE TABLE t2 AS SELECT generate_series(1,1000000);
+1: CREATE TABLE t2 AS SELECT generate_series(1,10000000);
 -- enlarge the quota limits
 1: SELECT diskquota.set_schema_quota('postmaster_restart_s', '100 MB');
 1: SELECT diskquota.wait_for_worker_new_epoch();

--- a/tests/regress/expected/config.out
+++ b/tests/regress/expected/config.out
@@ -1,11 +1,13 @@
 \c
 -- Show the values of all GUC variables
+-- start_ignore
+-- naptime cannot be 0 on Release build, so it will be 2
 SHOW diskquota.naptime;
  diskquota.naptime 
 -------------------
  0
 (1 row)
-
+-- end_ignore
 SHOW diskquota.max_active_tables;
  diskquota.max_active_tables 
 -----------------------------

--- a/tests/regress/expected/reset_config.out
+++ b/tests/regress/expected/reset_config.out
@@ -1,6 +1,6 @@
 SHOW diskquota.naptime;
  diskquota.naptime 
 -------------------
- 10
+ 2
 (1 row)
 

--- a/tests/regress/expected/test_ctas_pause.out
+++ b/tests/regress/expected/test_ctas_pause.out
@@ -15,7 +15,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 (1 row)
 
 -- heap table
-CREATE TABLE t1 (i) AS SELECT generate_series(1,1000000) DISTRIBUTED BY (i); -- expect fail
+CREATE TABLE t1 (i) AS SELECT generate_series(1,5000000) DISTRIBUTED BY (i); -- expect fail
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  schema's disk space quota exceeded with name:110528  (seg1 127.0.0.1:6003 pid=73892)
@@ -25,7 +25,7 @@ SELECT diskquota.pause();
  
 (1 row)
 
-CREATE TABLE t1 (i) AS SELECT generate_series(1,1000000) DISTRIBUTED BY (i); -- expect succeed
+CREATE TABLE t1 (i) AS SELECT generate_series(1,5000000) DISTRIBUTED BY (i); -- expect succeed
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- disable hardlimit and do some clean-ups.

--- a/tests/regress/expected/test_default_tablespace.out
+++ b/tests/regress/expected/test_default_tablespace.out
@@ -31,6 +31,12 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to success
 INSERT INTO t SELECT generate_series(1, 100);
 INSERT INTO t SELECT generate_series(1, 1000000);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
 ERROR:  tablespace:pg_default role:role1 diskquota exceeded
@@ -96,6 +102,12 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to success
 CREATE TABLE t_in_custom_tablespace (i) AS SELECT generate_series(1, 100) DISTRIBUTED BY (i);
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 -- expect insert to fail
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
 ERROR:  tablespace:custom_tablespace role:role1 diskquota exceeded

--- a/tests/regress/expected/test_drop_after_pause.out
+++ b/tests/regress/expected/test_drop_after_pause.out
@@ -45,7 +45,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t
 (1 row)
 
-INSERT INTO SX.a SELECT generate_series(1,1000000); -- expect insert fail
+INSERT INTO SX.a SELECT generate_series(1,10000000); -- expect insert fail
 ERROR:  schema's disk space quota exceeded with name:16933  (seg2 127.0.0.1:6004 pid=24622)
 \! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null

--- a/tests/regress/expected/test_update_db_cache.out
+++ b/tests/regress/expected/test_update_db_cache.out
@@ -41,7 +41,7 @@ WARNING:  database is not empty, please run `select diskquota.init_table_size_ta
 -- FIXME: We cannot use wait_for_worker_new_epoch() here because 
 -- diskquota.state is not clean. Change sleep() to wait() after removing
 -- diskquota.state
-SELECT pg_sleep(1);
+SELECT pg_sleep(5);
  pg_sleep 
 ----------
  

--- a/tests/regress/sql/config.sql
+++ b/tests/regress/sql/config.sql
@@ -11,7 +11,9 @@ CREATE DATABASE diskquota;
 
 \c
 -- Show the values of all GUC variables
+-- start_ignore
 SHOW diskquota.naptime;
+-- end_ignore
 SHOW diskquota.max_active_tables;
 SHOW diskquota.worker_timeout;
 SHOW diskquota.hard_limit;

--- a/tests/regress/sql/reset_config.sql
+++ b/tests/regress/sql/reset_config.sql
@@ -1,5 +1,5 @@
 --start_ignore
-\! gpconfig -c diskquota.naptime -v 10
+\! gpconfig -c diskquota.naptime -v 2
 \! gpstop -u
 --end_ignore
 

--- a/tests/regress/sql/test_ctas_pause.sql
+++ b/tests/regress/sql/test_ctas_pause.sql
@@ -7,11 +7,11 @@ SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
 SELECT diskquota.wait_for_worker_new_epoch();
 
 -- heap table
-CREATE TABLE t1 (i) AS SELECT generate_series(1,1000000) DISTRIBUTED BY (i); -- expect fail
+CREATE TABLE t1 (i) AS SELECT generate_series(1,5000000) DISTRIBUTED BY (i); -- expect fail
 
 SELECT diskquota.pause();
 
-CREATE TABLE t1 (i) AS SELECT generate_series(1,1000000) DISTRIBUTED BY (i); -- expect succeed
+CREATE TABLE t1 (i) AS SELECT generate_series(1,5000000) DISTRIBUTED BY (i); -- expect succeed
 
 -- disable hardlimit and do some clean-ups.
 \! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null

--- a/tests/regress/sql/test_default_tablespace.sql
+++ b/tests/regress/sql/test_default_tablespace.sql
@@ -23,6 +23,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to success
 INSERT INTO t SELECT generate_series(1, 100);
 INSERT INTO t SELECT generate_series(1, 1000000);
+SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to fail
 INSERT INTO t SELECT generate_series(1, 1000000);
 
@@ -64,6 +65,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to success
 CREATE TABLE t_in_custom_tablespace (i) AS SELECT generate_series(1, 100) DISTRIBUTED BY (i);
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
+SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert to fail
 INSERT INTO t_in_custom_tablespace SELECT generate_series(1, 1000000);
 

--- a/tests/regress/sql/test_drop_after_pause.sql
+++ b/tests/regress/sql/test_drop_after_pause.sql
@@ -18,7 +18,7 @@ CREATE SCHEMA SX;
 CREATE TABLE SX.a(i int) DISTRIBUTED BY (i);
 SELECT diskquota.set_schema_quota('SX', '1MB');
 SELECT diskquota.wait_for_worker_new_epoch();
-INSERT INTO SX.a SELECT generate_series(1,1000000); -- expect insert fail
+INSERT INTO SX.a SELECT generate_series(1,10000000); -- expect insert fail
 
 \! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null

--- a/tests/regress/sql/test_update_db_cache.sql
+++ b/tests/regress/sql/test_update_db_cache.sql
@@ -31,7 +31,7 @@ CREATE EXTENSION diskquota;
 -- FIXME: We cannot use wait_for_worker_new_epoch() here because 
 -- diskquota.state is not clean. Change sleep() to wait() after removing
 -- diskquota.state
-SELECT pg_sleep(1);
+SELECT pg_sleep(5);
 
 -- Should find nothing since t_no_extension is not recorded.
 SELECT diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])


### PR DESCRIPTION
- Introduce macro DISKQUOTA_DEBUG through CMAKE_BUILD_TYPE. For the
  debug build, check the macro and allow naptime = 0. The min naptime
  for release build is 1 to prevent high cpu usage in user's
  environment.
- Add EXCLUDE arg to Regree.cmake to skip some tests for the release
  build since the release GPDB build doesn't support fault injector.
- Use GPDB release candidate to compile diskquota release. The release
  candidate has assertion disabled in the pg_config.h.
- Set naptime=0 in the config.sql won't take effect for diskquota
  release since it is less than the min value. So the naptime stays the
  same (normally the default value, 2). This fails some of the test,
  especially the hardlimit related ones. If the insertion takes less
  time than naptime (2 seconds, normally), it fails since the limitation
  has not been dispatched before finish. Thus, the naptime is set to 2
  seconds instead of 10 in the reset_config.
