### PR TITLE
Fix bug: relation_cache cannot isolate table info for each database

### DIFF
--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -791,6 +791,9 @@ get_active_tables_oid(void)
 		RelFileNode rnode;
 		Oid         prelid;
 
+		/* The session of db1 should not see the table inside db2. */
+		if (active_table_file_entry->dbid != MyDatabaseId) continue;
+
 		rnode.dbNode  = active_table_file_entry->dbid;
 		rnode.relNode = active_table_file_entry->relfilenode;
 		rnode.spcNode = active_table_file_entry->tablespaceoid;

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -793,7 +793,8 @@ merge_uncommitted_table_to_oidlist(List *oidlist)
 	hash_seq_init(&iter, relation_cache);
 	while ((entry = hash_seq_search(&iter)) != NULL)
 	{
-		if (entry->primary_table_relid == entry->relid)
+		/* The session of db1 should not see the table inside db2. */
+		if (entry->primary_table_relid == entry->relid && entry->rnode.node.dbNode == MyDatabaseId)
 		{
 			oidlist = lappend_oid(oidlist, entry->relid);
 		}
@@ -1857,7 +1858,8 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 			bool                         found;
 			LWLockAcquire(diskquota_locks.relation_cache_lock, LW_SHARED);
 			relation_cache_entry = hash_search(relation_cache, &active_oid, HASH_FIND, &found);
-			if (found && relation_cache_entry)
+			/* The session of db1 should not see the table inside db2. */
+			if (found && relation_cache_entry && relation_cache_entry->rnode.node.dbNode == MyDatabaseId)
 			{
 				Oid            relnamespace  = relation_cache_entry->namespaceoid;
 				Oid            reltablespace = relation_cache_entry->rnode.node.spcNode;

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -284,6 +284,8 @@ remove_committed_relation_from_cache(void)
 	hash_seq_init(&iter, relation_cache);
 	while ((entry = hash_seq_search(&iter)) != NULL)
 	{
+		/* The session of db1 should not see the table inside db2. */
+		if (entry->rnode.node.dbNode != MyDatabaseId) continue;
 		local_entry = hash_search(local_relation_cache, &entry->relid, HASH_ENTER, NULL);
 		memcpy(local_entry, entry, sizeof(DiskQuotaRelationCacheEntry));
 	}
@@ -360,6 +362,8 @@ show_relation_cache(PG_FUNCTION_ARGS)
 		hash_seq_init(&hash_seq, relation_cache);
 		while ((entry = (DiskQuotaRelationCacheEntry *)hash_seq_search(&hash_seq)) != NULL)
 		{
+			/* The session of db1 should not see the table inside db2. */
+			if (entry->rnode.node.dbNode != MyDatabaseId) continue;
 			DiskQuotaRelationCacheEntry *local_entry =
 			        hash_search(relation_cache_ctx->relation_cache, &entry->relid, HASH_ENTER_NULL, NULL);
 			if (local_entry)

--- a/tests/isolation2/expected/test_relation_cache.out
+++ b/tests/isolation2/expected/test_relation_cache.out
@@ -1,0 +1,50 @@
+CREATE DATABASE tempdb1;
+CREATE
+CREATE DATABASE tempdb2;
+CREATE
+
+-- perpare extension
+1:@db_name tempdb1: CREATE EXTENSION diskquota;
+CREATE
+1:@db_name tempdb1: SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t                         
+(1 row)
+2:@db_name tempdb2: CREATE EXTENSION diskquota;
+CREATE
+2:@db_name tempdb2: SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t                         
+(1 row)
+
+-- create a table in tempdb1
+1:@db_name tempdb1: BEGIN;
+BEGIN
+1:@db_name tempdb1: CREATE TABLE t(i int);
+CREATE
+1:@db_name tempdb1: INSERT INTO t select generate_series(1, 10000);
+INSERT 10000
+
+-- query relation_cache in tempdb2
+2:@db_name tempdb2: SELECT count(*) from diskquota.show_relation_cache();
+ count 
+-------
+ 0     
+(1 row)
+
+1:@db_name tempdb1: ABORT;
+ABORT
+
+1:@db_name tempdb1: DROP EXTENSION diskquota;
+DROP
+2:@db_name tempdb2: DROP EXTENSION diskquota;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>
+
+DROP DATABASE tempdb1;
+DROP
+DROP DATABASE tempdb2;
+DROP

--- a/tests/isolation2/isolation2_schedule
+++ b/tests/isolation2/isolation2_schedule
@@ -8,5 +8,6 @@ test: test_truncate
 test: test_postmaster_restart
 test: test_worker_timeout
 test: test_per_segment_config
+test: test_relation_cache
 test: test_drop_extension
 test: reset_config

--- a/tests/isolation2/sql/test_relation_cache.sql
+++ b/tests/isolation2/sql/test_relation_cache.sql
@@ -1,0 +1,26 @@
+CREATE DATABASE tempdb1;
+CREATE DATABASE tempdb2;
+
+-- perpare extension
+1:@db_name tempdb1: CREATE EXTENSION diskquota;
+1:@db_name tempdb1: SELECT diskquota.wait_for_worker_new_epoch();
+2:@db_name tempdb2: CREATE EXTENSION diskquota;
+2:@db_name tempdb2: SELECT diskquota.wait_for_worker_new_epoch();
+
+-- create a table in tempdb1
+1:@db_name tempdb1: BEGIN;
+1:@db_name tempdb1: CREATE TABLE t(i int);
+1:@db_name tempdb1: INSERT INTO t select generate_series(1, 10000);
+
+-- query relation_cache in tempdb2
+2:@db_name tempdb2: SELECT count(*) from diskquota.show_relation_cache();
+
+1:@db_name tempdb1: ABORT;
+
+1:@db_name tempdb1: DROP EXTENSION diskquota;
+2:@db_name tempdb2: DROP EXTENSION diskquota;
+1q:
+2q:
+
+DROP DATABASE tempdb1;
+DROP DATABASE tempdb2;


### PR DESCRIPTION
Previously, users will see the information of tables in db2 when accessing db1 and executing `select diskquota.show_relation_cache()`.  Meanwhile, if db1's bgworker can see the table in db2, the performance will be influenced, because the table size in db2 will be calculated although it is not useful for db1 diskquota.

This PR has added a judgment to prevent this situation.