### PR TITLE
Compatible with ancient git

### DIFF
--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -19,8 +19,9 @@ regresstarget_add(
 # check whether DDL file (*.sql) is modified
 file(GLOB ddl_files ${CMAKE_SOURCE_DIR}/*.sql)
 foreach(ddl IN LISTS ddl_files)
+  cmake_path(GET ddl FILENAME ddl)
   exec_program(
-    git ARGS
+    git ${CMAKE_SOURCE_DIR} ARGS
     diff --exit-code ${ddl}
     OUTPUT_VARIABLE NULL
     RETURN_VALUE "${ddl}_modified")

--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach(ddl IN LISTS ddl_files)
   cmake_path(GET ddl FILENAME ddl)
   exec_program(
     git ${CMAKE_SOURCE_DIR} ARGS
-    diff --exit-code ${ddl}
+    diff origin/gpdb --exit-code ${ddl}
     OUTPUT_VARIABLE NULL
     RETURN_VALUE "${ddl}_modified")
 

--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach(ddl IN LISTS ddl_files)
   if("${${ddl}_modified}")
     message(
       NOTICE
-      "compare to ${latest_tag}, the DDL file ${ddl} is modified, checking if upgrade test is needed."
+      "compared to ${latest_tag}, the DDL file ${ddl} is modified, checking if upgrade test is needed."
     )
     set(DISKQUOTA_DDL_MODIFIED TRUE)
   endif()

--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -16,20 +16,26 @@ regresstarget_add(
   REGRESS_OPTS
   --dbname=contrib_regression)
 
+exec_program(
+  git ${CMAKE_SOURCE_DIR} ARGS
+  tag --sort version:refname | tail -n 1
+  OUTPUT_VARIABLE latest_tag
+)
+
 # check whether DDL file (*.sql) is modified
 file(GLOB ddl_files ${CMAKE_SOURCE_DIR}/*.sql)
 foreach(ddl IN LISTS ddl_files)
   cmake_path(GET ddl FILENAME ddl)
   exec_program(
     git ${CMAKE_SOURCE_DIR} ARGS
-    diff origin/gpdb --exit-code ${ddl}
+    diff ${latest_tag} --exit-code ${ddl}
     OUTPUT_VARIABLE NULL
     RETURN_VALUE "${ddl}_modified")
 
   if("${${ddl}_modified}")
     message(
       NOTICE
-      "detected DDL file ${ddl} is modified, checking if upgrade test is needed."
+      "compare to ${latest_tag}, the DDL file ${ddl} is modified, checking if upgrade test is needed."
     )
     set(DISKQUOTA_DDL_MODIFIED TRUE)
   endif()

--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -18,7 +18,7 @@ regresstarget_add(
 
 exec_program(
   git ${CMAKE_SOURCE_DIR} ARGS
-  tag --sort version:refname | tail -n 1
+  tag | sort --version-sort -r | head -n 1
   OUTPUT_VARIABLE latest_tag
 )
 


### PR DESCRIPTION
git 1.7.1 dose not support `git diff /absolute/path/to/current/project`

make our CI happy.