### PR TITLE
Support at least 20000 tables for each database

### DIFF
--- a/quotamodel.c
+++ b/quotamodel.c
@@ -475,8 +475,13 @@ DiskQuotaShmemSize(void)
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid)));
 	size = add_size(size, hash_estimate_size(MAX_NUM_MONITORED_DB,
 	                                         sizeof(struct MonitorDBEntryStruct))); // monitored_dbid_cache
-	size = add_size(size, diskquota_launcher_shmem_size());
-	size = add_size(size, diskquota_worker_shmem_size() * MAX_NUM_MONITORED_DB);
+
+	if (IS_QUERY_DISPATCHER())
+	{
+		size = add_size(size, diskquota_launcher_shmem_size());
+		size = add_size(size, diskquota_worker_shmem_size() * MAX_NUM_MONITORED_DB);
+	}
+
 	return size;
 }
 

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -2124,7 +2124,7 @@ get_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag)
 static void
 reset_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag)
 {
-	entry->flag &= -((uint32)flag);
+	entry->flag &= (UINT32_MAX ^ flag);
 }
 
 static void

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -44,7 +44,10 @@
 
 /* cluster level max size of rejectmap */
 #define MAX_DISK_QUOTA_REJECT_ENTRIES (1024 * 1024)
-#define MAX_TABLES (20 * 1024)
+/* init size of table_size_map */
+#define INIT_TABLES (20 * 1024)
+/* max size of table_size_map */
+#define MAX_TABLES (1024 * 1024)
 /* cluster level init size of rejectmap */
 #define INIT_DISK_QUOTA_REJECT_ENTRIES 8192
 /* per database level max size of rejectmap */
@@ -494,7 +497,7 @@ init_disk_quota_model(uint32 id)
 	hash_ctl.hash      = tag_hash;
 
 	format_name("TableSizeEntrymap", id, &str);
-	table_size_map = ShmemInitHash(str.data, MAX_TABLES, MAX_TABLES, &hash_ctl, HASH_ELEM | HASH_FUNCTION);
+	table_size_map = ShmemInitHash(str.data, INIT_TABLES, MAX_TABLES, &hash_ctl, HASH_ELEM | HASH_FUNCTION);
 
 	/* for localrejectmap */
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
@@ -552,7 +555,7 @@ vacuum_disk_quota_model(uint32 id)
 	hash_ctl.hash      = tag_hash;
 
 	format_name("TableSizeEntrymap", id, &str);
-	table_size_map = ShmemInitHash(str.data, MAX_TABLES, MAX_TABLES, &hash_ctl, HASH_ELEM | HASH_FUNCTION);
+	table_size_map = ShmemInitHash(str.data, INIT_TABLES, MAX_TABLES, &hash_ctl, HASH_ELEM | HASH_FUNCTION);
 	hash_seq_init(&iter, table_size_map);
 	while ((tsentry = hash_seq_search(&iter)) != NULL)
 	{


### PR DESCRIPTION
Currently, diskquota supports max to 8000 tables, including partition tables. It may cause unexpected results if there are too many tables in the customer cluster.

This PR change `init_size` of table_size_map to 20000, instead of MAX_TABLES, so that we can
economize the actual usage of SHM. To handle scenarios with a large number of tables,
we set `max_size` to MAX_TABLES (1000000).

To avoid memory waste, only the master should be allocated shared memory for diskquota_launcher and diskquota_worker.