### PR TITLE
slack-alert and PR pipeline fix

### DIFF
--- a/concourse/pipeline/dev.yml
+++ b/concourse/pipeline/dev.yml
@@ -14,10 +14,10 @@
 #@ res_type_map = {}
 #@ trigger = commit_dev_trigger(res_map)
 #@ confs= [
-#@   centos6_gpdb6_conf(release_build=True),
-#@   centos7_gpdb6_conf(release_build=True),
-#@   rhel8_gpdb6_conf(release_build=True),
-#@   ubuntu18_gpdb6_conf(release_build=True)
+#@   centos6_gpdb6_conf(release_build=False),
+#@   centos7_gpdb6_conf(release_build=False),
+#@   rhel8_gpdb6_conf(release_build=False),
+#@   ubuntu18_gpdb6_conf(release_build=False)
 #@ ]
 jobs:
 #@ param = {

--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -57,6 +57,9 @@ plan:
 - trigger: true
   _: #@ template.replace(to_get)
 #@   end
+#@   for to_put in trigger["to_put"]:
+- #@ to_put
+#@   end
 #@ end
 
 #! Like the entrance_job, with more static checks.
@@ -71,6 +74,9 @@ plan:
 - trigger: true
   _: #@ template.replace(to_get)
 #@   end
+#@   for to_put in trigger["to_put"]:
+- #@ to_put
+#@   end
 - get: clang-format-image
 - task: check_clang_format
   image: clang-format-image
@@ -80,6 +86,44 @@ plan:
     platform: linux
     run:
       path: diskquota_src/concourse/scripts/check-clang-format.sh
+#@ end
+
+#@ def exit_job(param):
+#@   trigger = param["trigger"]
+#@   confs = param["confs"]
+#@   passed_jobs = []
+#@   for conf in confs:
+#@     passed_jobs.append(build_test_job_name(conf))
+#@   end
+name: exit
+on_failure: #@ trigger["on_failure"]
+on_error: #@ trigger["on_error"]
+on_success: #@ trigger["on_success"]
+plan:
+#@   for to_get in trigger["to_get"]:
+- passed: passed_jobs
+  trigger: true
+  _: #@ template.replace(to_get)
+#@   end
+#@ end
+
+#@ def exit_pr_job(param):
+#@   trigger = param["trigger"]
+#@   confs = param["confs"]
+#@   passed_jobs = []
+#@   for conf in confs:
+#@     passed_jobs.append(build_test_job_name(conf))
+#@   end
+name: exit_pr
+on_failure: #@ trigger["on_failure"]
+on_error: #@ trigger["on_error"]
+on_success: #@ trigger["on_success"]
+plan:
+#@   for to_get in trigger["to_get"]:
+- passed: #@ passed_jobs
+  trigger: true
+  _: #@ template.replace(to_get)
+#@   end
 #@ end
 
 #@ def _build_task(conf):
@@ -105,6 +149,9 @@ params:
   DISKQUOTA_OS: #@ conf["os"]
 #@ end
 
+#@ def build_test_job_name(conf):
+#@   return "build_test_" + conf["os"]
+#@ end
 #@ def build_test_job(param):
 #@   res_map = param["res_map"]
 #@   trigger = param["trigger"]
@@ -113,9 +160,8 @@ params:
 #@   add_res_by_name(res_map, "bin_cmake")
 #@   add_res_by_name(res_map, "bin_diskquota_intermediates")
 #@   add_res_by_conf(res_map, conf)
-name: #@ "build_test_" + conf["os"]
+name: #@ build_test_job_name(conf)
 max_in_flight: 10
-on_success: #@ trigger["on_success"]
 on_failure: #@ trigger["on_failure"]
 on_error: #@ trigger["on_error"]
 plan:
@@ -123,9 +169,6 @@ plan:
 - passed: [entrance]
   trigger: true
   _: #@ template.replace(to_get)
-#@   end
-#@   for to_put in trigger["to_put"]:
-- #@ to_put
 #@   end
 - in_parallel:
   - get: gpdb_src

--- a/concourse/pipeline/pr.yml
+++ b/concourse/pipeline/pr.yml
@@ -1,5 +1,6 @@
 #@ load("job_def.lib.yml",
 #@   "entrance_check_job",
+#@   "exit_pr_job",
 #@   "build_test_job",
 #@   "centos6_gpdb6_conf",
 #@   "centos7_gpdb6_conf",
@@ -36,6 +37,11 @@ jobs:
 #@   }
 - #@ build_test_job(param)
 #@ end
+#@ param = {
+#@     "trigger": trigger,
+#@     "confs": confs
+#@ }
+- #@ exit_pr_job(param)
 
 resources: #@ declare_res(res_type_map, res_map)
 

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -11,6 +11,11 @@ resource_types:
   source:
     repository: teliaoss/github-pr-resource
 
+- name: slack-alert
+  type: docker-image
+  source:
+    repository: arbourd/concourse-slack-alert-resource
+
 resources:
 # Pull Request
 - name: diskquota_pr
@@ -229,3 +234,7 @@ resources:
     bucket: gpdb-extensions-concourse-resources
     json_key: ((extensions-gcs-service-account-key))
     regexp: dependencies/cmake-(.*)-linux-x86_64.sh
+- name: slack_notify
+  type: slack-alert
+  source:
+    url: ((extensions-slack-webhook))

--- a/concourse/pipeline/trigger_def.lib.yml
+++ b/concourse/pipeline/trigger_def.lib.yml
@@ -33,6 +33,7 @@ on_success:
 #! Commit trigger. For master pipelines
 #@ def commit_trigger(res_map):
 #@   add_res_by_name(res_map, "diskquota_commit")
+#@   add_res_by_name(res_map, "slack_notify")
 to_get:
 - get: diskquota_src
   resource: diskquota_commit
@@ -41,7 +42,13 @@ to_put: #@ []
 #! Unfortunately it doesn't work with Concourse 5.
 on_success:
 on_failure:
+  put: slack_notify
+  params:
+    alert_type: failed
 on_error:
+  put: slack_notify
+  params:
+    alert_type: errored
 #@ end
 
 #! Commit trigger. For dev pipelines. No webhook


### PR DESCRIPTION
- Add a slack alert when commit pipeline fails
- Add exit job to set successful state. That state cannot be set by
  individual job since at that point, the whole pipeline is not finished
  yet.