### PR TITLE
Don't format errno as '%d' in error messages.

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -595,8 +595,8 @@ create_monitor_db_table(void)
 		ret_code = SPI_execute(sql, false, 0);
 		if (ret_code != SPI_OK_UTILITY)
 		{
-			ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute error, sql: \"%s\", errno: %d, ret_code: %d.", sql,
-			                       errno, ret_code)));
+			ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute error, sql: \"%s\", reason: %s, ret_code: %d.", sql,
+			                       strerror(errno), ret_code)));
 		}
 	}
 	PG_CATCH();
@@ -642,12 +642,12 @@ start_workers_from_dblist(void)
 	PushActiveSnapshot(GetTransactionSnapshot());
 	ret = SPI_connect();
 	if (ret != SPI_OK_CONNECT)
-		ereport(ERROR, (errmsg("[diskquota launcher] SPI connect error, errno: %d, return code: %d.", errno, ret)));
+		ereport(ERROR, (errmsg("[diskquota launcher] SPI connect error, reason: %s, return code: %d.", strerror(errno), ret)));
 	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
 		ereport(ERROR,
-		        (errmsg("[diskquota launcher] 'select diskquota_namespace.database_list', errno: %d, return code: %d",
-		                errno, ret)));
+		        (errmsg("[diskquota launcher] 'select diskquota_namespace.database_list', reason: %s, return code: %d.",
+		                strerror(errno), ret)));
 	tupdesc = SPI_tuptable->tupdesc;
 	if (tupdesc->natts != 1 || tupdesc->attrs[0]->atttypid != OIDOID)
 	{
@@ -895,8 +895,8 @@ add_dbid_to_database_list(Oid dbid)
 
 	if (ret != SPI_OK_SELECT)
 		ereport(ERROR, (errmsg("[diskquota launcher] error occured while checking database_list, "
-		                       " code = %d errno = %d",
-		                       ret, errno)));
+		                       " code: %d, reason: %s.",
+		                       ret, strerror(errno))));
 
 	if (SPI_processed == 1)
 	{
@@ -911,8 +911,8 @@ add_dbid_to_database_list(Oid dbid)
 
 	if (ret != SPI_OK_INSERT || SPI_processed != 1)
 		ereport(ERROR, (errmsg("[diskquota launcher] error occured while updating database_list, "
-		                       " code = %d errno = %d",
-		                       ret, errno)));
+		                       " code: %d, reason: %s.",
+		                       ret, strerror(errno))));
 
 	return;
 }
@@ -937,7 +937,7 @@ del_dbid_from_database_list(Oid dbid)
 	                            NULL, false, 0);
 
 	ereportif(ret != SPI_OK_DELETE, ERROR,
-	          (errmsg("[diskquota launcher] del_dbid_from_database_list: errno: %d, ret_code: %d.", errno, ret)));
+	          (errmsg("[diskquota launcher] del_dbid_from_database_list: reason: %s, ret_code: %d.", strerror(errno), ret)));
 }
 
 /*

--- a/diskquota.c
+++ b/diskquota.c
@@ -595,8 +595,8 @@ create_monitor_db_table(void)
 		ret_code = SPI_execute(sql, false, 0);
 		if (ret_code != SPI_OK_UTILITY)
 		{
-			ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute error, sql: \"%s\", reason: %s, ret_code: %d.", sql,
-			                       strerror(errno), ret_code)));
+			ereport(ERROR, (errmsg("[diskquota launcher] SPI_execute error, sql: \"%s\", reason: %s, ret_code: %d.",
+			                       sql, strerror(errno), ret_code)));
 		}
 	}
 	PG_CATCH();
@@ -642,7 +642,8 @@ start_workers_from_dblist(void)
 	PushActiveSnapshot(GetTransactionSnapshot());
 	ret = SPI_connect();
 	if (ret != SPI_OK_CONNECT)
-		ereport(ERROR, (errmsg("[diskquota launcher] SPI connect error, reason: %s, return code: %d.", strerror(errno), ret)));
+		ereport(ERROR,
+		        (errmsg("[diskquota launcher] SPI connect error, reason: %s, return code: %d.", strerror(errno), ret)));
 	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
 		ereport(ERROR,
@@ -937,7 +938,8 @@ del_dbid_from_database_list(Oid dbid)
 	                            NULL, false, 0);
 
 	ereportif(ret != SPI_OK_DELETE, ERROR,
-	          (errmsg("[diskquota launcher] del_dbid_from_database_list: reason: %s, ret_code: %d.", strerror(errno), ret)));
+	          (errmsg("[diskquota launcher] del_dbid_from_database_list: reason: %s, ret_code: %d.", strerror(errno),
+	                  ret)));
 }
 
 /*

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -509,7 +509,8 @@ is_database_empty(void)
 	        "  pg_namespace AS n "
 	        "WHERE c.oid > 16384 and relnamespace = n.oid and nspname != 'diskquota'",
 	        true, 0);
-	if (ret != SPI_OK_SELECT) elog(ERROR, "cannot select pg_class and pg_namespace table, reason: %s.", strerror(errno));
+	if (ret != SPI_OK_SELECT)
+		elog(ERROR, "cannot select pg_class and pg_namespace table, reason: %s.", strerror(errno));
 
 	tupdesc = SPI_tuptable->tupdesc;
 	/* check sql return value whether database is empty */

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -509,7 +509,7 @@ is_database_empty(void)
 	        "  pg_namespace AS n "
 	        "WHERE c.oid > 16384 and relnamespace = n.oid and nspname != 'diskquota'",
 	        true, 0);
-	if (ret != SPI_OK_SELECT) elog(ERROR, "cannot select pg_class and pg_namespace table: error code %d", errno);
+	if (ret != SPI_OK_SELECT) elog(ERROR, "cannot select pg_class and pg_namespace table, reason: %s.", strerror(errno));
 
 	tupdesc = SPI_tuptable->tupdesc;
 	/* check sql return value whether database is empty */


### PR DESCRIPTION
Actually, errno *isn't* strictly an integer. It depends on your
operating system. Instead of formatting it as an integer, we should
transform it to C style string and format it as '%s'.

e.g., on my laptop the definition of errno is:

```C
/* The error code set by various library functions.  */
extern int *__errno_location (void) __THROW __attribute_const__;
# define errno (*__errno_location ())
```