### PR TITLE
[cmake] Use C compiler to link the target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ set_target_properties(
   PROPERTIES OUTPUT_NAME ${DISKQUOTA_BINARY_NAME}
              PREFIX ""
              C_STANDARD 99
-             LINKER_LANGUAGE "CXX")
+             LINKER_LANGUAGE "C")
 
 # packing part, move to a separate file if this part is too large
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Distro.cmake)


### PR DESCRIPTION
Since we didn't implement anything in C++, let's invoke C compiler to link the target.

See: https://cmake.org/cmake/help/latest/prop_tgt/LINKER_LANGUAGE.html#prop_tgt:LINKER_LANGUAGE