### PR TITLE
Minimize the risk of stale relfilenodes

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -396,16 +396,6 @@ disk_quota_worker_main(Datum main_arg)
 		CHECK_FOR_INTERRUPTS();
 
 		/*
-		 * Allow sinval catchup interrupts while sleeping
-		 *
-		 * This follows what the autovacuum launcher does
-		 *
-		 * TODO: Currently, this does not take effect because there is no
-		 * handler for it in disk_quota_sigusr1().
-		 */
-		EnableCatchupInterrupt();
-
-		/*
 		 * Background workers mustn't call usleep() or any direct equivalent:
 		 * instead, they may wait on their process latch, which sleeps as
 		 * necessary, but is awakened if postmaster dies.  That way the
@@ -413,8 +403,6 @@ disk_quota_worker_main(Datum main_arg)
 		 */
 		rc = WaitLatch(&MyProc->procLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH, diskquota_naptime * 1000L);
 		ResetLatch(&MyProc->procLatch);
-
-		DisableCatchupInterrupt();
 
 		// be nice to scheduler when naptime == 0 and diskquota_is_paused() == true
 		if (!diskquota_naptime) usleep(1);

--- a/diskquota.c
+++ b/diskquota.c
@@ -28,7 +28,6 @@
 #include "port/atomics.h"
 #include "storage/ipc.h"
 #include "storage/proc.h"
-#include "storage/sinval.h"
 #include "tcop/idle_resource_cleaner.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"

--- a/diskquota.c
+++ b/diskquota.c
@@ -398,7 +398,10 @@ disk_quota_worker_main(Datum main_arg)
 		/*
 		 * Allow sinval catchup interrupts while sleeping
 		 *
-		 * This follows what the Autovacuum launcher does
+		 * This follows what the autovacuum launcher does
+		 *
+		 * TODO: Currently, this does not take effect because there is no
+		 * handler for it in disk_quota_sigusr1().
 		 */
 		EnableCatchupInterrupt();
 

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -627,13 +627,18 @@ is_relation_being_altered(Oid relid)
 	return being_altered;
 }
 
+/*
+ * Check whether the given relfilenode is stale due to delayed cache 
+ * invalidation messages.
+ * 
+ * NOTE: It will return false if the relation is currently uncommitted.
+ */ 
 static bool
 is_relfilenode_stale(Oid relOid, RelFileNode rnode)
 {
 	/*
-	 * Since we don't take any lock on relation, check for cache
-	 * invalidation messages manually to minimize risk of cache
-	 * inconsistency.
+	 * Since we don't take any lock on relation, need to check for cache
+	 * invalidation messages manually.
 	 */
 	AcceptInvalidationMessages();
 	HeapTuple tp = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relOid));

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -643,7 +643,7 @@ is_cached_relfilenode_stale(Oid relOid, RelFileNode rnode)
 	AcceptInvalidationMessages();
 	HeapTuple tp = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relOid));
 
-	/* 
+	/*
 	 * Tuple is not valid if
 	 * - The relation has not been committed yet, or
 	 * - The relation has been deleted

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -628,11 +628,11 @@ is_relation_being_altered(Oid relid)
 }
 
 /*
- * Check whether the given relfilenode is stale due to delayed cache 
+ * Check whether the given relfilenode is stale due to delayed cache
  * invalidation messages.
- * 
+ *
  * NOTE: It will return false if the relation is currently uncommitted.
- */ 
+ */
 static bool
 is_relfilenode_stale(Oid relOid, RelFileNode rnode)
 {

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -358,7 +358,7 @@ gp_fetch_active_tables(bool is_init)
 		local_active_table_oid_maps = pull_active_list_from_seg();
 		active_oid_list             = convert_map_to_string(local_active_table_oid_maps);
 
-		ereport(WARNING,
+		ereport(DEBUG1,
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oid_list.data)));
 
 		/* step 2: fetch active table sizes based on active oids */

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -31,6 +31,8 @@
 #include "libpq-fe.h"
 #include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
+#include "utils/syscache.h"
+#include "utils/inval.h"
 
 #include "gp_activetable.h"
 #include "diskquota.h"
@@ -69,6 +71,7 @@ static void           pull_active_table_size_from_seg(HTAB *local_table_stats_ma
 static StringInfoData convert_map_to_string(HTAB *active_list);
 static void           load_table_size(HTAB *local_table_stats_map);
 static void           report_active_table_helper(const RelFileNodeBackend *relFileNode);
+static void           remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
 static void           report_relation_cache_helper(Oid relid);
 static void           report_altered_reloid(Oid reloid);
 
@@ -164,6 +167,11 @@ active_table_hook_smgrunlink(RelFileNodeBackend rnode)
 {
 	if (prev_file_unlink_hook) (*prev_file_unlink_hook)(rnode);
 
+	/*
+	 * Since we do not remove the relfilenode if it maps to no valid
+	 * relation oid, we need to do the cleaning here to avoid memory leak
+	 */
+	remove_from_active_table_map(&rnode);
 	remove_cache_entry(InvalidOid, rnode.node.relNode);
 }
 
@@ -297,6 +305,23 @@ report_active_table_helper(const RelFileNodeBackend *relFileNode)
 }
 
 /*
+ * Remove relfilenode from the active table map if exists.
+ */
+static void
+remove_from_active_table_map(const RelFileNodeBackend *relFileNode)
+{
+	DiskQuotaActiveTableFileEntry item = {0};
+
+	item.dbid          = relFileNode->node.dbNode;
+	item.relfilenode   = relFileNode->node.relNode;
+	item.tablespaceoid = relFileNode->node.spcNode;
+
+	LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
+	hash_search(active_tables_map, &item, HASH_REMOVE, NULL);
+	LWLockRelease(diskquota_locks.active_table_lock);
+}
+
+/*
  * Interface of activetable module
  * This function is called by quotamodel module.
  * Disk quota worker process need to collect
@@ -332,6 +357,10 @@ gp_fetch_active_tables(bool is_init)
 		/* step 1: fetch active oids from all the segments */
 		local_active_table_oid_maps = pull_active_list_from_seg();
 		active_oid_list             = convert_map_to_string(local_active_table_oid_maps);
+
+		ereport(DEBUG1,
+		        (errcode(ERRCODE_INTERNAL_ERROR), 
+				errmsg("[diskquota] active_old_list = %s", active_oid_list.data));
 
 		/* step 2: fetch active table sizes based on active oids */
 		pull_active_table_size_from_seg(local_table_stats_map, active_oid_list.data);
@@ -691,6 +720,25 @@ get_active_tables_oid(void)
 
 		if (relOid != InvalidOid)
 		{
+			/*
+			 * Since we don't take any lock on relation, check for cache
+			 * invalidation messages manually to minimize risk of cache
+			 * inconsistency.
+			 */
+			AcceptInvalidationMessages();
+			HeapTuple tp = SearchSysCache1(RELOID, ObjectIdGetDatum(relOid));
+			if (!HeapTupleIsValid(tp)) continue;
+			Form_pg_class reltup = (Form_pg_class)GETSTRUCT(tp);
+
+			/*
+			 * If cache invalidation messages are not delievered in time, the
+			 * relfilenode in the tuple of the relation is stale. In that case,
+			 * the relfilenode in the relation tuple is not equal to the one in
+			 * the active table map.
+			 */
+			bool is_relfilenode_stale = reltup->relfilenode != rnode.relNode;
+			ReleaseSysCache(tp);
+
 			prelid             = get_primary_table_oid(relOid, true);
 			active_table_entry = hash_search(local_active_table_stats_map, &prelid, HASH_ENTER, &found);
 			if (active_table_entry && !found)
@@ -700,8 +748,15 @@ get_active_tables_oid(void)
 				active_table_entry->tablesize = 0;
 				active_table_entry->segid     = -1;
 			}
-			if (!is_relation_being_altered(relOid))
+			/*
+			 * Do NOT remove relation from the active table map if it is being
+			 * altered or its relfilenode is stale so that we can check it
+			 * again in the next epoch.
+			 */
+			if (!is_relation_being_altered(relOid) && !is_relfilenode_stale)
+			{
 				hash_search(local_active_table_file_map, active_table_file_entry, HASH_REMOVE, NULL);
+			}
 		}
 	}
 

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -359,8 +359,7 @@ gp_fetch_active_tables(bool is_init)
 		active_oid_list             = convert_map_to_string(local_active_table_oid_maps);
 
 		ereport(DEBUG1,
-		        (errcode(ERRCODE_INTERNAL_ERROR), 
-				errmsg("[diskquota] active_old_list = %s", active_oid_list.data));
+		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oid_list.data)));
 
 		/* step 2: fetch active table sizes based on active oids */
 		pull_active_table_size_from_seg(local_table_stats_map, active_oid_list.data);

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -31,6 +31,7 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/faultinjector.h"
+#include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1225,7 +1225,7 @@ static void
 do_load_quotas(void)
 {
 	int       ret;
-	TupleDesc tupdesc = NULL;
+	TupleDesc tupdesc;
 	int       i;
 
 	/*
@@ -1258,8 +1258,8 @@ do_load_quotas(void)
 		                errmsg("[diskquota] load_quotas SPI_execute failed: error code %d", ret)));
 
 	tupdesc = SPI_tuptable->tupdesc;
-	if (tupdesc && (tupdesc->natts != NUM_QUOTA_CONFIG_ATTRS || ((tupdesc)->attrs[0])->atttypid != OIDOID ||
-	                ((tupdesc)->attrs[1])->atttypid != INT4OID || ((tupdesc)->attrs[2])->atttypid != INT8OID))
+	if (tupdesc->natts != NUM_QUOTA_CONFIG_ATTRS || ((tupdesc)->attrs[0])->atttypid != OIDOID ||
+	    ((tupdesc)->attrs[1])->atttypid != INT4OID || ((tupdesc)->attrs[2])->atttypid != INT8OID)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] configuration table is corrupted in database \"%s\","

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1225,7 +1225,7 @@ static void
 do_load_quotas(void)
 {
 	int       ret;
-	TupleDesc tupdesc;
+	TupleDesc tupdesc = NULL;
 	int       i;
 
 	/*
@@ -1256,10 +1256,10 @@ do_load_quotas(void)
 	if (ret != SPI_OK_SELECT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] load_quotas SPI_execute failed: error code %d", ret)));
-
+	
 	tupdesc = SPI_tuptable->tupdesc;
-	if (tupdesc->natts != NUM_QUOTA_CONFIG_ATTRS || ((tupdesc)->attrs[0])->atttypid != OIDOID ||
-	    ((tupdesc)->attrs[1])->atttypid != INT4OID || ((tupdesc)->attrs[2])->atttypid != INT8OID)
+	if (tupdesc && (tupdesc->natts != NUM_QUOTA_CONFIG_ATTRS || ((tupdesc)->attrs[0])->atttypid != OIDOID ||
+	    ((tupdesc)->attrs[1])->atttypid != INT4OID || ((tupdesc)->attrs[2])->atttypid != INT8OID))
 	{
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] configuration table is corrupted in database \"%s\","

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1322,6 +1322,12 @@ get_rel_owner_schema_tablespace(Oid relid, Oid *ownerOid, Oid *nsOid, Oid *table
 {
 	HeapTuple tp;
 
+	/*
+	 * Since we don't take any lock on relation, check for cache
+	 * invalidation messages manually to minimize risk of cache
+	 * inconsistency.
+	 */
+	AcceptInvalidationMessages();
 	tp         = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
 	bool found = HeapTupleIsValid(tp);
 	if (HeapTupleIsValid(tp))
@@ -1351,6 +1357,12 @@ get_rel_name_namespace(Oid relid, Oid *nsOid, char *relname)
 {
 	HeapTuple tp;
 
+	/*
+	 * Since we don't take any lock on relation, check for cache
+	 * invalidation messages manually to minimize risk of cache
+	 * inconsistency.
+	 */
+	AcceptInvalidationMessages();
 	tp         = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
 	bool found = HeapTupleIsValid(tp);
 	if (found)
@@ -1705,6 +1717,12 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 		active_oid = DatumGetObjectId(datums[i]);
 		if (!OidIsValid(active_oid)) continue;
 
+		/*
+		 * Since we don't take any lock on relation, check for cache
+		 * invalidation messages manually to minimize risk of cache
+		 * inconsistency.
+		 */
+		AcceptInvalidationMessages();
 		tuple = SearchSysCacheCopy1(RELOID, active_oid);
 		if (HeapTupleIsValid(tuple))
 		{

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1256,10 +1256,10 @@ do_load_quotas(void)
 	if (ret != SPI_OK_SELECT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] load_quotas SPI_execute failed: error code %d", ret)));
-	
+
 	tupdesc = SPI_tuptable->tupdesc;
 	if (tupdesc && (tupdesc->natts != NUM_QUOTA_CONFIG_ATTRS || ((tupdesc)->attrs[0])->atttypid != OIDOID ||
-	    ((tupdesc)->attrs[1])->atttypid != INT4OID || ((tupdesc)->attrs[2])->atttypid != INT8OID))
+	                ((tupdesc)->attrs[1])->atttypid != INT4OID || ((tupdesc)->attrs[2])->atttypid != INT8OID))
 	{
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] configuration table is corrupted in database \"%s\","

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -19,6 +19,7 @@
 #include "utils/relfilenodemap.h"
 #include "utils/syscache.h"
 #include "utils/array.h"
+#include "utils/inval.h"
 #include "funcapi.h"
 
 #include "relation_cache.h"
@@ -449,6 +450,12 @@ get_relation_entry_from_pg_class(Oid relid, DiskQuotaRelationCacheEntry *relatio
 	Oid           visimaprelid = InvalidOid;
 	bool          is_ao        = false;
 
+	/*
+	 * Since we don't take any lock on relation, check for cache
+	 * invalidation messages manually to minimize risk of cache
+	 * inconsistency.
+	 */
+	AcceptInvalidationMessages();
 	classTup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relid));
 	if (!HeapTupleIsValid(classTup) || relation_entry == NULL)
 	{
@@ -549,6 +556,12 @@ get_relfilenode_by_relid(Oid relid, RelFileNodeBackend *rnode, char *relstorage)
 	Form_pg_class                classForm;
 
 	memset(rnode, 0, sizeof(RelFileNodeBackend));
+	/*
+	 * Since we don't take any lock on relation, check for cache
+	 * invalidation messages manually to minimize risk of cache
+	 * inconsistency.
+	 */
+	AcceptInvalidationMessages();
 	classTup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relid));
 	if (HeapTupleIsValid(classTup))
 	{


### PR DESCRIPTION
Since we do NOT take any lock when accessing info of a relation,
cache invalidation messages may not be delievered in time each time
we SeearchSysCache() for relfilenode. As a result, the relfilenode may
be stale and the table size may be incorrect.

This patch fixes this issue by

- Checking for invalidation messages each time before
SearchSysCache(RELOID).
- Not removing a relation from active table map if the relfilenode
is stale.

Besides, since we do not remove the relfilenode if it maps to no
valid relation oid, we need remove those dangling relfilenodes
when unlink() to avoid memory leak.