### PR TITLE
Fix the test failure on release pipeline

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -1364,7 +1364,7 @@ worker_get_epoch(Oid dbid)
 	if (!found)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-		                errmsg("[diskquota] worker not found for database \"%s\"", get_db_name(dbid))));
+		                errmsg("[diskquota] worker not found for database \"%s\"", get_database_name(dbid))));
 	}
 	return epoch;
 }

--- a/diskquota.c
+++ b/diskquota.c
@@ -1363,7 +1363,7 @@ worker_get_epoch(Oid dbid)
 	LWLockRelease(diskquota_locks.monitored_dbid_cache_lock);
 	if (!found)
 	{
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] worker not found for database \"%s\"", get_database_name(dbid))));
 	}
 	return epoch;

--- a/diskquota.c
+++ b/diskquota.c
@@ -640,14 +640,51 @@ disk_quota_launcher_main(Datum main_arg)
 	/* main loop: do this until the SIGTERM handler tells us to terminate. */
 	ereport(LOG, (errmsg("[diskquota launcher] start main loop")));
 	curDB = NULL;
-
 	while (!got_sigterm)
 	{
-		int  rc;
+		int rc;
+		CHECK_FOR_INTERRUPTS();
+
+		/*
+		 * modify wait time
+		 */
+		long secs;
+		int  microsecs;
+		TimestampDifference(GetCurrentTimestamp(),
+		                    TimestampTzPlusMilliseconds(loop_start_time, diskquota_naptime * 1000L), &secs, &microsecs);
+		nap.tv_sec  = secs;
+		nap.tv_usec = microsecs;
+
+		if (curDB == DiskquotaLauncherShmem->dbArrayTail)
+		{
+			/* Have sleep enough time, should start another loop */
+			if (nap.tv_sec == 0 && nap.tv_usec == 0)
+			{
+				loop_start_time = GetCurrentTimestamp();
+				/* set the curDB pointing to the head of the db list */
+				curDB = NULL;
+			}
+			/* do nothing, just to sleep untill the nap time is 0 */
+			else
+			{
+				continue;
+			}
+		}
+
+		/* If there are no enough workers to run db, we can firstly sleep to wait workers */
+		if (nap.tv_sec == 0 && nap.tv_usec == 0)
+		{
+			nap.tv_sec  = diskquota_naptime > 0 ? diskquota_naptime : 1;
+			nap.tv_usec = 0;
+		}
+
+		while (curDB != DiskquotaLauncherShmem->dbArrayTail && CanLaunchWorker())
+		{
+			start_worker();
+		}
+
 		bool sigusr1 = false;
 		bool sigusr2 = false;
-
-		CHECK_FOR_INTERRUPTS();
 
 		/*
 		 * background workers mustn't call usleep() or any direct equivalent:
@@ -700,44 +737,6 @@ disk_quota_launcher_main(Datum main_arg)
 		{
 			got_sigusr1 = false;
 			sigusr1     = true;
-		}
-
-		/*
-		 * modify wait time
-		 */
-		long secs;
-		int  microsecs;
-		TimestampDifference(GetCurrentTimestamp(),
-		                    TimestampTzPlusMilliseconds(loop_start_time, diskquota_naptime * 1000L), &secs, &microsecs);
-		nap.tv_sec  = secs;
-		nap.tv_usec = microsecs;
-
-		if (curDB == DiskquotaLauncherShmem->dbArrayTail)
-		{
-			/* Have sleep enough time, should start another loop */
-			if (nap.tv_sec == 0 && nap.tv_usec == 0)
-			{
-				loop_start_time = GetCurrentTimestamp();
-				/* set the curDB pointing to the head of the db list */
-				curDB = NULL;
-			}
-			/* do nothing, just to sleep untill the nap time is 0 */
-			else
-			{
-				continue;
-			}
-		}
-
-		/* If there are no enough workers to run db, we can firstly sleep to wait workers */
-		if (nap.tv_sec == 0 && nap.tv_usec == 0)
-		{
-			nap.tv_sec  = diskquota_naptime > 0 ? diskquota_naptime : 1;
-			nap.tv_usec = 0;
-		}
-
-		while (curDB != DiskquotaLauncherShmem->dbArrayTail && CanLaunchWorker())
-		{
-			start_worker();
 		}
 
 		loop_begin = loop_end;

--- a/diskquota.c
+++ b/diskquota.c
@@ -1364,7 +1364,7 @@ worker_get_epoch(Oid dbid)
 	if (!found)
 	{
 		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR),
-		                errmsg("[diskquota] worker not found for database \"%s\"", get_database_name(dbid))));
+		                  errmsg("[diskquota] worker not found for database \"%s\"", get_database_name(dbid))));
 	}
 	return epoch;
 }

--- a/tests/init_file
+++ b/tests/init_file
@@ -5,6 +5,7 @@
 -- start_matchignore
 # This pattern is extracted from gpdb/src/test/regress/init_file
 m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
+m/WARNING:  \[diskquota\] worker not found for database.*/
 -- end_matchignore
 
 -- start_matchsubs
@@ -35,4 +36,5 @@ s/ERROR:  tablespace: \d+, schema: \d+ diskquota exceeded.*/[hardlimit] tablespa
 
 m/^ERROR:  Can not set disk quota for system owner:.*/
 s/^ERROR:  Can not set disk quota for system owner:.*/ERROR:  Can not set disk quota from system owner:/
+
 -- end_matchsubs

--- a/tests/regress/expected/test_extension.out
+++ b/tests/regress/expected/test_extension.out
@@ -59,7 +59,7 @@ show diskquota.max_workers;
  20
 (1 row)
 
-\! sleep 0.5; ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+\! sleep 1.5; ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 2
 -- FIXME: We need to sleep for a while each time after CREATE EXTENSION and
 -- DROP EXTENSION to wait for the bgworker to start or to exit.

--- a/tests/regress/sql/test_extension.sql
+++ b/tests/regress/sql/test_extension.sql
@@ -20,7 +20,7 @@ CREATE DATABASE dbx10 ;
 show max_worker_processes;
 show diskquota.max_workers;
 
-\! sleep 0.5; ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
+\! sleep 1.5; ps -ef | grep postgres | grep "\[diskquota]" | grep -v grep | wc -l
 
 -- FIXME: We need to sleep for a while each time after CREATE EXTENSION and
 -- DROP EXTENSION to wait for the bgworker to start or to exit.


### PR DESCRIPTION
Fix test failure on release pipeline
Regress tests failed on the release
pipeline due to the diskquota.naptime
is not 0. As diskquota launcher
first sleeps, then starts diskquota
workers. When naptime is not 0, workers
are started very late, then some tests
which checking them failed.

In this pr, fix the test by starting
diskquota workers in the launcher before
it sleeps. This makes diskquota workers
will be started immediately when the launcher
starts.

Also, increased the sleep time in
the tests.

Using get_database_name instead
of get_db_name, as worker_get_epoch
is called in a transaction.