### PR TITLE
Fix compiler version on concourse

### DIFF
--- a/concourse/scripts/build_diskquota.sh
+++ b/concourse/scripts/build_diskquota.sh
@@ -6,9 +6,9 @@ function pkg() {
     [ -f /opt/gcc_env.sh ] && source /opt/gcc_env.sh
     source /usr/local/greenplum-db-devel/greenplum_path.sh
 
-    if [ "${DISKQUOTA_OS}" = "rhel6" ]; then
-        export CC="$(which gcc)"
-    fi
+    # Always use the gcc from $PATH, to avoid using a lower version compiler by /usr/bin/cc
+    export CC="$(which gcc)"
+    export CXX="$(which g++)"
 
     pushd /home/gpadmin/diskquota_artifacts
     local last_release_path


### PR DESCRIPTION
cmake will look up c compiler by checking /usr/bin/cc. On CentOS7, that
symbolic linked to the gcc in the same directory. Although a newer gcc
is installed, cmake will not use the newer one.

We always export the CC and CXX, then the gcc/g++ in the $PATH will be
used.
