### PR TITLE
Use released gpdb instead of release candidate

### DIFF
--- a/concourse/README.md
+++ b/concourse/README.md
@@ -46,16 +46,21 @@ https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/COMMIT:diskquota:gpdb
 
 ## Fly the release pipeline
 
-By default, the release is built from the `gpdb` branch
+By default, the release is built from the `gpdb` branch.
+
+The release pipeline should be located in https://prod.ci.gpdb.pivotal.io
 
 ```
-./fly.sh -t extension -c release
+# Login to prod
+fly -t prod login -c https://prod.ci.gpdb.pivotal.io
+# Fly the release pipeline
+./fly.sh -t prod -c release
 ```
 
 To fly a release pipeline from a specific branch:
 
 ```
-./fly.sh -t extension -c release -b release/<major>.<minor>
+./fly.sh -t <target> -c release -b release/<major>.<minor>
 ```
 
 ## Fly the dev pipeline

--- a/concourse/fly.sh
+++ b/concourse/fly.sh
@@ -118,9 +118,10 @@ if [ "${pipeline_config}" == "dev" ]; then
     exit 0
 fi
 
+concourse_url=$(fly targets | awk "{if (\$1 == \"${target}\") {print \$2}}")
 echo ""
 echo "================================================================================"
 echo "Remeber to set the the webhook URL on GitHub:"
-echo "https://<target>.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/${pipeline_name}/resources/${hook_res}/check/webhook?webhook_token=<hook_token>"
+echo "${concourse_url}/api/v1/teams/main/pipelines/${pipeline_name}/resources/${hook_res}/check/webhook?webhook_token=<hook_token>"
 echo "You may need to change the base URL if a differnt concourse server is used."
 echo "================================================================================"

--- a/concourse/fly.sh
+++ b/concourse/fly.sh
@@ -121,6 +121,6 @@ fi
 echo ""
 echo "================================================================================"
 echo "Remeber to set the the webhook URL on GitHub:"
-echo "https://extensions.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/${pipeline_name}/resources/${hook_res}/check/webhook?webhook_token=<hook_token>"
+echo "https://<target>.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/${pipeline_name}/resources/${hook_res}/check/webhook?webhook_token=<hook_token>"
 echo "You may need to change the base URL if a differnt concourse server is used."
 echo "================================================================================"

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -149,25 +149,25 @@ resources:
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/server-rc-(.*)-rhel6_x86_64.debug.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel6_x86_64.tar.gz
 - name: bin_gpdb6_centos7
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.tar.gz
 - name: bin_gpdb6_rhel8
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.debug.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.tar.gz
 - name: bin_gpdb6_ubuntu18
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.debug.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.tar.gz
 
 # Diskquota releases
 - name: bin_diskquota_gpdb6_rhel6

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -149,25 +149,25 @@ resources:
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-centos6.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel6_x86_64.debug.tar.gz
 - name: bin_gpdb6_centos7
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-centos7.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
 - name: bin_gpdb6_rhel8
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-rhel8.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.debug.tar.gz
 - name: bin_gpdb6_ubuntu18
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/release-candidates/gpdb6/greenplum-db-server-(.*)-ubuntu18.04.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.debug.tar.gz
 
 # Diskquota releases
 - name: bin_diskquota_gpdb6_rhel6

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,20 +1,5 @@
 include(${CMAKE_SOURCE_DIR}/cmake/Regress.cmake)
 
-# Test cases need fault injector needs to be excluded from release build.
-# GPDB release build doesn't support fault injector
-if (CMAKE_BUILD_TYPE STREQUAL "Release")
-list(APPEND exclude_regress_for_release
-    test_fetch_table_stat)
-list(APPEND exclude_isolation2_for_release
-    test_relation_size
-    test_blackmap
-    test_vacuum
-    test_truncate
-    test_worker_timeout)
-else()
-    set(load_inject_fault_opts --load-extension=gp_inject_fault)
-endif()
-
 RegressTarget_Add(regress
     INIT_FILE
     ${CMAKE_CURRENT_SOURCE_DIR}/init_file
@@ -23,10 +8,8 @@ RegressTarget_Add(regress
     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/regress/diskquota_schedule
-    EXCLUDE
-    ${exclude_regress_for_release}
     REGRESS_OPTS
-    ${load_inject_fault_opts}
+    --load-extension=gp_inject_fault
     --dbname=contrib_regression)
 
 RegressTarget_Add(isolation2
@@ -39,10 +22,8 @@ RegressTarget_Add(isolation2
     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/isolation2_schedule
-    EXCLUDE
-    ${exclude_isolation2_for_release}
     REGRESS_OPTS
-    ${load_inject_fault_opts}
+    --load-extension=gp_inject_fault
     --dbname=isolation2test)
 
 add_custom_target(installcheck)
@@ -59,7 +40,7 @@ add_dependencies(installcheck isolation2 regress)
 #     REGRESS
 #     config test_create_extension
 #     REGRESS_OPTS
-#     ${load_inject_fault_opts}
+#     --load-extension=gp_inject_fault
 #     --dbname=contrib_regression)
 # RegressTarget_Add(regress_truncate_loop
 #     INIT_FILE
@@ -72,7 +53,7 @@ add_dependencies(installcheck isolation2 regress)
 #     test_truncate
 #     RUN_TIMES -1
 #     REGRESS_OPTS
-#     ${load_inject_fault_opts}
+#     --load-extension=gp_inject_fault
 #     --dbname=contrib_regression
 #     --use-existing)
 # add_dependencies(regress_truncate_loop regress_config)


### PR DESCRIPTION
By the gcs resource regex rule, 6.99.99 will be matched as the most
recent gpdb release candidate, which is not what we want. It is a
testing version from release team. And due to the go regex
implementation, (!?) is not supported to filter out an exact string.

So the release pipeline is changed to use the most recent RELEASED gpdb
binary instead.
