### PR TITLE
Fix change tablespace test case

### DIFF
--- a/tests/regress/expected/test_tablespace_role_perseg.out
+++ b/tests/regress/expected/test_tablespace_role_perseg.out
@@ -134,14 +134,20 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t
 (1 row)
 
+-- expect insert success
+INSERT INTO b SELECT generate_series(1,100);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 SELECT role_name, tablespace_name, quota_in_mb, rolsize_tablespace_in_bytes FROM diskquota.show_fast_role_tablespace_quota_view WHERE role_name = 'rolespc_persegu1' and tablespace_name = 'rolespc_perseg';
     role_name     | tablespace_name | quota_in_mb | rolsize_tablespace_in_bytes 
 ------------------+-----------------+-------------+-----------------------------
  rolespc_persegu1 | rolespc_perseg  |          10 |                     4063232
 (1 row)
 
--- expect insert success
-INSERT INTO b SELECT generate_series(1,100);
 SELECT diskquota.set_per_segment_quota('rolespc_perseg', 0.11);
  set_per_segment_quota 
 -----------------------

--- a/tests/regress/sql/test_tablespace_role_perseg.sql
+++ b/tests/regress/sql/test_tablespace_role_perseg.sql
@@ -64,10 +64,11 @@ INSERT INTO b SELECT generate_series(1,100);
 -- Test update per segment ratio
 SELECT diskquota.set_per_segment_quota('rolespc_perseg', 3.1);
 SELECT diskquota.wait_for_worker_new_epoch();
-SELECT role_name, tablespace_name, quota_in_mb, rolsize_tablespace_in_bytes FROM diskquota.show_fast_role_tablespace_quota_view WHERE role_name = 'rolespc_persegu1' and tablespace_name = 'rolespc_perseg';
-
 -- expect insert success
 INSERT INTO b SELECT generate_series(1,100);
+SELECT diskquota.wait_for_worker_new_epoch();
+SELECT role_name, tablespace_name, quota_in_mb, rolsize_tablespace_in_bytes FROM diskquota.show_fast_role_tablespace_quota_view WHERE role_name = 'rolespc_persegu1' and tablespace_name = 'rolespc_perseg';
+
 SELECT diskquota.set_per_segment_quota('rolespc_perseg', 0.11);
 SELECT diskquota.wait_for_worker_new_epoch();
 -- expect insert fail


### PR DESCRIPTION
"ALTER TABLE xx SET TABLESPACE" will change the relfilenode of
a table, it will copy files from old relfilenode directory to
the new one and delete all files when commiting the transaction.

As diskquota doesn't acquire a lock on the relation when
fetching table size, so if diskquota is collecting active
tables' size and another session is deleting a active table's
files under a old relfilenode directory in a changing
tablespace transaction, the diskquota may can't get all segment's
table size as files on part of segments have been deleted.

To fix it, we try to make a table to be an active table by
inserting data into it and wait the diskquota to recalculate
the tablesize after changing tablespace.