### PR TITLE
Fix cmake build on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,12 @@ set(CMAKE_C_FLAGS_RELEASE "" CACHE
 set(CMAKE_C_FLAGS_DEBUG "-DDISKQUOTA_DEBUG"
     CACHE STRING "Flags for DEBUG build" FORCE)
 # set link flags for all sub-projects
-set(CMAKE_SHARED_LINKER_FLAGS "${PG_LD_FLAGS}")
+set(CMAKE_MODULE_LINKER_FLAGS "${PG_LD_FLAGS}")
+if (APPLE)
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -bundle_loader ${PG_BIN_DIR}/postgres")
+endif()
 # set c and ld flags for all projects
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${PG_C_FLAGS}")
-set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS} ${PG_LD_FLAGS}")
 
 # generate version
 if(NOT DEFINED DISKQUOTA_VERSION)

--- a/tests/data/current_binary_name
+++ b/tests/data/current_binary_name
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
 
-if [ $(grep -P '^1.0' ../../VERSION) ]; then
+if grep -q -E '^1.0' ../../VERSION;  then
     echo -n "diskquota.so"
 else
-    echo -n "diskquota-$(grep -o -P '^\d+.\d+' ../../VERSION).so"
+    echo -n "diskquota-$(grep -o -E '^[0-9]*.[0-9]*' ../../VERSION).so"
 fi


### PR DESCRIPTION
- Mac needs extra linker options that the symbols in the postgres
  executable can be found.
- Mac's grep doesn't have '-P' option.
- To make a extension so file, we use a 'module' target instead of
  'shared' on purpose. Since "A SHARED library may be marked with
  the FRAMEWORK target property to create an macOS Framework."
  Thus, the global link flags should be set through
  CMAKE_MODULE_LINKER_FLAGS than CMAK_SHARED_LINKER_FLAGS.
