### PR TITLE
Scripts for new pipeline naming rules

### DIFF
--- a/concourse/README.md
+++ b/concourse/README.md
@@ -15,7 +15,7 @@ https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/pr.diskquota
 
 ### Main Branch Pipeline
 
-The development happens on the `gpdb` branch. The merge pipeline for the `gpdb`
+The development happens on the `gpdb` branch. The merge pipeline for the `gpdb` branch is
 https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/merge.diskquota:gpdb
 
 

--- a/concourse/README.md
+++ b/concourse/README.md
@@ -2,20 +2,21 @@
 
 ## Naming Prefix Rule
 
-- `PR:<project_name>` for pull-request pipelines
-- `COMMIT:<project_name>:<branch_name>` for branch pipelines. It will be executed when a commit committed/merged into the branch.
-- `DEV:<your_name>_<project_name>[any_other_info]` for personal development usage. Put your name into the pipeline name so others can know who own it.
+- `pr.<project_name>` for pull-request pipelines
+- `merge.<project_name>.<branch_name>` for branch pipelines. It will be executed when a commit committed/merged into the branch.
+- `dev.<project_name>.<branch_name>.<your_postfix>` for personal development usage. Put your name into the pipeline name so others can know who own it.
+- `<pipeline>_test.<project_name>.<branch_name>` for pipeline debugging.
 
 ## Pipelines for daily work
 
 ### PR Pipeline
 
-https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/PR:diskquota
+https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/pr.diskquota
 
 ### Main Branch Pipeline
 
-The development happens on the `gpdb` branch. The commit pipeline for the `gpdb`
-https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/COMMIT:diskquota:gpdb
+The development happens on the `gpdb` branch. The merge pipeline for the `gpdb`
+https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/merge.diskquota:gpdb
 
 
 # Fly a pipeline
@@ -38,10 +39,10 @@ https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/COMMIT:diskquota:gpdb
 ./fly.sh -t extension -c pr
 ```
 
-## Fly the commit pipeline
+## Fly the merge pipeline
 
 ```
-./fly.sh -t extension -c commit
+./fly.sh -t extension -c merge
 ```
 
 ## Fly the release pipeline
@@ -54,24 +55,24 @@ The release pipeline should be located in https://prod.ci.gpdb.pivotal.io
 # Login to prod
 fly -t prod login -c https://prod.ci.gpdb.pivotal.io
 # Fly the release pipeline
-./fly.sh -t prod -c release
+./fly.sh -t prod -c rel
 ```
 
 To fly a release pipeline from a specific branch:
 
 ```
-./fly.sh -t <target> -c release -b release/<major>.<minor>
+./fly.sh -t <target> -c rel -b release/<major>.<minor>
 ```
 
 ## Fly the dev pipeline
 
 ```
-./fly.sh -t extension -c dev -p <your_name>_diskquota -b <your_branch>
+./fly.sh -t extension -c dev -p <your_postfix> -b <your_branch>
 ```
 
 ## Webhook
 
-By default, the PR and commit pipelines are using webhook instead of polling to trigger a build. The webhook URL will be printed when flying such a pipeline by `fly.sh`. The webhook needs to be set in the `github repository` -> `Settings` -> `Webhooks` with push notification enabled.
+By default, the PR and merge pipelines are using webhook instead of polling to trigger a build. The webhook URL will be printed when flying such a pipeline by `fly.sh`. The webhook needs to be set in the `github repository` -> `Settings` -> `Webhooks` with push notification enabled.
 
 To test if the webhook works, use `curl` to send a `POST` request to the hook URL with some random data. If it is the right URL, the relevant resource will be refreshed on the Concourse UI. The command line looks like:
 
@@ -83,6 +84,6 @@ curl --data-raw "foo" <hook_url>
 
 ## PR pipeline is not triggered.
 
-The PR pipeline relies on the webhook to detect the new PR. However, due the the limitation of the webhook implemention of concourse, we rely on the push hook for this. It means if the PR is from a forked repo, the PR pipeline won't be triggered immediately. To manually trigger the pipeline, go to https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/PR:diskquota/resources/diskquota_pr and click ⟳ button there.
+The PR pipeline relies on the webhook to detect the new PR. However, due the the limitation of the webhook implemention of concourse, we rely on the push hook for this. It means if the PR is from a forked repo, the PR pipeline won't be triggered immediately. To manually trigger the pipeline, go to https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/pr.diskquota/resources/diskquota_pr and click ⟳ button there.
 
 TIPS: Just don't fork, name your branch as `<your_id>/<branch_name>` and push it here to create PR.

--- a/concourse/README.md
+++ b/concourse/README.md
@@ -84,6 +84,6 @@ curl --data-raw "foo" <hook_url>
 
 ## PR pipeline is not triggered.
 
-The PR pipeline relies on the webhook to detect the new PR. However, due the the limitation of the webhook implemention of concourse, we rely on the push hook for this. It means if the PR is from a forked repo, the PR pipeline won't be triggered immediately. To manually trigger the pipeline, go to https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/pr.diskquota/resources/diskquota_pr and click ⟳ button there.
+The PR pipeline relies on the webhook to detect the new PR. However, due to the the limitation of the webhook implemention of concourse, we rely on the push hook for this. It means if the PR is from a forked repo, the PR pipeline won't be triggered immediately. To manually trigger the pipeline, go to https://extensions.ci.gpdb.pivotal.io/teams/main/pipelines/pr.diskquota/resources/diskquota_pr and click ⟳ button there.
 
 TIPS: Just don't fork, name your branch as `<your_id>/<branch_name>` and push it here to create PR.

--- a/concourse/fly.sh
+++ b/concourse/fly.sh
@@ -2,25 +2,28 @@
 
 set -e
 
-workspace=${WORKSPACE:-"$HOME/workspace"}
 fly=${FLY:-"fly"}
-echo "'workspace' location: ${workspace}"
 echo "'fly' command: ${fly}"
 echo ""
+proj_name="diskquota"
 
 usage() {
-    echo "Usage: $0 -t <concourse_target> -c <pr|commit|dev> [-p <pipeline_name>] [-b branch]" 1>&2
     if [ -n "$1" ]; then
-        echo "$1"
+        echo "$1" 1>&2
+        echo "" 1>&2
     fi
+
+    echo "Usage: $0 -t <concourse_target> -c <pr|rel|merge|dev> [-p <postfix>] [-b branch] [-T]"
+    echo "Options:"
+    echo "       '-T' adds '_test' suffix to the pipeline type. Useful for pipeline debugging."
     exit 1
 }
 
 # Parse command line options
-while getopts ":c:t:p:b:" o; do
+while getopts ":c:t:p:b:T" o; do
     case "${o}" in
         c)
-            # pipeline type/config. pr/commit/dev/release
+            # pipeline type/config. pr/merge/dev/rel
             pipeline_config=${OPTARG}
             ;;
         t)
@@ -29,11 +32,14 @@ while getopts ":c:t:p:b:" o; do
             ;;
         p)
             # pipeline name
-            pipeline_name=${OPTARG}
+            postfix=${OPTARG}
             ;;
         b)
             # branch name
             branch=${OPTARG}
+            ;;
+        T)
+            test_suffix="_test"
             ;;
         *)
             usage ""
@@ -46,52 +52,66 @@ if [ -z "${target}" ] || [ -z "${pipeline_config}" ]; then
     usage ""
 fi
 
+pipeline_type=""
 # Decide ytt options to generate pipeline
 case ${pipeline_config} in
   pr)
-      if [ -z "${pipeline_name}" ]; then
-          pipeline_name="PR:diskquota"
-      fi
+      pipeline_type="pr"
       config_file="pr.yml"
-      hook_res="diskquota_pr"
+      hook_res="${proj_name}_pr"
     ;;
-  commit)
-      if [ -z "${pipeline_name}" ]; then
-          pipeline_name="COMMIT:diskquota:gpdb"
-      fi
+  merge|commit)
       # Default branch is 'gpdb' as it is our main branch
       if [ -z "${branch}" ]; then
           branch="gpdb"
       fi
+      pipeline_type="merge"
       config_file="commit.yml"
-      hook_res="diskquota_commit"
+      hook_res="${proj_name}_commit"
     ;;
   dev)
-      if [ -z "${pipeline_name}" ]; then
-          usage "'-p' needs to be supplied to specify the pipeline name for flying a 'dev' pipeline."
+      if [ -z "${postfix}" ]; then
+          usage "'-p' needs to be supplied to specify the pipeline name postfix for flying a 'dev' pipeline."
       fi
-      pipeline_name="DEV:${pipeline_name}"
+      if [ -z "${branch}" ]; then
+          usage "'-b' needs to be supplied to specify the branch for flying a 'dev' pipeline."
+      fi
+      pipeline_type="dev"
       config_file="dev.yml"
     ;;
-  release)
+  release|rel)
       # Default branch is 'gpdb' as it is our main branch
       if [ -z "${branch}" ]; then
           branch="gpdb"
       fi
-      if [ -z "${pipeline_name}" ]; then
-          pipeline_name="RELEASE:diskquota:${branch}"
-      fi
+      pipeline_type="rel"
       config_file="release.yml"
-      hook_res="diskquota_commit"
+      hook_res="${proj_name}_commit"
     ;;
   *)
       usage ""
     ;;
 esac
 
-yml_path="/tmp/diskquota_pipeline.yml"
+yml_path="/tmp/${proj_name}.yml"
 my_path=$(realpath "${BASH_SOURCE[0]}")
 ytt_base=$(dirname "${my_path}")/pipeline
+# pipeline cannot contain '/'
+pipeline_name=${pipeline_name/\//"_"}
+
+# Generate pipeline name
+if [ -n "${test_suffix}" ]; then
+    pipeline_type="${pipeline_type}_test"
+fi
+pipeline_name="${pipeline_type}.${proj_name}"
+if [ -n "${branch}" ]; then
+    pipeline_name="${pipeline_name}.${branch}"
+fi
+if [ -n "${postfix}" ]; then
+    pipeline_name="${pipeline_name}.${postfix}"
+fi
+# pipeline cannot contain '/'
+pipeline_name=${pipeline_name/\//"_"}
 
 ytt --data-values-file "${ytt_base}/res_def.yml" \
     -f "${ytt_base}/base.lib.yml" \
@@ -108,7 +128,7 @@ set -v
     sp \
     -p "${pipeline_name}" \
     -c "${yml_path}" \
-    -v "diskquota-branch=${branch}"
+    -v "${proj_name}-branch=${branch}"
 set +v
 
 if [ "${pipeline_config}" == "dev" ]; then


### PR DESCRIPTION
Concourse is deprecating some special characters in the pipeline name.
See details at https://concourse-ci.org/config-basics.html#schema.identifier

The pipelines will be named as:
<rel|pr|merge|dev>[_test].<project_name>[branch_name][.user_defined_postfix]

- Pipeline type 'release' is renamed to 'rel'
- Pipeline type 'commit' is renamed to 'merge'
- '_test' suffix will be added to pipeline type for pipeline debugging
- Instead of setting the whole name of pipeline, user can only set the
  postfix.

Patch from https://github.com/pivotal/ip4r/pull/2
