### PR TITLE
Fix set quota with upper case object name

### DIFF
--- a/tests/regress/expected/test_role.out
+++ b/tests/regress/expected/test_role.out
@@ -107,14 +107,26 @@ INSERT INTO b2 SELECT generate_series(1,100);
 SELECT rolname from pg_roles where rolsuper=true;
  rolname 
 ---------
- xx
+ sa
 (1 row)
 
 --end_ignore
 \gset
 select diskquota.set_role_quota(:'rolname', '1mb');
-ERROR:  Can not set disk quota for system owner: xx
+ERROR:  Can not set disk quota for system owner: sa
+CREATE ROLE "Tn" NOLOGIN;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SELECT diskquota.set_role_quota('Tn', '-1 MB'); -- fail
+ERROR:  role "tn" does not exist
+SELECT diskquota.set_role_quota('"tn"', '-1 MB'); -- fail
+ERROR:  role "tn" does not exist
+SELECT diskquota.set_role_quota('"Tn"', '-1 MB');
+ set_role_quota 
+----------------
+ 
+(1 row)
+
 DROP TABLE b, b2;
-DROP ROLE u1, u2;
+DROP ROLE u1, u2, "Tn";
 RESET search_path;
 DROP SCHEMA srole;

--- a/tests/regress/expected/test_schema.out
+++ b/tests/regress/expected/test_schema.out
@@ -2,8 +2,6 @@
 CREATE SCHEMA s1;
 SET search_path TO s1;
 CREATE TABLE a(i int) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO a SELECT generate_series(1,100);
 -- expect insert success
 INSERT INTO a SELECT generate_series(1,100000);
@@ -23,8 +21,6 @@ SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO a SELECT generate_series(1,100);
 ERROR:  schema's disk space quota exceeded with name: s1
 CREATE TABLE a2(i int) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- expect insert fail
 INSERT INTO a2 SELECT generate_series(1,100);
 ERROR:  schema's disk space quota exceeded with name: s1
@@ -48,8 +44,6 @@ NOTICE:  role "testbody" does not exist, skipping
 CREATE ROLE testbody;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE badquota.t1(i INT) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE badquota.t1 OWNER TO testbody;
 INSERT INTO badquota.t1 SELECT generate_series(0, 100000);
 SELECT diskquota.init_table_size_table();
@@ -100,9 +94,16 @@ SELECT schema_name, quota_in_mb FROM diskquota.show_fast_schema_quota_view WHERE
  s1          |           1
 (1 row)
 
+CREATE SCHEMA "Tn1";
+SELECT diskquota.set_schema_quota('"Tn1"', '-1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
 RESET search_path;
 DROP TABLE s1.a2, badquota.a;
-DROP SCHEMA s1, s2;
+DROP SCHEMA s1, s2, "Tn1";
 DROP TABLE badquota.t1;
 DROP ROLE testbody;
 DROP SCHEMA badquota;

--- a/tests/regress/expected/test_tablespace_role.out
+++ b/tests/regress/expected/test_tablespace_role.out
@@ -8,17 +8,15 @@ CREATE TABLESPACE rolespc LOCATION '/tmp/rolespc';
 CREATE SCHEMA rolespcrole;
 SET search_path TO rolespcrole;
 DROP ROLE IF EXISTS rolespcu1;
+NOTICE:  role "rolespcu1" does not exist, skipping
 DROP ROLE IF EXISTS rolespcu2;
+NOTICE:  role "rolespcu2" does not exist, skipping
 CREATE ROLE rolespcu1 NOLOGIN;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE rolespcu2 NOLOGIN;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE b (t TEXT) TABLESPACE rolespc DISTRIBUTED BY (t);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE b2 (t TEXT) TABLESPACE rolespc DISTRIBUTED BY (t);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE b2 OWNER TO rolespcu1;
 INSERT INTO b SELECT generate_series(1,100);
 -- expect insert success
@@ -152,16 +150,45 @@ INSERT INTO b SELECT generate_series(1,100);
 SELECT rolname from pg_roles where rolsuper=true;
  rolname 
 ---------
- xx
+ sa
 (1 row)
 
 -- end_ignore
 \gset
 select diskquota.set_role_tablespace_quota(:'rolname', 'rolespc', '1mb');
-ERROR:  Can not set disk quota for system owner: xx
+ERROR:  Can not set disk quota for system owner: sa
+-- start_ignore
+\! mkdir -p /tmp/rolespc3
+-- end_ignore
+DROP ROLE IF EXISTS "Rolespcu3";
+NOTICE:  role "Rolespcu3" does not exist, skipping
+CREATE ROLE "Rolespcu3" NOLOGIN;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+DROP TABLESPACE  IF EXISTS "Rolespc3";
+NOTICE:  tablespace "Rolespc3" does not exist, skipping
+CREATE TABLESPACE "Rolespc3" LOCATION '/tmp/rolespc3';
+SELECT diskquota.set_role_tablespace_quota('rolespcu1', '"Rolespc3"', '-1 MB');
+ set_role_tablespace_quota 
+---------------------------
+ 
+(1 row)
+
+SELECT diskquota.set_role_tablespace_quota('"Rolespcu3"', 'rolespc', '-1 mB');
+ set_role_tablespace_quota 
+---------------------------
+ 
+(1 row)
+
+SELECT diskquota.set_role_tablespace_quota('"Rolespcu3"', '"Rolespc3"', '-1 Mb');
+ set_role_tablespace_quota 
+---------------------------
+ 
+(1 row)
+
 DROP TABLE b, b2;
 DROP ROLE rolespcu1, rolespcu2;
 RESET search_path;
 DROP SCHEMA rolespcrole;
 DROP TABLESPACE rolespc;
 DROP TABLESPACE rolespc2;
+DROP TABLESPACE "Rolespc3";

--- a/tests/regress/expected/test_tablespace_role_perseg.out
+++ b/tests/regress/expected/test_tablespace_role_perseg.out
@@ -16,8 +16,6 @@ NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE rolespc_persegu2 NOLOGIN;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE b (t TEXT) TABLESPACE rolespc_perseg DISTRIBUTED BY (t);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE b OWNER TO rolespc_persegu1;
 SELECT diskquota.set_role_tablespace_quota('rolespc_persegu1', 'rolespc_perseg', '1 MB');
  set_role_tablespace_quota 
@@ -208,9 +206,30 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- expect insert success
 INSERT INTO b SELECT generate_series(1,100);
+-- start_ignore
+\! mkdir -p /tmp/rolespc_perseg3
+-- end_ignore
+DROP TABLESPACE  IF EXISTS "Rolespc_perseg3";
+NOTICE:  tablespace "Rolespc_perseg3" does not exist, skipping
+CREATE TABLESPACE "Rolespc_perseg3" LOCATION '/tmp/rolespc_perseg3';
+CREATE ROLE "Rolespc_persegu3" NOLOGIN;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SELECT diskquota.set_role_tablespace_quota('"Rolespc_persegu3"', '"Rolespc_perseg3"', '-1 MB');
+ set_role_tablespace_quota 
+---------------------------
+ 
+(1 row)
+
+SELECT diskquota.set_per_segment_quota('"Rolespc_perseg3"', 0.11);
+ set_per_segment_quota 
+-----------------------
+ 
+(1 row)
+
 DROP table b;
-DROP ROLE rolespc_persegu1, rolespc_persegu2;
+DROP ROLE rolespc_persegu1, rolespc_persegu2, "Rolespc_persegu3";
 RESET search_path;
 DROP SCHEMA rolespc_persegrole;
 DROP TABLESPACE rolespc_perseg;
 DROP TABLESPACE rolespc_perseg2;
+DROP TABLESPACE "Rolespc_perseg3";

--- a/tests/regress/expected/test_tablespace_schema.out
+++ b/tests/regress/expected/test_tablespace_schema.out
@@ -8,8 +8,6 @@ NOTICE:  tablespace "schemaspc" does not exist, skipping
 CREATE TABLESPACE schemaspc LOCATION '/tmp/schemaspc';
 SET search_path TO spcs1;
 CREATE TABLE a(i int) TABLESPACE schemaspc DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO a SELECT generate_series(1,100);
 -- expect insert fail
 INSERT INTO a SELECT generate_series(1,100000);
@@ -29,8 +27,6 @@ SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO a SELECT generate_series(1,100);
 ERROR:  tablespace: schemaspc, schema: spcs1 diskquota exceeded
 CREATE TABLE a2(i int) TABLESPACE schemaspc DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- expect insert fail
 INSERT INTO a2 SELECT generate_series(1,100);
 ERROR:  tablespace: schemaspc, schema: spcs1 diskquota exceeded
@@ -130,8 +126,22 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- expect insert success
 INSERT INTO a SELECT generate_series(1,100);
+-- start_ignore
+\! mkdir -p /tmp/schemaspc3
+-- end_ignore
+DROP TABLESPACE  IF EXISTS "Schemaspc3";
+NOTICE:  tablespace "Schemaspc3" does not exist, skipping
+CREATE TABLESPACE "Schemaspc3" LOCATION '/tmp/schemaspc3';
+CREATE SCHEMA "Spcs2";
+SELECT diskquota.set_schema_tablespace_quota('"Spcs2"', '"Schemaspc3"', '-1 MB');
+ set_schema_tablespace_quota 
+-----------------------------
+ 
+(1 row)
+
 RESET search_path;
 DROP TABLE spcs1.a2, spcs1.a;
 DROP SCHEMA spcs1, spcs2;
 DROP TABLESPACE schemaspc;
 DROP TABLESPACE schemaspc2;
+DROP TABLESPACE "Schemaspc3";

--- a/tests/regress/expected/test_tablespace_schema_perseg.out
+++ b/tests/regress/expected/test_tablespace_schema_perseg.out
@@ -94,10 +94,10 @@ SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FR
 -- start_ignore
 \! mkdir -p /tmp/schemaspc_perseg2
 -- end_ignore
-DROP TABLESPACE  IF EXISTS schemaspc_perseg2;
-NOTICE:  tablespace "schemaspc_perseg2" does not exist, skipping
-CREATE TABLESPACE schemaspc_perseg2 LOCATION '/tmp/schemaspc_perseg2';
-ALTER TABLE a SET TABLESPACE schemaspc_perseg2;
+DROP TABLESPACE  IF EXISTS "Schemaspc_perseg2";
+NOTICE:  tablespace "Schemaspc_perseg2" does not exist, skipping
+CREATE TABLESPACE "Schemaspc_perseg2" LOCATION '/tmp/schemaspc_perseg2';
+ALTER TABLE a SET TABLESPACE "Schemaspc_perseg2";
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -203,19 +203,19 @@ SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FR
 (0 rows)
 
 -- test config per segment quota
-SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','1');
+SELECT diskquota.set_per_segment_quota('"Schemaspc_perseg2"','1');
  set_per_segment_quota 
 -----------------------
  
 (1 row)
 
-SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'Schemaspc_perseg2';
  segratio 
 ----------
         1
 (1 row)
 
-SELECT diskquota.set_schema_tablespace_quota('spcs2_perseg', 'schemaspc_perseg2','1 MB');
+SELECT diskquota.set_schema_tablespace_quota('spcs2_perseg', '"Schemaspc_perseg2"','1 MB');
  set_schema_tablespace_quota 
 -----------------------------
  
@@ -229,13 +229,13 @@ SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.t
         1
 (1 row)
 
-SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','-2');
+SELECT diskquota.set_per_segment_quota('"Schemaspc_perseg2"','-2');
  set_per_segment_quota 
 -----------------------
  
 (1 row)
 
-SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'Schemaspc_perseg2';
  segratio 
 ----------
 (0 rows)
@@ -248,13 +248,13 @@ SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.t
         0
 (1 row)
 
-SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','3');
+SELECT diskquota.set_per_segment_quota('"Schemaspc_perseg2"','3');
  set_per_segment_quota 
 -----------------------
  
 (1 row)
 
-SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'Schemaspc_perseg2';
  segratio 
 ----------
         3
@@ -268,15 +268,15 @@ SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.t
         3
 (1 row)
 
-SELECT tablespace_name, per_seg_quota_ratio FROM diskquota.show_segment_ratio_quota_view where tablespace_name in ('schemaspc_perseg2', 'schemaspc_perseg');
+SELECT tablespace_name, per_seg_quota_ratio FROM diskquota.show_segment_ratio_quota_view where tablespace_name in ('Schemaspc_perseg2', 'schemaspc_perseg');
   tablespace_name  | per_seg_quota_ratio 
 -------------------+---------------------
  schemaspc_perseg  |                   2
- schemaspc_perseg2 |                   3
+ Schemaspc_perseg2 |                   3
 (2 rows)
 
 RESET search_path;
 DROP TABLE spcs1_perseg.a;
 DROP SCHEMA spcs1_perseg;
 DROP TABLESPACE schemaspc_perseg;
-DROP TABLESPACE schemaspc_perseg2;
+DROP TABLESPACE "Schemaspc_perseg2";

--- a/tests/regress/sql/test_role.sql
+++ b/tests/regress/sql/test_role.sql
@@ -56,7 +56,13 @@ SELECT rolname from pg_roles where rolsuper=true;
 --end_ignore
 \gset
 select diskquota.set_role_quota(:'rolname', '1mb');
+
+CREATE ROLE "Tn" NOLOGIN;
+SELECT diskquota.set_role_quota('Tn', '-1 MB'); -- fail
+SELECT diskquota.set_role_quota('"tn"', '-1 MB'); -- fail
+SELECT diskquota.set_role_quota('"Tn"', '-1 MB');
+
 DROP TABLE b, b2;
-DROP ROLE u1, u2;
+DROP ROLE u1, u2, "Tn";
 RESET search_path;
 DROP SCHEMA srole;

--- a/tests/regress/sql/test_schema.sql
+++ b/tests/regress/sql/test_schema.sql
@@ -47,9 +47,12 @@ INSERT INTO badquota.a SELECT generate_series(0, 100);
 SELECT diskquota.wait_for_worker_new_epoch();
 SELECT schema_name, quota_in_mb FROM diskquota.show_fast_schema_quota_view WHERE schema_name = 's1';
 
+CREATE SCHEMA "Tn1";
+SELECT diskquota.set_schema_quota('"Tn1"', '-1 MB');
+
 RESET search_path;
 DROP TABLE s1.a2, badquota.a;
-DROP SCHEMA s1, s2;
+DROP SCHEMA s1, s2, "Tn1";
 
 DROP TABLE badquota.t1;
 DROP ROLE testbody;

--- a/tests/regress/sql/test_tablespace_role.sql
+++ b/tests/regress/sql/test_tablespace_role.sql
@@ -84,9 +84,21 @@ SELECT rolname from pg_roles where rolsuper=true;
 \gset
 select diskquota.set_role_tablespace_quota(:'rolname', 'rolespc', '1mb');
 
+-- start_ignore
+\! mkdir -p /tmp/rolespc3
+-- end_ignore
+DROP ROLE IF EXISTS "Rolespcu3";
+CREATE ROLE "Rolespcu3" NOLOGIN;
+DROP TABLESPACE  IF EXISTS "Rolespc3";
+CREATE TABLESPACE "Rolespc3" LOCATION '/tmp/rolespc3';
+SELECT diskquota.set_role_tablespace_quota('rolespcu1', '"Rolespc3"', '-1 MB');
+SELECT diskquota.set_role_tablespace_quota('"Rolespcu3"', 'rolespc', '-1 mB');
+SELECT diskquota.set_role_tablespace_quota('"Rolespcu3"', '"Rolespc3"', '-1 Mb');
+
 DROP TABLE b, b2;
 DROP ROLE rolespcu1, rolespcu2;
 RESET search_path;
 DROP SCHEMA rolespcrole;
 DROP TABLESPACE rolespc;
 DROP TABLESPACE rolespc2;
+DROP TABLESPACE "Rolespc3";

--- a/tests/regress/sql/test_tablespace_role_perseg.sql
+++ b/tests/regress/sql/test_tablespace_role_perseg.sql
@@ -90,9 +90,19 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert success
 INSERT INTO b SELECT generate_series(1,100);
 
+-- start_ignore
+\! mkdir -p /tmp/rolespc_perseg3
+-- end_ignore
+DROP TABLESPACE  IF EXISTS "Rolespc_perseg3";
+CREATE TABLESPACE "Rolespc_perseg3" LOCATION '/tmp/rolespc_perseg3';
+CREATE ROLE "Rolespc_persegu3" NOLOGIN;
+SELECT diskquota.set_role_tablespace_quota('"Rolespc_persegu3"', '"Rolespc_perseg3"', '-1 MB');
+SELECT diskquota.set_per_segment_quota('"Rolespc_perseg3"', 0.11);
+
 DROP table b;
-DROP ROLE rolespc_persegu1, rolespc_persegu2;
+DROP ROLE rolespc_persegu1, rolespc_persegu2, "Rolespc_persegu3";
 RESET search_path;
 DROP SCHEMA rolespc_persegrole;
 DROP TABLESPACE rolespc_perseg;
 DROP TABLESPACE rolespc_perseg2;
+DROP TABLESPACE "Rolespc_perseg3";

--- a/tests/regress/sql/test_tablespace_schema.sql
+++ b/tests/regress/sql/test_tablespace_schema.sql
@@ -66,9 +66,17 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert success
 INSERT INTO a SELECT generate_series(1,100);
 
+-- start_ignore
+\! mkdir -p /tmp/schemaspc3
+-- end_ignore
+DROP TABLESPACE  IF EXISTS "Schemaspc3";
+CREATE TABLESPACE "Schemaspc3" LOCATION '/tmp/schemaspc3';
+CREATE SCHEMA "Spcs2";
+SELECT diskquota.set_schema_tablespace_quota('"Spcs2"', '"Schemaspc3"', '-1 MB');
+
 RESET search_path;
 DROP TABLE spcs1.a2, spcs1.a;
 DROP SCHEMA spcs1, spcs2;
 DROP TABLESPACE schemaspc;
 DROP TABLESPACE schemaspc2;
-
+DROP TABLESPACE "Schemaspc3";

--- a/tests/regress/sql/test_tablespace_schema_perseg.sql
+++ b/tests/regress/sql/test_tablespace_schema_perseg.sql
@@ -44,9 +44,9 @@ SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FR
 -- start_ignore
 \! mkdir -p /tmp/schemaspc_perseg2
 -- end_ignore
-DROP TABLESPACE  IF EXISTS schemaspc_perseg2;
-CREATE TABLESPACE schemaspc_perseg2 LOCATION '/tmp/schemaspc_perseg2';
-ALTER TABLE a SET TABLESPACE schemaspc_perseg2;
+DROP TABLESPACE  IF EXISTS "Schemaspc_perseg2";
+CREATE TABLESPACE "Schemaspc_perseg2" LOCATION '/tmp/schemaspc_perseg2';
+ALTER TABLE a SET TABLESPACE "Schemaspc_perseg2";
 SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert succeed
 INSERT INTO a SELECT generate_series(1,200);
@@ -84,35 +84,35 @@ INSERT INTO a SELECT generate_series(1,100);
 SELECT schema_name, tablespace_name, quota_in_mb, nspsize_tablespace_in_bytes FROM diskquota.show_fast_schema_tablespace_quota_view WHERE schema_name = 'spcs1_perseg' and tablespace_name ='schemaspc_perseg';
 
 -- test config per segment quota
-SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','1');
-SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+SELECT diskquota.set_per_segment_quota('"Schemaspc_perseg2"','1');
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'Schemaspc_perseg2';
 
-SELECT diskquota.set_schema_tablespace_quota('spcs2_perseg', 'schemaspc_perseg2','1 MB');
-
-SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
- WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
-       diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
-
-SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','-2');
-
-SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+SELECT diskquota.set_schema_tablespace_quota('spcs2_perseg', '"Schemaspc_perseg2"','1 MB');
 
 SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
  WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
        diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
 
-SELECT diskquota.set_per_segment_quota('schemaspc_perseg2','3');
+SELECT diskquota.set_per_segment_quota('"Schemaspc_perseg2"','-2');
 
-SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'schemaspc_perseg2';
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'Schemaspc_perseg2';
 
 SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
  WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
        diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
-SELECT tablespace_name, per_seg_quota_ratio FROM diskquota.show_segment_ratio_quota_view where tablespace_name in ('schemaspc_perseg2', 'schemaspc_perseg');
+
+SELECT diskquota.set_per_segment_quota('"Schemaspc_perseg2"','3');
+
+SELECT distinct(segratio) from diskquota.quota_config, pg_tablespace where targetoid = oid and spcname = 'Schemaspc_perseg2';
+
+SELECT distinct(segratio) FROM diskquota.quota_config, pg_namespace, diskquota.target
+ WHERE diskquota.quota_config.targetoid = diskquota.target.rowId AND
+       diskquota.target.primaryOid = pg_namespace.oid AND nspname = 'spcs2_perseg';
+SELECT tablespace_name, per_seg_quota_ratio FROM diskquota.show_segment_ratio_quota_view where tablespace_name in ('Schemaspc_perseg2', 'schemaspc_perseg');
 
 RESET search_path;
 DROP TABLE spcs1_perseg.a;
 DROP SCHEMA spcs1_perseg;
 DROP TABLESPACE schemaspc_perseg;
-DROP TABLESPACE schemaspc_perseg2;
+DROP TABLESPACE "Schemaspc_perseg2";
 


### PR DESCRIPTION
the code transform all object name to lower case on purpose.

    create schema "S1";
    select * from diskquota.set_schema_quota("S1", '1MB');
    ERROR:  schema "s1" does not exist