### PR TITLE
clean blackmap after drop diskquota

### DIFF
--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -19,10 +19,12 @@
 #include "access/xact.h"
 #include "catalog/catalog.h"
 #include "catalog/objectaccess.h"
+#include "catalog/pg_extension.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbvars.h"
 #include "commands/dbcommands.h"
+#include "commands/extension.h"
 #include "executor/spi.h"
 #include "funcapi.h"
 #include "libpq-fe.h"
@@ -168,6 +170,15 @@ static void
 object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, Oid objectId, int subId, void *arg)
 {
 	if (prev_object_access_hook) (*prev_object_access_hook)(access, classId, objectId, subId, arg);
+
+	// if is 'drop extension diskquota'
+	if (classId == ExtensionRelationId)
+	{
+		if (get_extension_oid("diskquota", true) == objectId)
+		{
+			invalidate_database_blackmap(MyDatabaseId);
+		}
+	}
 
 	/* TODO: do we need to use "&&" instead of "||"? */
 	if (classId != RelationRelationId || subId != 0)

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -28,6 +28,7 @@ test: test_many_active_tables
 test: test_fetch_table_stat
 test: test_appendonly
 test: test_blackmap
+test: test_clean_blackmap_after_drop
 test: test_ctas_pause
 test: test_ctas_role
 test: test_ctas_schema

--- a/tests/regress/expected/test_clean_blackmap_after_drop.out
+++ b/tests/regress/expected/test_clean_blackmap_after_drop.out
@@ -1,0 +1,30 @@
+CREATE DATABASE test_clean_blackmap_after_drop;
+\c test_clean_blackmap_after_drop
+CREATE EXTENSION diskquota;
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpstop -u > /dev/null
+CREATE ROLE r;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SELECT diskquota.set_role_quota('r', '1MB');
+ set_role_quota 
+----------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
+ALTER TABLE b OWNER TO r;
+INSERT INTO b SELECT generate_series(1, 100000); -- fail
+ERROR:  role's disk space quota exceeded with name:40716  (seg2 127.0.0.1:6004 pid=1245042)
+DROP EXTENSION diskquota;
+INSERT INTO b SELECT generate_series(1, 100); -- ok
+\c contrib_regression
+DROP DATABASE test_clean_blackmap_after_drop;
+DROP ROLE r;
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
+\! gpstop -u > /dev/null

--- a/tests/regress/expected/test_clean_blackmap_after_drop.out
+++ b/tests/regress/expected/test_clean_blackmap_after_drop.out
@@ -11,14 +11,14 @@ SELECT diskquota.set_role_quota('r', '1MB');
  
 (1 row)
 
+CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
+ALTER TABLE b OWNER TO r;
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
  t
 (1 row)
 
-CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
-ALTER TABLE b OWNER TO r;
 INSERT INTO b SELECT generate_series(1, 100000); -- fail
 ERROR:  role's disk space quota exceeded with name:40716  (seg2 127.0.0.1:6004 pid=1245042)
 DROP EXTENSION diskquota;

--- a/tests/regress/sql/test_clean_blackmap_after_drop.sql
+++ b/tests/regress/sql/test_clean_blackmap_after_drop.sql
@@ -8,10 +8,9 @@ CREATE EXTENSION diskquota;
 
 CREATE ROLE r;
 SELECT diskquota.set_role_quota('r', '1MB');
-SELECT diskquota.wait_for_worker_new_epoch();
-
 CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
 ALTER TABLE b OWNER TO r;
+SELECT diskquota.wait_for_worker_new_epoch();
 
 INSERT INTO b SELECT generate_series(1, 100000); -- fail
 

--- a/tests/regress/sql/test_clean_blackmap_after_drop.sql
+++ b/tests/regress/sql/test_clean_blackmap_after_drop.sql
@@ -1,0 +1,27 @@
+CREATE DATABASE test_clean_blackmap_after_drop;
+
+\c test_clean_blackmap_after_drop
+CREATE EXTENSION diskquota;
+
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpstop -u > /dev/null
+
+CREATE ROLE r;
+SELECT diskquota.set_role_quota('r', '1MB');
+SELECT diskquota.wait_for_worker_new_epoch();
+
+CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
+ALTER TABLE b OWNER TO r;
+
+INSERT INTO b SELECT generate_series(1, 100000); -- fail
+
+DROP EXTENSION diskquota;
+
+INSERT INTO b SELECT generate_series(1, 100); -- ok
+
+\c contrib_regression
+DROP DATABASE test_clean_blackmap_after_drop;
+DROP ROLE r;
+
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
+\! gpstop -u > /dev/null


### PR DESCRIPTION
    Fix hardlimit exceed after drop diskquota.

    fix this scenario:
      - create hard limit
      - blackmap on segment was updated
      - drop diskquota
      - the blackmap on segment is not cleanup

    use ObjectAccess hook on segment. when drop diskquota. clean up the in
    memory blackmap.