### PR TITLE
Fix un-expected remove when two tablespace-quota has a same role or schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 build*/
 
 # The tests results
-/results/
+results/
 
 # For IDE/Editors
 .vscode

--- a/diskquota--1.0--2.0.sql
+++ b/diskquota--1.0--2.0.sql
@@ -4,7 +4,7 @@
 ALTER TABLE diskquota.quota_config ADD COLUMN segratio float4 DEFAULT 0;
 
 CREATE TABLE diskquota.target (
-  rowId serial,
+	rowId serial,
 	quotatype int, -- REFERENCES disquota.quota_config.quotatype,
 	primaryOid oid,
 	tablespaceOid oid, -- REFERENCES pg_tablespace.oid,

--- a/diskquota--1.0--2.0.sql
+++ b/diskquota--1.0--2.0.sql
@@ -4,6 +4,7 @@
 ALTER TABLE diskquota.quota_config ADD COLUMN segratio float4 DEFAULT 0;
 
 CREATE TABLE diskquota.target (
+  rowId serial,
 	quotatype int, -- REFERENCES disquota.quota_config.quotatype,
 	primaryOid oid,
 	tablespaceOid oid, -- REFERENCES pg_tablespace.oid,
@@ -193,27 +194,27 @@ WITH
   ),
   full_quota_config AS (
     SELECT
-      targetOid,
+      primaryOid,
       tablespaceoid,
       quotalimitMB
     FROM
       diskquota.quota_config AS config,
       diskquota.target AS target
     WHERE
-      config.targetOid = target.primaryOid AND
+      config.targetOid = target.rowId AND
       config.quotaType = target.quotaType AND
       config.quotaType = 2 -- NAMESPACE_TABLESPACE_QUOTA
   )
 SELECT
   nspname AS schema_name,
-  targetoid AS schema_oid,
+  primaryoid AS schema_oid,
   spcname AS tablespace_name,
   tablespaceoid AS tablespace_oid,
   quotalimitMB AS quota_in_mb,
   COALESCE(total_size, 0) AS nspsize_tablespace_in_bytes
 FROM
   full_quota_config JOIN
-  pg_namespace ON targetoid = pg_namespace.oid JOIN
+  pg_namespace ON primaryoid = pg_namespace.oid JOIN
   pg_tablespace ON tablespaceoid = pg_tablespace.oid LEFT OUTER JOIN
   quota_usage ON pg_namespace.oid = relnamespace AND pg_tablespace.oid = reltablespace;
 
@@ -245,27 +246,27 @@ WITH
   ),
   full_quota_config AS (
     SELECT
-      targetOid,
+      primaryOid,
       tablespaceoid,
       quotalimitMB
     FROM
       diskquota.quota_config AS config,
       diskquota.target AS target
     WHERE
-      config.targetOid = target.primaryOid AND
+      config.targetOid = target.rowId AND
       config.quotaType = target.quotaType AND
       config.quotaType = 3 -- ROLE_TABLESPACE_QUOTA
   )
 SELECT
   rolname AS role_name,
-  targetoid AS role_oid,
+  primaryoid AS role_oid,
   spcname AS tablespace_name,
   tablespaceoid AS tablespace_oid,
   quotalimitMB AS quota_in_mb,
   COALESCE(total_size, 0) AS rolsize_tablespace_in_bytes
 FROM
   full_quota_config JOIN
-  pg_roles ON targetoid = pg_roles.oid JOIN
+  pg_roles ON primaryoid = pg_roles.oid JOIN
   pg_tablespace ON tablespaceoid = pg_tablespace.oid LEFT OUTER JOIN
   quota_usage ON pg_roles.oid = relowner AND pg_tablespace.oid = reltablespace;
 -- views end

--- a/diskquota--2.0--1.0.sql
+++ b/diskquota--2.0--1.0.sql
@@ -63,7 +63,7 @@ DROP FUNCTION diskquota.show_relation_cache_all_seg();
 -- UDF end
 
 -- table part
--- clean up schema_tablespace quota, rolsize_tablespace quota AND tablespace quota
+-- clean up NAMESPACE_TABLESPACE_QUOTA(2), ROLE_TABLESPACE_QUOTA(3) and TABLESPACE_QUOTA(4)
 DELETE FROM diskquota.quota_config WHERE quotatype in (2, 3, 4);
 
 DROP TABLE diskquota.target;

--- a/diskquota--2.0--1.0.sql
+++ b/diskquota--2.0--1.0.sql
@@ -63,8 +63,8 @@ DROP FUNCTION diskquota.show_relation_cache_all_seg();
 -- UDF end
 
 -- table part
--- clean up schema_tablespace quota AND rolsize_tablespace quota
-DELETE FROM diskquota.quota_config WHERE quotatype = 2 or quotatype = 3;
+-- clean up schema_tablespace quota, rolsize_tablespace quota AND tablespace quota
+DELETE FROM diskquota.quota_config WHERE quotatype in (2, 3, 4);
 
 DROP TABLE diskquota.target;
 

--- a/diskquota--2.0.sql
+++ b/diskquota--2.0.sql
@@ -14,7 +14,7 @@ CREATE TABLE diskquota.quota_config(
 ) DISTRIBUTED BY (targetOid, quotatype);
 
 CREATE TABLE diskquota.target (
-  rowId serial,
+	rowId serial,
 	quotatype int, --REFERENCES disquota.quota_config.quotatype,
 	primaryOid oid,
 	tablespaceOid oid, --REFERENCES pg_tablespace.oid,

--- a/diskquota--2.0.sql
+++ b/diskquota--2.0.sql
@@ -3,6 +3,8 @@
 
 CREATE SCHEMA diskquota;
 
+-- when (quotatype == NAMESPACE_QUOTA/ROLE_QUOTA) then targetOid = role_oid/schema_oid;
+-- when (quotatype == NAMESPACE_TABLESPACE_QUOTA/ROLE_TABLESPACE_QUOTA) then targetOid = diskquota.target.rowId;
 CREATE TABLE diskquota.quota_config(
 	targetOid oid,
 	quotatype int,
@@ -12,6 +14,7 @@ CREATE TABLE diskquota.quota_config(
 ) DISTRIBUTED BY (targetOid, quotatype);
 
 CREATE TABLE diskquota.target (
+  rowId serial,
 	quotatype int, --REFERENCES disquota.quota_config.quotatype,
 	primaryOid oid,
 	tablespaceOid oid, --REFERENCES pg_tablespace.oid,
@@ -208,27 +211,27 @@ WITH
   ),
   full_quota_config AS (
     SELECT
-      targetOid,
+      primaryOid,
       tablespaceoid,
       quotalimitMB
     FROM
       diskquota.quota_config AS config,
       diskquota.target AS target
     WHERE
-      config.targetOid = target.primaryOid AND
+      config.targetOid = target.rowId AND
       config.quotaType = target.quotaType AND
       config.quotaType = 2 -- NAMESPACE_TABLESPACE_QUOTA
   )
 SELECT
   nspname AS schema_name,
-  targetoid AS schema_oid,
+  primaryoid AS schema_oid,
   spcname AS tablespace_name,
   tablespaceoid AS tablespace_oid,
   quotalimitMB AS quota_in_mb,
   COALESCE(total_size, 0) AS nspsize_tablespace_in_bytes
 FROM
   full_quota_config JOIN
-  pg_namespace ON targetoid = pg_namespace.oid JOIN
+  pg_namespace ON primaryOid = pg_namespace.oid JOIN
   pg_tablespace ON tablespaceoid = pg_tablespace.oid LEFT OUTER JOIN
   quota_usage ON pg_namespace.oid = relnamespace AND pg_tablespace.oid = reltablespace;
 
@@ -260,27 +263,27 @@ WITH
   ),
   full_quota_config AS (
     SELECT
-      targetOid,
+      primaryOid,
       tablespaceoid,
       quotalimitMB
     FROM
       diskquota.quota_config AS config,
       diskquota.target AS target
     WHERE
-      config.targetOid = target.primaryOid AND
+      config.targetOid = target.rowId AND
       config.quotaType = target.quotaType AND
       config.quotaType = 3 -- ROLE_TABLESPACE_QUOTA
   )
 SELECT
   rolname AS role_name,
-  targetoid AS role_oid,
+  primaryoid AS role_oid,
   spcname AS tablespace_name,
   tablespaceoid AS tablespace_oid,
   quotalimitMB AS quota_in_mb,
   COALESCE(total_size, 0) AS rolsize_tablespace_in_bytes
 FROM
   full_quota_config JOIN
-  pg_roles ON targetoid = pg_roles.oid JOIN
+  pg_roles ON primaryoid = pg_roles.oid JOIN
   pg_tablespace ON tablespaceoid = pg_tablespace.oid LEFT OUTER JOIN
   quota_usage ON pg_roles.oid = relowner AND pg_tablespace.oid = reltablespace;
 -- view end

--- a/diskquota.h
+++ b/diskquota.h
@@ -36,6 +36,9 @@ typedef enum
 	ROLE_QUOTA,
 	NAMESPACE_TABLESPACE_QUOTA,
 	ROLE_TABLESPACE_QUOTA,
+
+	NUM_QUOTA_TYPES,
+
 	/*
 	 * TABLESPACE_QUOTA
 	 * used in `quota_config` table,
@@ -45,10 +48,10 @@ typedef enum
 	 * quotatype = 4 (TABLESPACE_QUOTA)
 	 * quotalimitMB = 0 (invalid quota confined)
 	 * segratio = 1.0
+	 *
+	 * TABLESPACE_QUOTA is not a real quota currently, so we won't put it into quota_info
 	 */
 	TABLESPACE_QUOTA,
-
-	NUM_QUOTA_TYPES
 } QuotaType;
 
 typedef enum

--- a/diskquota.h
+++ b/diskquota.h
@@ -36,9 +36,6 @@ typedef enum
 	ROLE_QUOTA,
 	NAMESPACE_TABLESPACE_QUOTA,
 	ROLE_TABLESPACE_QUOTA,
-
-	NUM_QUOTA_TYPES,
-
 	/*
 	 * TABLESPACE_QUOTA
 	 * used in `quota_config` table,
@@ -48,10 +45,10 @@ typedef enum
 	 * quotatype = 4 (TABLESPACE_QUOTA)
 	 * quotalimitMB = 0 (invalid quota confined)
 	 * segratio = 1.0
-	 *
-	 * TABLESPACE_QUOTA is not a real quota currently, so we won't put it into quota_info
 	 */
 	TABLESPACE_QUOTA,
+
+	NUM_QUOTA_TYPES,
 } QuotaType;
 
 typedef enum

--- a/tests/isolation2/expected/test_per_segment_config.out
+++ b/tests/isolation2/expected/test_per_segment_config.out
@@ -41,7 +41,7 @@ COMMIT
 2: COMMIT;
 COMMIT
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
  segratio 
 ----------
  1.0      
@@ -78,7 +78,7 @@ COMMIT
 2: COMMIT;
 COMMIT
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
  segratio 
 ----------
  1.0      
@@ -124,7 +124,7 @@ COMMIT
 2: COMMIT;
 COMMIT
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
  segratio 
 ----------
  1.0      
@@ -166,7 +166,7 @@ COMMIT
 2: COMMIT;
 COMMIT
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
  segratio 
 ----------
  1.0      
@@ -208,7 +208,7 @@ COMMIT
 2: COMMIT;
 COMMIT
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
  segratio 
 ----------
  0.0      
@@ -249,7 +249,7 @@ COMMIT
 2: COMMIT;
 COMMIT
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
  segratio 
 ----------
  0.0      

--- a/tests/isolation2/sql/test_per_segment_config.sql
+++ b/tests/isolation2/sql/test_per_segment_config.sql
@@ -9,7 +9,7 @@ CREATE SCHEMA s101;
 DROP TABLESPACE IF EXISTS spc101;
 CREATE TABLESPACE spc101 LOCATION '/tmp/spc101';
 
--- 
+--
 -- There is no tablesapce per segment quota configed yet
 --
 
@@ -22,13 +22,14 @@ CREATE TABLESPACE spc101 LOCATION '/tmp/spc101';
 2<:
 2: COMMIT;
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
 SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
 -- cleanup
 truncate table diskquota.quota_config;
 truncate table diskquota.target;
 
--- Read commited, first set_schema_tablespace_quota, then set_per_segment_quota, 
+-- Read commited, first set_schema_tablespace_quota, then set_per_segment_quota,
 1: BEGIN;
 1: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
 2: BEGIN;
@@ -37,13 +38,14 @@ truncate table diskquota.target;
 2<:
 2: COMMIT;
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
 SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
 -- cleanup
 truncate table diskquota.quota_config;
 truncate table diskquota.target;
 
--- 
+--
 -- There is already a tablesapce per segment quota configed
 --
 
@@ -57,13 +59,14 @@ SELECT diskquota.set_per_segment_quota('spc101', 2);
 2<:
 2: COMMIT;
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
 SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
 -- cleanup
 truncate table diskquota.quota_config;
 truncate table diskquota.target;
 
--- Read commited, first set_schema_tablespace_quota, then set_per_segment_quota, 
+-- Read commited, first set_schema_tablespace_quota, then set_per_segment_quota,
 SELECT diskquota.set_per_segment_quota('spc101', 2);
 1: BEGIN;
 1: SELECT diskquota.set_schema_tablespace_quota('s101', 'spc101','1 MB');
@@ -73,7 +76,8 @@ SELECT diskquota.set_per_segment_quota('spc101', 2);
 2<:
 2: COMMIT;
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
 SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
 -- cleanup
 truncate table diskquota.quota_config;
@@ -89,7 +93,8 @@ SELECT diskquota.set_per_segment_quota('spc101', 2);
 2<:
 2: COMMIT;
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
 SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
 -- cleanup
 truncate table diskquota.quota_config;
@@ -105,7 +110,8 @@ SELECT diskquota.set_per_segment_quota('spc101', 2);
 2<:
 2: COMMIT;
 
-SELECT segratio from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 's101';
+SELECT segratio FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE targetoid = diskquota.target.rowId AND diskquota.target.primaryOid = oid AND nspname = 's101';
 SELECT segratio from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'spc101';
 -- cleanup
 truncate table diskquota.quota_config;

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -34,5 +34,6 @@ test: test_ctas_schema
 test: test_ctas_tablespace_role
 test: test_ctas_tablespace_schema
 test: test_default_tablespace
+test: test_tablespace_diff_schema
 test: test_drop_extension
 test: reset_config

--- a/tests/regress/expected/test_tablespace_diff_schema.out
+++ b/tests/regress/expected/test_tablespace_diff_schema.out
@@ -1,0 +1,80 @@
+-- allow set quota for different schema in the same tablespace
+-- delete quota for one schema will not drop other quotas with different schema in the same tablespace
+-- start_ignore
+\! mkdir -p /tmp/spc_diff_schema
+-- end_ignore
+CREATE TABLESPACE spc_diff_schema LOCATION '/tmp/spc_diff_schema';
+CREATE SCHEMA schema_in_tablespc;
+SET search_path TO schema_in_tablespc;
+CREATE TABLE a(i int) TABLESPACE spc_diff_schema DISTRIBUTED BY (i);
+INSERT INTO a SELECT generate_series(1,100);
+SELECT diskquota.set_schema_tablespace_quota('schema_in_tablespc', 'spc_diff_schema','1 MB');
+ set_schema_tablespace_quota 
+-----------------------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+-- with hardlimits off, expect to success
+INSERT INTO a SELECT generate_series(1,1000000);
+-- expect to fail
+INSERT INTO a SELECT generate_series(1,1000000);
+ERROR:  tablespace:spc_diff_schema schema:schema_in_tablespc diskquota exceeded
+SELECT schema_name, tablespace_name FROM diskquota.show_fast_schema_tablespace_quota_view;
+    schema_name     | tablespace_name 
+--------------------+-----------------
+ schema_in_tablespc | spc_diff_schema
+(1 row)
+
+SELECT diskquota.set_schema_tablespace_quota('schema_in_tablespc', 'pg_default','1 MB');
+ set_schema_tablespace_quota 
+-----------------------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SELECT schema_name, tablespace_name FROM diskquota.show_fast_schema_tablespace_quota_view;
+    schema_name     | tablespace_name 
+--------------------+-----------------
+ schema_in_tablespc | spc_diff_schema
+ schema_in_tablespc | pg_default
+(2 rows)
+
+SELECT diskquota.set_schema_tablespace_quota('schema_in_tablespc', 'pg_default','-1');
+ set_schema_tablespace_quota 
+-----------------------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SELECT schema_name, tablespace_name FROM diskquota.show_fast_schema_tablespace_quota_view;
+    schema_name     | tablespace_name 
+--------------------+-----------------
+ schema_in_tablespc | spc_diff_schema
+(1 row)
+
+-- expect to fail
+INSERT INTO a SELECT generate_series(1,1000000);
+ERROR:  tablespace:spc_diff_schema schema:schema_in_tablespc diskquota exceeded
+reset search_path;
+DROP TABLE IF EXISTS schema_in_tablespc.a;
+DROP tablespace IF EXISTS spc_diff_schema;
+DROP SCHEMA IF EXISTS schema_in_tablespc;
+-- start_ignore
+\! rmdir /tmp/spc_diff_schema
+  -- end_ignore

--- a/tests/regress/expected/test_tablespace_schema_perseg.out
+++ b/tests/regress/expected/test_tablespace_schema_perseg.out
@@ -202,7 +202,7 @@ SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FR
 -------------+-----------------+-------------+-----------------------------
 (0 rows)
 
--- test config per segment quota 
+-- test config per segment quota
 SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','1');
  set_per_segment_quota 
 -----------------------
@@ -221,7 +221,9 @@ SELECT diskquota.set_schema_tablespace_quota('spcs2_perseg', 'schemaspc_perseg2'
  
 (1 row)
 
-SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
+       diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
  segratio 
 ----------
         1
@@ -238,7 +240,9 @@ SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targe
 ----------
 (0 rows)
 
-SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
+       diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
  segratio 
 ----------
         0
@@ -256,7 +260,9 @@ SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targe
         3
 (1 row)
 
-SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
+       diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
  segratio 
 ----------
         3

--- a/tests/regress/sql/test_relation_size.sql
+++ b/tests/regress/sql/test_relation_size.sql
@@ -26,6 +26,9 @@ SELECT pg_table_size('t2');
 
 DROP TABLE t1, t2;
 DROP TABLESPACE test_spc;
+-- start_ignore
+\! rm -rf /tmp/test_spc
+  -- end_ignore
 
 CREATE TABLE ao (i int) WITH (appendonly=true) DISTRIBUTED BY (i);
 INSERT INTO ao SELECT generate_series(1, 10000);

--- a/tests/regress/sql/test_tablespace_diff_schema.sql
+++ b/tests/regress/sql/test_tablespace_diff_schema.sql
@@ -1,0 +1,43 @@
+-- allow set quota for different schema in the same tablespace
+-- delete quota for one schema will not drop other quotas with different schema in the same tablespace
+
+-- start_ignore
+\! mkdir -p /tmp/spc_diff_schema
+-- end_ignore
+
+CREATE TABLESPACE spc_diff_schema LOCATION '/tmp/spc_diff_schema';
+CREATE SCHEMA schema_in_tablespc;
+SET search_path TO schema_in_tablespc;
+
+CREATE TABLE a(i int) TABLESPACE spc_diff_schema DISTRIBUTED BY (i);
+INSERT INTO a SELECT generate_series(1,100);
+SELECT diskquota.set_schema_tablespace_quota('schema_in_tablespc', 'spc_diff_schema','1 MB');
+SELECT diskquota.wait_for_worker_new_epoch();
+
+-- with hardlimits off, expect to success
+INSERT INTO a SELECT generate_series(1,1000000);
+
+-- expect to fail
+INSERT INTO a SELECT generate_series(1,1000000);
+
+SELECT schema_name, tablespace_name FROM diskquota.show_fast_schema_tablespace_quota_view;
+
+SELECT diskquota.set_schema_tablespace_quota('schema_in_tablespc', 'pg_default','1 MB');
+SELECT diskquota.wait_for_worker_new_epoch();
+SELECT schema_name, tablespace_name FROM diskquota.show_fast_schema_tablespace_quota_view;
+
+SELECT diskquota.set_schema_tablespace_quota('schema_in_tablespc', 'pg_default','-1');
+SELECT diskquota.wait_for_worker_new_epoch();
+SELECT schema_name, tablespace_name FROM diskquota.show_fast_schema_tablespace_quota_view;
+
+-- expect to fail
+INSERT INTO a SELECT generate_series(1,1000000);
+
+reset search_path;
+DROP TABLE IF EXISTS schema_in_tablespc.a;
+DROP tablespace IF EXISTS spc_diff_schema;
+DROP SCHEMA IF EXISTS schema_in_tablespc;
+
+-- start_ignore
+\! rmdir /tmp/spc_diff_schema
+  -- end_ignore

--- a/tests/regress/sql/test_tablespace_schema_perseg.sql
+++ b/tests/regress/sql/test_tablespace_schema_perseg.sql
@@ -83,17 +83,31 @@ SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO a SELECT generate_series(1,100);
 SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name = 'spcs1_perseg' and tablespace_name ='schemaspc_perseg';
 
--- test config per segment quota 
+-- test config per segment quota
 SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','1');
 SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+
 SELECT diskquota.set_schema_tablespace_quota('spcs2_perseg', 'schemaspc_perseg2','1 MB');
-SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+
+SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
+       diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
+
 SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','-2');
+
 SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
-SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+
+SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
+       diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
+
 SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','3');
+
 SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
-SELECT distinct(segratio) from diskquota.quota_config, pg_namespace where targetoid = oid and nspname = 'spcs2_perseg';
+
+SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
+       diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
 
 RESET search_path;
 DROP TABLE spcs1_perseg.a;

--- a/upgrade_test/expected/2.0_catalog.out
+++ b/upgrade_test/expected/2.0_catalog.out
@@ -25,8 +25,8 @@ GROUP BY
     t1.typname
 ORDER BY
     t1.typname;
-                typname                 |                       typname                       
-----------------------------------------+-----------------------------------------------------
+                typname                 |                                     typname                                      
+----------------------------------------+----------------------------------------------------------------------------------
  blackmap                               | {bool,int4,text,oid,oid,oid,oid,oid,oid}
  blackmap_entry                         | {bool,int4,oid,oid,oid}
  blackmap_entry_detail                  | {bool,int4,text,oid,oid,oid,oid,oid,oid}
@@ -40,8 +40,9 @@ ORDER BY
  show_fast_schema_tablespace_quota_view | {name,name,int8,oid,oid,numeric}
  state                                  | {int4,int4,oid,tid,xid,xid,cid,cid}
  table_size                             | {int8,int2,int4,oid,oid,tid,xid,xid,cid,cid}
- target                                 | {int4,int4,oid,oid,oid,tid,xid,xid,cid,cid}
-(14 rows)
+ target                                 | {int4,int4,int4,oid,oid,oid,tid,xid,xid,cid,cid}
+ target_rowid_seq                       | {bool,bool,name,int8,int8,int8,int8,int8,int8,int8,int4,oid,tid,xid,xid,cid,cid}
+(15 rows)
 
 -- types end
 -- tables
@@ -72,7 +73,8 @@ ORDER BY
  table_size_pkey             |                               | 
  target                      | {target}                      | 
  target_pkey                 |                               | 
-(12 rows)
+ target_rowid_seq            | {target_rowid_seq}            | 
+(13 rows)
 
 -- tables end
 -- UDF
@@ -191,21 +193,21 @@ ORDER by
             |                                        |           WHERE ((table_size.tableid = pg_class.oid) AND (table_size.segid = (-1)))                                                        +
             |                                        |           GROUP BY pg_class.relowner, pg_class.reltablespace, default_tablespace.dattablespace                                             +
             |                                        |         ), full_quota_config AS (                                                                                                          +
-            |                                        |          SELECT config.targetoid,                                                                                                          +
+            |                                        |          SELECT target.primaryoid,                                                                                                         +
             |                                        |             target.tablespaceoid,                                                                                                          +
             |                                        |             config.quotalimitmb                                                                                                            +
             |                                        |            FROM diskquota.quota_config config,                                                                                             +
             |                                        |             diskquota.target target                                                                                                        +
-            |                                        |           WHERE (((config.targetoid = target.primaryoid) AND (config.quotatype = target.quotatype)) AND (config.quotatype = 3))            +
+            |                                        |           WHERE (((config.targetoid = (target.rowid)::oid) AND (config.quotatype = target.quotatype)) AND (config.quotatype = 3))          +
             |                                        |         )                                                                                                                                  +
             |                                        |  SELECT pg_roles.rolname AS role_name,                                                                                                     +
-            |                                        |     full_quota_config.targetoid AS role_oid,                                                                                               +
+            |                                        |     full_quota_config.primaryoid AS role_oid,                                                                                              +
             |                                        |     pg_tablespace.spcname AS tablespace_name,                                                                                              +
             |                                        |     full_quota_config.tablespaceoid AS tablespace_oid,                                                                                     +
             |                                        |     full_quota_config.quotalimitmb AS quota_in_mb,                                                                                         +
             |                                        |     COALESCE(quota_usage.total_size, (0)::numeric) AS rolsize_tablespace_in_bytes                                                          +
             |                                        |    FROM (((full_quota_config                                                                                                               +
-            |                                        |      JOIN pg_roles ON ((full_quota_config.targetoid = pg_roles.oid)))                                                                      +
+            |                                        |      JOIN pg_roles ON ((full_quota_config.primaryoid = pg_roles.oid)))                                                                     +
             |                                        |      JOIN pg_tablespace ON ((full_quota_config.tablespaceoid = pg_tablespace.oid)))                                                        +
             |                                        |      LEFT JOIN quota_usage ON (((pg_roles.oid = quota_usage.relowner) AND (pg_tablespace.oid = quota_usage.reltablespace))));
  diskquota  | show_fast_schema_quota_view            |  WITH quota_usage AS (                                                                                                                     +
@@ -241,21 +243,21 @@ ORDER by
             |                                        |           WHERE ((table_size.tableid = pg_class.oid) AND (table_size.segid = (-1)))                                                        +
             |                                        |           GROUP BY pg_class.relnamespace, pg_class.reltablespace, default_tablespace.dattablespace                                         +
             |                                        |         ), full_quota_config AS (                                                                                                          +
-            |                                        |          SELECT config.targetoid,                                                                                                          +
+            |                                        |          SELECT target.primaryoid,                                                                                                         +
             |                                        |             target.tablespaceoid,                                                                                                          +
             |                                        |             config.quotalimitmb                                                                                                            +
             |                                        |            FROM diskquota.quota_config config,                                                                                             +
             |                                        |             diskquota.target target                                                                                                        +
-            |                                        |           WHERE (((config.targetoid = target.primaryoid) AND (config.quotatype = target.quotatype)) AND (config.quotatype = 2))            +
+            |                                        |           WHERE (((config.targetoid = (target.rowid)::oid) AND (config.quotatype = target.quotatype)) AND (config.quotatype = 2))          +
             |                                        |         )                                                                                                                                  +
             |                                        |  SELECT pg_namespace.nspname AS schema_name,                                                                                               +
-            |                                        |     full_quota_config.targetoid AS schema_oid,                                                                                             +
+            |                                        |     full_quota_config.primaryoid AS schema_oid,                                                                                            +
             |                                        |     pg_tablespace.spcname AS tablespace_name,                                                                                              +
             |                                        |     full_quota_config.tablespaceoid AS tablespace_oid,                                                                                     +
             |                                        |     full_quota_config.quotalimitmb AS quota_in_mb,                                                                                         +
             |                                        |     COALESCE(quota_usage.total_size, (0)::numeric) AS nspsize_tablespace_in_bytes                                                          +
             |                                        |    FROM (((full_quota_config                                                                                                               +
-            |                                        |      JOIN pg_namespace ON ((full_quota_config.targetoid = pg_namespace.oid)))                                                              +
+            |                                        |      JOIN pg_namespace ON ((full_quota_config.primaryoid = pg_namespace.oid)))                                                             +
             |                                        |      JOIN pg_tablespace ON ((full_quota_config.tablespaceoid = pg_tablespace.oid)))                                                        +
             |                                        |      LEFT JOIN quota_usage ON (((pg_namespace.oid = quota_usage.relnamespace) AND (pg_tablespace.oid = quota_usage.reltablespace))));
 (6 rows)


### PR DESCRIPTION
When there are two namespace_tablespace_quota configurations with the
same schema but different tablespaces, removing one quota will remove
another one automatically. The same bug happens for the
role_tabelspace_quota case. The root cause of this bug is that we
can't distinguish these two quotas using only quotaType and targetOid
of diskquota.quota_config.

This PR fixes this by changing the meaning of targetOid column of
diskquota.quota_config table. When quotaType is
role_quota/schema_quota, targetOid refers to role_oid/schema_oid. When
quotaType is role_tablespace_quota/namespace_tablespace_quota,
targetOid refers to the rowId column of diskquota.target. This will
make it possible to distinguish two namespace_tablespace_quota with
the same schema and different tablespace. Because their rowId will be
different.

For the new quota type TABLESPACE_QUOTA. It is not a real quota, we
only use it for configuration. So we won't insert quotas with this
type into quota_info.