### PR TITLE
Reset memory account to fix memory leak

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -422,7 +422,7 @@ disk_quota_worker_main(Datum main_arg)
 		/* Do the work */
 		if (!diskquota_is_paused()) refresh_disk_quota_model(false);
 
-		/* Reset memory account to fix memry leak */
+		/* Reset memory account to fix memory leak */
 		MemoryAccounting_Reset();
 		worker_increase_epoch(MyDatabaseId);
 	}

--- a/diskquota.c
+++ b/diskquota.c
@@ -422,6 +422,8 @@ disk_quota_worker_main(Datum main_arg)
 		/* Do the work */
 		if (!diskquota_is_paused()) refresh_disk_quota_model(false);
 
+		/* Reset memory account to fix memry leak */
+		MemoryAccounting_Reset();
 		worker_increase_epoch(MyDatabaseId);
 	}
 


### PR DESCRIPTION
Diskquota workers dispatch queries periodically. For each dispatch,
one or more memory accounts will be created to keep track of the
memory usage. These accounts should be reset after the query
finishes to avoid memory leak.

Part of the stack trace of account creation looks like this:

```
   fun:CreateMemoryAccountImpl
   fun:MemoryAccounting_CreateAccount
   fun:serializeNode
   fun:cdbdisp_buildPlanQueryParms
   fun:cdbdisp_dispatchX
   fun:CdbDispatchPlan
   fun:standard_ExecutorStart
   fun:_SPI_pquery.constprop.11
   fun:_SPI_execute_plan
   fun:SPI_execute
   fun:do_load_quotas
   fun:load_quotas
   fun:refresh_disk_quota_model
   fun:disk_quota_worker_main
   fun:StartBackgroundWorker
   fun:do_start_bgworker
   fun:maybe_start_bgworker
```

This patch fixes the memory leak issue by calling the reset function 
at the end of the worker loop.