### PR TITLE
Fix tablespace per segment ratio

### DIFF
--- a/diskquota--1.0--2.0.sql
+++ b/diskquota--1.0--2.0.sql
@@ -11,7 +11,7 @@ CREATE TABLE diskquota.target (
 );
 -- TODO ALTER TABLE diskquota.target SET DEPENDS ON EXTENSION diskquota;
 
-ALTER TABLE diskquota.table_size ADD COLUMN segid smallint DEFAULT 0; -- segid = coordinator means table size in cluster level
+ALTER TABLE diskquota.table_size ADD COLUMN segid smallint DEFAULT -1; -- segid = coordinator means table size in cluster level
 ALTER TABLE diskquota.table_size DROP CONSTRAINT table_size_pkey;
 ALTER TABLE diskquota.table_size ADD PRIMARY KEY (tableid, segid);
 ALTER TABLE diskquota.table_size SET WITH (REORGANIZE=true) DISTRIBUTED BY (tableid, segid);

--- a/diskquota--1.0--2.0.sql
+++ b/diskquota--1.0--2.0.sql
@@ -1,7 +1,7 @@
 -- TODO check if worker should not refresh, current lib should be diskquota-2.0.so
 
 -- table part
-ALTER TABLE diskquota.quota_config ADD COLUMN segratio float4 DEFAULT -1;
+ALTER TABLE diskquota.quota_config ADD COLUMN segratio float4 DEFAULT 0;
 
 CREATE TABLE diskquota.target (
 	quotatype int, -- REFERENCES disquota.quota_config.quotatype,
@@ -11,7 +11,7 @@ CREATE TABLE diskquota.target (
 );
 -- TODO ALTER TABLE diskquota.target SET DEPENDS ON EXTENSION diskquota;
 
-ALTER TABLE diskquota.table_size ADD COLUMN segid smallint DEFAULT -1; -- segid = coordinator means table size in cluster level
+ALTER TABLE diskquota.table_size ADD COLUMN segid smallint DEFAULT 0; -- segid = coordinator means table size in cluster level
 ALTER TABLE diskquota.table_size DROP CONSTRAINT table_size_pkey;
 ALTER TABLE diskquota.table_size ADD PRIMARY KEY (tableid, segid);
 ALTER TABLE diskquota.table_size SET WITH (REORGANIZE=true) DISTRIBUTED BY (tableid, segid);

--- a/diskquota--2.0.sql
+++ b/diskquota--2.0.sql
@@ -7,7 +7,7 @@ CREATE TABLE diskquota.quota_config(
 	targetOid oid,
 	quotatype int,
 	quotalimitMB int8,
-	segratio float4 DEFAULT -1,
+	segratio float4 DEFAULT 0,
 	PRIMARY KEY(targetOid, quotatype)
 ) DISTRIBUTED BY (targetOid, quotatype);
 

--- a/diskquota.h
+++ b/diskquota.h
@@ -18,23 +18,22 @@
 
 /* max number of monitored database with diskquota enabled */
 #define MAX_NUM_MONITORED_DB 10
-/* TABLESPACE_QUOTA
- * used to store the tablespace segratio value in quota_config
- * table. It doesn't store valid disk quota.
- * When set_per_segment_quota("xx",1.0) is called, a new
- * config will be added like:
- *
- *  97103 |         4 |            0 |        1
- *
- * 0 means invalid quota configed
- * 4 means TABLESPACE_QUOTA
- */
 typedef enum
 {
 	NAMESPACE_QUOTA = 0,
 	ROLE_QUOTA,
 	NAMESPACE_TABLESPACE_QUOTA,
 	ROLE_TABLESPACE_QUOTA,
+	/*
+	 * TABLESPACE_QUOTA
+	 * used in `quota_config` table,
+	 * when set_per_segment_quota("xx",1.0) is called
+	 * to set per segment quota to '1.0', the config
+	 * will be:
+	 * quotatype = 4 (TABLESPACE_QUOTA)
+	 * quotalimitMB = 0 (invalid quota confined)
+	 * segratio = 1.0
+	 */
 	TABLESPACE_QUOTA,
 
 	NUM_QUOTA_TYPES

--- a/diskquota.h
+++ b/diskquota.h
@@ -18,13 +18,24 @@
 
 /* max number of monitored database with diskquota enabled */
 #define MAX_NUM_MONITORED_DB 10
-
+/* TABLESPACE_QUOTA
+ * used to store the tablespace segratio value in quota_config
+ * table. It doesn't store valid disk quota.
+ * When set_per_segment_quota("xx","1.0) is called, a new
+ * config will be added like:
+ *
+ *  97103 |         4 |            0 |        1
+ *
+ * 0 means invalid quota configed
+ * 4 means TABLESPACE_QUOTA
+ */
 typedef enum
 {
 	NAMESPACE_QUOTA = 0,
 	ROLE_QUOTA,
 	NAMESPACE_TABLESPACE_QUOTA,
 	ROLE_TABLESPACE_QUOTA,
+	TABLESPACE_QUOTA,
 
 	NUM_QUOTA_TYPES
 } QuotaType;

--- a/diskquota.h
+++ b/diskquota.h
@@ -21,7 +21,7 @@
 /* TABLESPACE_QUOTA
  * used to store the tablespace segratio value in quota_config
  * table. It doesn't store valid disk quota.
- * When set_per_segment_quota("xx","1.0) is called, a new
+ * When set_per_segment_quota("xx",1.0) is called, a new
  * config will be added like:
  *
  *  97103 |         4 |            0 |        1

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -1208,7 +1208,7 @@ set_per_segment_quota(PG_FUNCTION_ARGS)
 	 * (EXLUSIZE lock), if we don't lock the table in
 	 * exlusive mode first, deadlock will heappen.
 	 */
-	ret = SPI_execute("LOCK TABLE diskquota.quota_config IN MODE EXLUSIVE", false, 0);
+	ret = SPI_execute("LOCK TABLE diskquota.quota_config IN EXCLUSIVE MODE", false, 0);
 	if (ret != SPI_OK_UTILITY) elog(ERROR, "cannot lock quota_config table, error code %d", ret);
 
 	/*

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -65,6 +65,15 @@ PG_FUNCTION_INFO_V1(pull_all_table_size);
 
 /* timeout count to wait response from launcher process, in 1/10 sec */
 #define WAIT_TIME_COUNT 1200
+/*
+ * three types values for "quota" column in "quota_config" table:
+ * 1) more than 0: valid value
+ * 2) equal to 0: meaningless value, rejected by diskquota UDF
+ * 3) less than 0: to delete the quota config in the table
+ *
+ * the values for segratio column are the same as quota column
+ *
+ */
 #define DEFAULT_SEGRATIO -1.0
 #define INVALID_SEGRATIO 0.0
 #define INVALID_QUOTA 0

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -898,7 +898,8 @@ set_quota_config_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type, f
 	{
 		if (SPI_processed == 0)
 		{
-			if (segratio == INVALID_SEGRATIO && !(type == ROLE_QUOTA || type == NAMESPACE_QUOTA)) segratio = get_per_segment_ratio(spcoid);
+			if (segratio == INVALID_SEGRATIO && !(type == ROLE_QUOTA || type == NAMESPACE_QUOTA))
+				segratio = get_per_segment_ratio(spcoid);
 			ret = SPI_execute_with_args("insert into diskquota.quota_config values($1, $2, $3, $4)", 4,
 			                            (Oid[]){
 			                                    OIDOID,

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -854,7 +854,7 @@ set_quota_config_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type, f
 
 	if (to_delete_quota(type, quota_limit_mb, segratio))
 	{
-		if (rows > 0)
+		if (SPI_processed > 0)
 		{
 			ret = SPI_execute_with_args("delete from diskquota.quota_config where targetoid = $1 and quotatype = $2", 2,
 			                            (Oid[]){

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -112,7 +112,8 @@ struct QuotaInfo quota_info[NUM_QUOTA_TYPES] = {
                                         .num_keys  = 2,
                                         .sys_cache = (Oid[]){AUTHOID, TABLESPACEOID},
                                         .map       = NULL},
-        [TABLESPACE_QUOTA]           = {.map_name = "Tablespace map", .num_keys = 1, .sys_cache = (Oid[]){TABLESPACEOID}, .map = NULL}};
+        [TABLESPACE_QUOTA]           = {
+                          .map_name = "Tablespace map", .num_keys = 1, .sys_cache = (Oid[]){TABLESPACEOID}, .map = NULL}};
 
 /* global blacklist for which exceed their quota limit */
 struct BlackMapEntry

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -111,7 +111,8 @@ struct QuotaInfo quota_info[NUM_QUOTA_TYPES] = {
         [ROLE_TABLESPACE_QUOTA]      = {.map_name  = "Tablespace-role map",
                                         .num_keys  = 2,
                                         .sys_cache = (Oid[]){AUTHOID, TABLESPACEOID},
-                                        .map       = NULL}};
+                                        .map       = NULL},
+        [TABLESPACE_QUOTA]           = {.map_name = "Tablespace map", .num_keys = 1, .sys_cache = (Oid[]){TABLESPACEOID}, .map = NULL}};
 
 /* global blacklist for which exceed their quota limit */
 struct BlackMapEntry
@@ -1388,6 +1389,8 @@ prepare_blackmap_search_key(BlackMapEntry *keyitem, QuotaType type, Oid relowner
 		keyitem->targetoid = relowner;
 	else if (type == NAMESPACE_QUOTA || type == NAMESPACE_TABLESPACE_QUOTA)
 		keyitem->targetoid = relnamespace;
+	else if (type == TABLESPACE_QUOTA)
+		keyitem->targetoid = reltablespace;
 	else
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] unknown quota type: %d", type)));
 

--- a/tests/isolation2/expected/test_per_segment_config.out
+++ b/tests/isolation2/expected/test_per_segment_config.out
@@ -211,7 +211,7 @@ COMMIT
 SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
  segratio 
 ----------
- -1.0     
+ 0.0      
 (1 row)
 SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
  segratio 
@@ -252,7 +252,7 @@ COMMIT
 SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
  segratio 
 ----------
- -1.0     
+ 0.0      
 (1 row)
 SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
  segratio 

--- a/tests/isolation2/expected/test_per_segment_config.out
+++ b/tests/isolation2/expected/test_per_segment_config.out
@@ -1,0 +1,269 @@
+-- Test one session read tablespace segratio,
+-- and at the same time, another session
+-- update or insert the segratio
+
+-- start_ignore
+!\retcode mkdir -p /tmp/spc101;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+CREATE SCHEMA s101;
+CREATE
+DROP TABLESPACE IF EXISTS spc101;
+DROP
+CREATE TABLESPACE spc101 LOCATION '/tmp/spc101';
+CREATE
+
+--
+-- There is no tablesapce per segment quota configed yet
+--
+
+-- Read commited, first set_per_segment_quota, then set_schema_tablespace_quota
+1: BEGIN;
+BEGIN
+1: SELECT diskquota.set_per_segment_quota('spc101', 1);
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+2: BEGIN;
+BEGIN
+2&: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ set_schema_tablespace_quota 
+-----------------------------
+                             
+(1 row)
+2: COMMIT;
+COMMIT
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+ segratio 
+----------
+ 1.0      
+(1 row)
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+ segratio 
+----------
+ 1.0      
+(1 row)
+-- cleanup
+truncate table diskquota.quota_config;
+TRUNCATE
+truncate table diskquota.target;
+TRUNCATE
+
+-- Read commited, first set_schema_tablespace_quota, then set_per_segment_quota,
+1: BEGIN;
+BEGIN
+1: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
+ set_schema_tablespace_quota 
+-----------------------------
+                             
+(1 row)
+2: BEGIN;
+BEGIN
+2&: SELECT diskquota.set_per_segment_quota('spc101', 1);  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+2: COMMIT;
+COMMIT
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+ segratio 
+----------
+ 1.0      
+(1 row)
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+ segratio 
+----------
+ 1.0      
+(1 row)
+-- cleanup
+truncate table diskquota.quota_config;
+TRUNCATE
+truncate table diskquota.target;
+TRUNCATE
+
+--
+-- There is already a tablesapce per segment quota configed
+--
+
+-- Read commited, first set_per_segment_quota, then set_schema_tablespace_quota
+SELECT diskquota.set_per_segment_quota('spc101', 2);
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+1: BEGIN;
+BEGIN
+1: SELECT diskquota.set_per_segment_quota('spc101', 1);
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+2: BEGIN;
+BEGIN
+2&: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ set_schema_tablespace_quota 
+-----------------------------
+                             
+(1 row)
+2: COMMIT;
+COMMIT
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+ segratio 
+----------
+ 1.0      
+(1 row)
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+ segratio 
+----------
+ 1.0      
+(1 row)
+-- cleanup
+truncate table diskquota.quota_config;
+TRUNCATE
+truncate table diskquota.target;
+TRUNCATE
+
+-- Read commited, first set_schema_tablespace_quota, then set_per_segment_quota,
+SELECT diskquota.set_per_segment_quota('spc101', 2);
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+1: BEGIN;
+BEGIN
+1: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
+ set_schema_tablespace_quota 
+-----------------------------
+                             
+(1 row)
+2: BEGIN;
+BEGIN
+2&: SELECT diskquota.set_per_segment_quota('spc101', 1);  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+2: COMMIT;
+COMMIT
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+ segratio 
+----------
+ 1.0      
+(1 row)
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+ segratio 
+----------
+ 1.0      
+(1 row)
+-- cleanup
+truncate table diskquota.quota_config;
+TRUNCATE
+truncate table diskquota.target;
+TRUNCATE
+
+-- Read commited, first delete per_segment_quota, then set_schema_tablespace_quota
+SELECT diskquota.set_per_segment_quota('spc101', 2);
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+1: BEGIN;
+BEGIN
+1: SELECT diskquota.set_per_segment_quota('spc101', -1);
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+2: BEGIN;
+BEGIN
+2&: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ set_schema_tablespace_quota 
+-----------------------------
+                             
+(1 row)
+2: COMMIT;
+COMMIT
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+ segratio 
+----------
+ -1.0     
+(1 row)
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+ segratio 
+----------
+(0 rows)
+-- cleanup
+truncate table diskquota.quota_config;
+TRUNCATE
+truncate table diskquota.target;
+TRUNCATE
+
+-- Read commited, first set_schema_tablespace_quota, then delete tablespace per segment ratio
+SELECT diskquota.set_per_segment_quota('spc101', 2);
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+1: BEGIN;
+BEGIN
+1: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
+ set_schema_tablespace_quota 
+-----------------------------
+                             
+(1 row)
+2: BEGIN;
+BEGIN
+2&: SELECT diskquota.set_per_segment_quota('spc101', -1);  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ set_per_segment_quota 
+-----------------------
+                       
+(1 row)
+2: COMMIT;
+COMMIT
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+ segratio 
+----------
+ -1.0     
+(1 row)
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+ segratio 
+----------
+(0 rows)
+-- cleanup
+truncate table diskquota.quota_config;
+TRUNCATE
+truncate table diskquota.target;
+TRUNCATE
+DROP SCHEMA s101;
+DROP
+DROP TABLESPACE spc101;
+DROP

--- a/tests/isolation2/isolation2_schedule
+++ b/tests/isolation2/isolation2_schedule
@@ -6,5 +6,6 @@ test: test_vacuum
 test: test_truncate
 test: test_postmaster_restart
 test: test_worker_timeout
+test: test_per_segment_config
 test: test_drop_extension
 test: reset_config

--- a/tests/isolation2/sql/test_per_segment_config.sql
+++ b/tests/isolation2/sql/test_per_segment_config.sql
@@ -1,0 +1,114 @@
+-- Test one session read tablespace segratio,
+-- and at the same time, another session
+-- update or insert the segratio
+
+-- start_ignore
+!\retcode mkdir -p /tmp/spc101;
+-- end_ignore
+CREATE SCHEMA s101;
+DROP TABLESPACE IF EXISTS spc101;
+CREATE TABLESPACE spc101 LOCATION '/tmp/spc101';
+
+-- 
+-- There is no tablesapce per segment quota configed yet
+--
+
+-- Read commited, first set_per_segment_quota, then set_schema_tablespace_quota
+1: BEGIN;
+1: SELECT diskquota.set_per_segment_quota('spc101', 1);
+2: BEGIN;
+2&: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
+1: COMMIT;
+2<:
+2: COMMIT;
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+-- cleanup
+truncate table diskquota.quota_config;
+truncate table diskquota.target;
+
+-- Read commited, first set_schema_tablespace_quota, then set_per_segment_quota, 
+1: BEGIN;
+1: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
+2: BEGIN;
+2&: SELECT diskquota.set_per_segment_quota('spc101', 1);
+1: COMMIT;
+2<:
+2: COMMIT;
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+-- cleanup
+truncate table diskquota.quota_config;
+truncate table diskquota.target;
+
+-- 
+-- There is already a tablesapce per segment quota configed
+--
+
+-- Read commited, first set_per_segment_quota, then set_schema_tablespace_quota
+SELECT diskquota.set_per_segment_quota('spc101', 2);
+1: BEGIN;
+1: SELECT diskquota.set_per_segment_quota('spc101', 1);
+2: BEGIN;
+2&: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
+1: COMMIT;
+2<:
+2: COMMIT;
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+-- cleanup
+truncate table diskquota.quota_config;
+truncate table diskquota.target;
+
+-- Read commited, first set_schema_tablespace_quota, then set_per_segment_quota, 
+SELECT diskquota.set_per_segment_quota('spc101', 2);
+1: BEGIN;
+1: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
+2: BEGIN;
+2&: SELECT diskquota.set_per_segment_quota('spc101', 1);
+1: COMMIT;
+2<:
+2: COMMIT;
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+-- cleanup
+truncate table diskquota.quota_config;
+truncate table diskquota.target;
+
+-- Read commited, first delete per_segment_quota, then set_schema_tablespace_quota
+SELECT diskquota.set_per_segment_quota('spc101', 2);
+1: BEGIN;
+1: SELECT diskquota.set_per_segment_quota('spc101', -1);
+2: BEGIN;
+2&: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
+1: COMMIT;
+2<:
+2: COMMIT;
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+-- cleanup
+truncate table diskquota.quota_config;
+truncate table diskquota.target;
+
+-- Read commited, first set_schema_tablespace_quota, then delete tablespace per segment ratio
+SELECT diskquota.set_per_segment_quota('spc101', 2);
+1: BEGIN;
+1: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
+2: BEGIN;
+2&: SELECT diskquota.set_per_segment_quota('spc101', -1);
+1: COMMIT;
+2<:
+2: COMMIT;
+
+SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
+-- cleanup
+truncate table diskquota.quota_config;
+truncate table diskquota.target;
+DROP SCHEMA s101;
+DROP TABLESPACE spc101;

--- a/tests/regress/expected/test_tablespace_schema_perseg.out
+++ b/tests/regress/expected/test_tablespace_schema_perseg.out
@@ -15,8 +15,6 @@ SELECT diskquota.set_schema_tablespace_quota('spcs1_perseg', 'schemaspc_perseg',
 
 SET search_path TO spcs1_perseg;
 CREATE TABLE a(i int) TABLESPACE schemaspc_perseg DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO a SELECT generate_series(1,100);
 -- expect insert success
 INSERT INTO a SELECT generate_series(1,100000);
@@ -203,6 +201,66 @@ SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FR
  schema_name | tablespace_name | quota_in_mb | nspsize_tablespace_in_bytes 
 -------------+-----------------+-------------+-----------------------------
 (0 rows)
+
+-- test config per segment quota 
+SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','1');
+ set_per_segment_quota 
+-----------------------
+ 
+(1 row)
+
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+ segratio 
+----------
+        1
+(1 row)
+
+SELECT diskquota.set_schema_tablespace_quota('spcs2_perseg', 'schemaspc_perseg2','1 MB');
+ set_schema_tablespace_quota 
+-----------------------------
+ 
+(1 row)
+
+SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+ segratio 
+----------
+        1
+(1 row)
+
+SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','-2');
+ set_per_segment_quota 
+-----------------------
+ 
+(1 row)
+
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+ segratio 
+----------
+(0 rows)
+
+SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+ segratio 
+----------
+       -1
+(1 row)
+
+SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','3');
+ set_per_segment_quota 
+-----------------------
+ 
+(1 row)
+
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+ segratio 
+----------
+        3
+(1 row)
+
+SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+ segratio 
+----------
+        3
+(1 row)
 
 RESET search_path;
 DROP TABLE spcs1_perseg.a;

--- a/tests/regress/expected/test_tablespace_schema_perseg.out
+++ b/tests/regress/expected/test_tablespace_schema_perseg.out
@@ -241,7 +241,7 @@ SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targe
 SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
  segratio 
 ----------
-       -1
+        0
 (1 row)
 
 SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','3');

--- a/tests/regress/sql/test_tablespace_schema_perseg.sql
+++ b/tests/regress/sql/test_tablespace_schema_perseg.sql
@@ -83,6 +83,18 @@ SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO a SELECT generate_series(1,100);
 SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name = 'spcs1_perseg' and tablespace_name ='schemaspc_perseg';
 
+-- test config per segment quota 
+SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','1');
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+SELECT diskquota.set_schema_tablespace_quota('spcs2_perseg', 'schemaspc_perseg2','1 MB');
+SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','-2');
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','3');
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+
 RESET search_path;
 DROP TABLE spcs1_perseg.a;
 DROP SCHEMA spcs1_perseg;


### PR DESCRIPTION
If one tablespace segratio is configured,
this commit will make sure that ethier
the alredy existed (schema/role)_tablespace_quota
or new configs after this, will have the
same segratio.

1) Add a new quota type: TABLESPACE_QUOTA
used to store the tablespace segratio value
in quota_config table.
When set_per_segment_quota("xx","1.0) is
called, a new config will be added like:

      ` 97103 |         4 |            0 |        1`

   0 means invalid quota configed
   4 means TABLE_SPACE_QUOTA

2) Modify set_quota_config_internal to
support insert/delete/update new type config

3) Add function get_per_segment_ratio
it is called when insert new
(schema/role)_tablespace_quota.
"for share" is used to query segratio,it only
can keep the segratio is consistent in
"read committed" level.