### PR TITLE
Fix creating artifact

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ add_custom_target(create_artifact
   COMMAND
   ${CMAKE_COMMAND} --build . --target package
   COMMAND
-  ${CMAKE_COMMAND} -E tar cvf ${artifact_NAME} "${tgz_NAME}.tar.gz")
+  ${CMAKE_COMMAND} -E tar czvf ${artifact_NAME} "${tgz_NAME}.tar.gz")
 # packing end
 
 # Create build-info


### PR DESCRIPTION
The artifact was tared without "c", which is a tar only but not gzipped.
untar it with "xzvf" will report error:

"
tar  xzvf diskquota_rhel7_gpdb6.tar.gz

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
"
