### PR TITLE
Wait next loop for bgworker to refresh before INSERT in testcase

### DIFF
--- a/tests/regress/expected/test_tablespace_diff_schema.out
+++ b/tests/regress/expected/test_tablespace_diff_schema.out
@@ -22,6 +22,13 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- with hardlimits off, expect to success
 INSERT INTO a SELECT generate_series(1,1000000);
+-- wait for next loop for bgworker to add it to blackmap
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 -- expect to fail
 INSERT INTO a SELECT generate_series(1,1000000);
 ERROR:  tablespace:spc_diff_schema schema:schema_in_tablespc diskquota exceeded

--- a/tests/regress/sql/test_tablespace_diff_schema.sql
+++ b/tests/regress/sql/test_tablespace_diff_schema.sql
@@ -17,6 +17,8 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- with hardlimits off, expect to success
 INSERT INTO a SELECT generate_series(1,1000000);
 
+-- wait for next loop for bgworker to add it to blackmap
+SELECT diskquota.wait_for_worker_new_epoch();
 -- expect to fail
 INSERT INTO a SELECT generate_series(1,1000000);
 


### PR DESCRIPTION
`diskquota.naptime` is 2 by default in release version. So it's better to wait for the bgworker to fresh blackmap after INSERT.