### PR TITLE
some fix for release CI

### DIFF
--- a/quotamodel.c
+++ b/quotamodel.c
@@ -124,6 +124,7 @@ struct BlackMapEntry
 	Oid    tablespaceoid;
 	uint32 targettype;
 	/*
+	 * TODO refactor this data structure
 	 * QD index the blackmap by (targetoid, databaseoid, tablespaceoid, targettype).
 	 * QE index the blackmap by (relfilenode).
 	 */
@@ -1499,7 +1500,7 @@ invalidate_database_blackmap(Oid dbid)
 	hash_seq_init(&iter, disk_quota_black_map);
 	while ((entry = hash_seq_search(&iter)) != NULL)
 	{
-		if (entry->databaseoid == dbid)
+		if (entry->databaseoid == dbid || entry->relfilenode.dbNode == dbid)
 		{
 			hash_search(disk_quota_black_map, entry, HASH_REMOVE, NULL);
 		}

--- a/tests/regress/expected/test_activetable_limit.out
+++ b/tests/regress/expected/test_activetable_limit.out
@@ -20,14 +20,34 @@ SELECT diskquota.set_schema_quota('s', '1 MB');
  
 (1 row)
 
-CREATE TABLE s.t1(i int) DISTRIBUTED BY (i);
-INSERT INTO s.t1 SELECT generate_series(1,100000); -- expect failed. diskquota should works. activetable = 1
-CREATE TABLE s.t2(i int) DISTRIBUTED BY (i);
-INSERT INTO s.t2 SELECT generate_series(1,100000);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+CREATE TABLE s.t1(i int) DISTRIBUTED BY (i); -- activetable = 1
+INSERT INTO s.t1 SELECT generate_series(1, 100000); -- ok. diskquota soft limit dose not check when first write
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+CREATE TABLE s.t2(i int) DISTRIBUTED BY (i); -- activetable = 2
+INSERT INTO s.t2 SELECT generate_series(1, 10);  -- expect failed
 ERROR:  schema's disk space quota exceeded with name:s
-CREATE TABLE s.t3(i int) DISTRIBUTED BY (i);
-INSERT INTO s.t3 SELECT generate_series(1,100000); -- should not crash. activetable = 3
+CREATE TABLE s.t3(i int) DISTRIBUTED BY (i); -- activetable = 3 should not crash.
+INSERT INTO s.t3 SELECT generate_series(1, 10);  -- expect failed
 ERROR:  schema's disk space quota exceeded with name:s
+-- Q: why diskquota still works when activetable = 3?
+-- A: the activetable limit by shmem size, calculate by hash_estimate_size()
+--    the result will bigger than sizeof(DiskQuotaActiveTableEntry) * max_active_tables
+--    the real capacity of this data structure based on the hash conflict probability.
+--    so we can not predict when the data structure will be fill in fully.
+--
+--    this test case is use less, remove this if anyone dislike it.
+--    but the hash capacity is smaller than 6, so the test case works for issue 51
 DROP EXTENSION diskquota;
 -- wait worker exit
 \! sleep 1

--- a/tests/regress/expected/test_activetable_limit.out
+++ b/tests/regress/expected/test_activetable_limit.out
@@ -27,7 +27,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 (1 row)
 
 CREATE TABLE s.t1(i int) DISTRIBUTED BY (i); -- activetable = 1
-INSERT INTO s.t1 SELECT generate_series(1, 100000); -- ok. diskquota soft limit dose not check when first write
+INSERT INTO s.t1 SELECT generate_series(1, 100000); -- ok. diskquota soft limit does not check when first write
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -46,7 +46,7 @@ ERROR:  schema's disk space quota exceeded with name:s
 --    the real capacity of this data structure based on the hash conflict probability.
 --    so we can not predict when the data structure will be fill in fully.
 --
---    this test case is use less, remove this if anyone dislike it.
+--    this test case is useless, remove this if anyone dislike it.
 --    but the hash capacity is smaller than 6, so the test case works for issue 51
 DROP EXTENSION diskquota;
 -- wait worker exit

--- a/tests/regress/expected/test_clean_blackmap_after_drop.out
+++ b/tests/regress/expected/test_clean_blackmap_after_drop.out
@@ -19,8 +19,8 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t
 (1 row)
 
-INSERT INTO b SELECT generate_series(1, 100000); -- fail
-ERROR:  role's disk space quota exceeded with name:40716  (seg2 127.0.0.1:6004 pid=1245042)
+INSERT INTO b SELECT generate_series(1, 100000000); -- fail
+ERROR:  role's disk space quota exceeded with name:16574  (seg0 127.0.0.1:6002 pid=356116)
 DROP EXTENSION diskquota;
 INSERT INTO b SELECT generate_series(1, 100); -- ok
 \c contrib_regression

--- a/tests/regress/sql/test_activetable_limit.sql
+++ b/tests/regress/sql/test_activetable_limit.sql
@@ -25,7 +25,7 @@ SELECT diskquota.set_schema_quota('s', '1 MB');
 SELECT diskquota.wait_for_worker_new_epoch();
 
 CREATE TABLE s.t1(i int) DISTRIBUTED BY (i); -- activetable = 1
-INSERT INTO s.t1 SELECT generate_series(1, 100000); -- ok. diskquota soft limit dose not check when first write
+INSERT INTO s.t1 SELECT generate_series(1, 100000); -- ok. diskquota soft limit does not check when first write
 
 SELECT diskquota.wait_for_worker_new_epoch();
 
@@ -40,7 +40,7 @@ INSERT INTO s.t3 SELECT generate_series(1, 10);  -- expect failed
 --    the real capacity of this data structure based on the hash conflict probability.
 --    so we can not predict when the data structure will be fill in fully.
 --
---    this test case is use less, remove this if anyone dislike it.
+--    this test case is useless, remove this if anyone dislike it.
 --    but the hash capacity is smaller than 6, so the test case works for issue 51
 
 DROP EXTENSION diskquota;

--- a/tests/regress/sql/test_activetable_limit.sql
+++ b/tests/regress/sql/test_activetable_limit.sql
@@ -22,13 +22,26 @@ CREATE EXTENSION diskquota;
 CREATE SCHEMA s;
 SELECT diskquota.set_schema_quota('s', '1 MB');
 
-CREATE TABLE s.t1(i int) DISTRIBUTED BY (i);
-INSERT INTO s.t1 SELECT generate_series(1,100000); -- expect failed. diskquota should works. activetable = 1
-CREATE TABLE s.t2(i int) DISTRIBUTED BY (i);
-INSERT INTO s.t2 SELECT generate_series(1,100000);
+SELECT diskquota.wait_for_worker_new_epoch();
 
-CREATE TABLE s.t3(i int) DISTRIBUTED BY (i);
-INSERT INTO s.t3 SELECT generate_series(1,100000); -- should not crash. activetable = 3
+CREATE TABLE s.t1(i int) DISTRIBUTED BY (i); -- activetable = 1
+INSERT INTO s.t1 SELECT generate_series(1, 100000); -- ok. diskquota soft limit dose not check when first write
+
+SELECT diskquota.wait_for_worker_new_epoch();
+
+CREATE TABLE s.t2(i int) DISTRIBUTED BY (i); -- activetable = 2
+INSERT INTO s.t2 SELECT generate_series(1, 10);  -- expect failed
+CREATE TABLE s.t3(i int) DISTRIBUTED BY (i); -- activetable = 3 should not crash.
+INSERT INTO s.t3 SELECT generate_series(1, 10);  -- expect failed
+
+-- Q: why diskquota still works when activetable = 3?
+-- A: the activetable limit by shmem size, calculate by hash_estimate_size()
+--    the result will bigger than sizeof(DiskQuotaActiveTableEntry) * max_active_tables
+--    the real capacity of this data structure based on the hash conflict probability.
+--    so we can not predict when the data structure will be fill in fully.
+--
+--    this test case is use less, remove this if anyone dislike it.
+--    but the hash capacity is smaller than 6, so the test case works for issue 51
 
 DROP EXTENSION diskquota;
 

--- a/tests/regress/sql/test_clean_blackmap_after_drop.sql
+++ b/tests/regress/sql/test_clean_blackmap_after_drop.sql
@@ -12,7 +12,7 @@ CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
 ALTER TABLE b OWNER TO r;
 SELECT diskquota.wait_for_worker_new_epoch();
 
-INSERT INTO b SELECT generate_series(1, 100000); -- fail
+INSERT INTO b SELECT generate_series(1, 100000000); -- fail
 
 DROP EXTENSION diskquota;
 


### PR DESCRIPTION
release CI use naptime = 2.
add some `diskquota.wait_for_worker_new_epoch()` to make CI happy.

`invalidate_database_blackmap` on segment does work as expected, the old test is ﬂaky.
fix by correcting the search key. the key is different on master and segment.