### PR TITLE
Minimize the risk of stale relfilenode

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -27,6 +27,7 @@
 #include "port/atomics.h"
 #include "storage/ipc.h"
 #include "storage/proc.h"
+#include "storage/sinval.h"
 #include "tcop/idle_resource_cleaner.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
@@ -394,6 +395,9 @@ disk_quota_worker_main(Datum main_arg)
 
 		CHECK_FOR_INTERRUPTS();
 
+		/* Allow sinval catchup interrupts while sleeping */
+		EnableCatchupInterrupt();
+
 		/*
 		 * Background workers mustn't call usleep() or any direct equivalent:
 		 * instead, they may wait on their process latch, which sleeps as
@@ -402,6 +406,8 @@ disk_quota_worker_main(Datum main_arg)
 		 */
 		rc = WaitLatch(&MyProc->procLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH, diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
+
+		DisableCatchupInterrupt();
 
 		// be nice to scheduler when naptime == 0 and diskquota_is_paused() == true
 		if (!diskquota_naptime) usleep(1);

--- a/diskquota.c
+++ b/diskquota.c
@@ -254,6 +254,7 @@ define_guc_variables(void)
 void
 disk_quota_worker_main(Datum main_arg)
 {
+	optimizer = false;
 	char *dbname = MyBgworkerEntry->bgw_name;
 
 	ereport(LOG, (errmsg("[diskquota] start disk quota worker process to monitor database:%s", dbname)));
@@ -425,6 +426,7 @@ disk_quota_worker_main(Datum main_arg)
 		if (!diskquota_is_paused()) refresh_disk_quota_model(false);
 
 		worker_increase_epoch(MyDatabaseId);
+		MemoryAccounting_Reset();
 	}
 
 	ereport(LOG, (errmsg("[diskquota] bgworker for \"%s\" is being terminated by SIGTERM.", dbname)));

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -321,6 +321,8 @@ gp_fetch_active_tables(bool is_init)
 		local_active_table_oid_maps = pull_active_list_from_seg();
 		active_oid_list             = convert_map_to_string(local_active_table_oid_maps);
 
+		elog(WARNING, "active_old_list = %s", active_oid_list.data);
+
 		/* step 2: fetch active table sizes based on active oids */
 		pull_active_table_size_from_seg(local_table_stats_map, active_oid_list.data);
 
@@ -677,7 +679,7 @@ get_active_tables_oid(void)
 		rnode.spcNode = active_table_file_entry->tablespaceoid;
 		relOid        = get_relid_by_relfilenode(rnode);
 
-		elog(WARNING, "get_active_tables_oid: relfilenode = %u, relid = %u", relOid, rnode.relNode);
+		elog(WARNING, "get_active_tables_oid: relfilenode = %u, relid = %u", rnode.relNode, relOid);
 
 		if (relOid != InvalidOid)
 		{

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -677,6 +677,8 @@ get_active_tables_oid(void)
 		rnode.spcNode = active_table_file_entry->tablespaceoid;
 		relOid        = get_relid_by_relfilenode(rnode);
 
+		elog(WARNING, "get_active_tables_oid: relfilenode = %u, relid = %u", relOid, rnode.relNode);
+
 		if (relOid != InvalidOid)
 		{
 			prelid             = get_primary_table_oid(relOid, true);
@@ -689,7 +691,10 @@ get_active_tables_oid(void)
 				active_table_entry->segid     = -1;
 			}
 			if (!is_relation_being_altered(relOid))
+			{
 				hash_search(local_active_table_file_map, active_table_file_entry, HASH_REMOVE, NULL);
+				elog(WARNING, "relation removed from active table map.");
+			}
 		}
 	}
 

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1221,7 +1221,7 @@ static void
 do_load_quotas(void)
 {
 	int       ret;
-	TupleDesc tupdesc;
+	TupleDesc tupdesc = NULL;
 	int       i;
 
 	/*
@@ -1243,10 +1243,10 @@ do_load_quotas(void)
 	if (ret != SPI_OK_SELECT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] load_quotas SPI_execute failed: error code %d", ret)));
-
+	
 	tupdesc = SPI_tuptable->tupdesc;
-	if (tupdesc->natts != NUM_QUOTA_CONFIG_ATTRS || ((tupdesc)->attrs[0])->atttypid != OIDOID ||
-	    ((tupdesc)->attrs[1])->atttypid != INT4OID || ((tupdesc)->attrs[2])->atttypid != INT8OID)
+	if (tupdesc && (tupdesc->natts != NUM_QUOTA_CONFIG_ATTRS || ((tupdesc)->attrs[0])->atttypid != OIDOID ||
+	    ((tupdesc)->attrs[1])->atttypid != INT4OID || ((tupdesc)->attrs[2])->atttypid != INT8OID))
 	{
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] configuration table is corrupted in database \"%s\","

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -579,6 +579,8 @@ do_calculate_table_size(DiskQuotaRelationCacheEntry *entry)
 	get_relfilenode_by_relid(entry->relid, &rnode, &relstorage);
 	tablesize += calculate_relation_size_all_forks(&rnode, relstorage);
 
+	elog(WARNING, "do_calculate_table_size: relid = %u, relfilenode = %u, size= %ld", entry->relid, rnode.node.relNode, tablesize);
+
 	for (i = 0; i < entry->auxrel_num; i++)
 	{
 		subrelid = entry->auxrel_oid[i];

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -8,6 +8,7 @@
 #include "utils/relfilenodemap.h"
 #include "utils/syscache.h"
 #include "utils/array.h"
+#include "utils/inval.h"
 #include "funcapi.h"
 
 #include "relation_cache.h"
@@ -441,6 +442,12 @@ get_relation_entry_from_pg_class(Oid relid, DiskQuotaRelationCacheEntry *relatio
 	Oid           visimaprelid = InvalidOid;
 	bool          is_ao        = false;
 
+	/* 
+	 * Since we don't take any lock on relation, check for cache 
+	 * invalidation messages manually to minimize risk of cache 
+	 * inconsistency.
+	 */
+	AcceptInvalidationMessages();
 	classTup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relid));
 	if (!HeapTupleIsValid(classTup) || relation_entry == NULL)
 	{
@@ -541,6 +548,12 @@ get_relfilenode_by_relid(Oid relid, RelFileNodeBackend *rnode, char *relstorage)
 	Form_pg_class                classForm;
 
 	memset(rnode, 0, sizeof(RelFileNodeBackend));
+	/* 
+	 * Since we don't take any lock on relation, check for cache 
+	 * invalidation messages manually to minimize risk of cache 
+	 * inconsistency.
+	 */
+	AcceptInvalidationMessages();
 	classTup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relid));
 	if (HeapTupleIsValid(classTup))
 	{

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -51,6 +51,9 @@ get_relid_by_relfilenode(RelFileNode relfilenode)
 	Oid relid;
 
 	relid = RelidByRelfilenode(relfilenode.spcNode, relfilenode.relNode);
+
+	elog(WARNING, "get_active_tables_oid committed: relfilenode = %u, relid = %u", relfilenode.relNode, relid);
+
 	if (OidIsValid(relid))
 	{
 		remove_cache_entry(InvalidOid, relfilenode.relNode);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,34 +46,34 @@ RegressTarget_Add(isolation2
     --dbname=isolation2test)
 
 add_custom_target(installcheck)
-add_dependencies(installcheck isolation2 regress)
+#add_dependencies(installcheck isolation2 regress)
 
 # Example to run test_truncate infinite times
-# RegressTarget_Add(regress_config
-#     INIT_FILE
-#     ${CMAKE_CURRENT_SOURCE_DIR}/init_file
-#     SQL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/sql
-#     EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/expected
-#     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
-#     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
-#     REGRESS
-#     config test_create_extension
-#     REGRESS_OPTS
-#     ${load_inject_fault_opts}
-#     --dbname=contrib_regression)
-# RegressTarget_Add(regress_truncate_loop
-#     INIT_FILE
-#     ${CMAKE_CURRENT_SOURCE_DIR}/init_file
-#     SQL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/sql
-#     EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/expected
-#     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
-#     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
-#     REGRESS
-#     test_truncate
-#     RUN_TIMES -1
-#     REGRESS_OPTS
-#     ${load_inject_fault_opts}
-#     --dbname=contrib_regression
-#     --use-existing)
-# add_dependencies(regress_truncate_loop regress_config)
-# add_dependencies(installcheck regress_truncate_loop)
+RegressTarget_Add(regress_config
+    INIT_FILE
+    ${CMAKE_CURRENT_SOURCE_DIR}/init_file
+    SQL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/sql
+    EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/expected
+    RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
+    DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
+    REGRESS
+    config test_create_extension
+    REGRESS_OPTS
+    ${load_inject_fault_opts}
+    --dbname=contrib_regression)
+RegressTarget_Add(regress_truncate_loop
+    INIT_FILE
+    ${CMAKE_CURRENT_SOURCE_DIR}/init_file
+    SQL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/sql
+    EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/expected
+    RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
+    DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
+    REGRESS
+    test_truncate
+    RUN_TIMES 100000
+    REGRESS_OPTS
+    ${load_inject_fault_opts}
+    --dbname=contrib_regression
+    --use-existing)
+add_dependencies(regress_truncate_loop regress_config)
+add_dependencies(installcheck regress_truncate_loop)

--- a/tests/regress/expected/test_truncate.out
+++ b/tests/regress/expected/test_truncate.out
@@ -1,3 +1,6 @@
+--start_ignore
+DROP SCHEMA s7 CASCADE;
+--end_ignore
 -- Test truncate
 CREATE SCHEMA s7;
 SELECT diskquota.set_schema_quota('s7', '1 MB');
@@ -35,6 +38,4 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert succeed
 INSERT INTO a SELECT generate_series(1,30);
 INSERT INTO b SELECT generate_series(1,30);
-DROP TABLE a, b;
 RESET search_path;
-DROP SCHEMA s7;

--- a/tests/regress/sql/test_truncate.sql
+++ b/tests/regress/sql/test_truncate.sql
@@ -1,3 +1,7 @@
+--start_ignore
+DROP SCHEMA s7 CASCADE;
+--end_ignore
+
 -- Test truncate
 CREATE SCHEMA s7;
 SELECT diskquota.set_schema_quota('s7', '1 MB');
@@ -15,7 +19,4 @@ SELECT diskquota.wait_for_worker_new_epoch();
 INSERT INTO a SELECT generate_series(1,30);
 INSERT INTO b SELECT generate_series(1,30);
 
-DROP TABLE a, b;
 RESET search_path;
-DROP SCHEMA s7;
-


### PR DESCRIPTION
- Check for invalidation messages each time before SearchSysCache().
- Do not remove a relation if the relfilenode is stale.