### PR TITLE
Fix test_rejectmap flaky test

### DIFF
--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1557,7 +1557,6 @@ quota_check_common(Oid reloid, RelFileNode *relfilenode)
 #ifdef FAULT_INJECTOR
 	if (SIMPLE_FAULT_INJECTOR("enable_check_quota_by_relfilenode") == FaultInjectorTypeSkip) enable_hardlimit = true;
 #endif
-	SIMPLE_FAULT_INJECTOR("check_rejectmap_by_relfilenode");
 	if (relfilenode && enable_hardlimit) return check_rejectmap_by_relfilenode(*relfilenode);
 
 	return true;

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1557,7 +1557,7 @@ quota_check_common(Oid reloid, RelFileNode *relfilenode)
 #ifdef FAULT_INJECTOR
 	if (SIMPLE_FAULT_INJECTOR("enable_check_quota_by_relfilenode") == FaultInjectorTypeSkip) enable_hardlimit = true;
 #endif
-
+	SIMPLE_FAULT_INJECTOR("check_rejectmap_by_relfilenode");
 	if (relfilenode && enable_hardlimit) return check_rejectmap_by_relfilenode(*relfilenode);
 
 	return true;

--- a/tests/isolation2/expected/test_rejectmap.out
+++ b/tests/isolation2/expected/test_rejectmap.out
@@ -33,6 +33,12 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
 -- Insert a small amount of data into blocked_t1. It will hang up at check_rejectmap_by_relfilenode().
 1&: INSERT INTO blocked_t1 SELECT generate_series(1, 10000);  <waiting ...>
 
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t1'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
@@ -72,6 +78,12 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
 -- Insert a small amount of data into blocked_t2. It will hang up at check_rejectmap_by_relfilenode().
 1&: INSERT INTO blocked_t2 SELECT generate_series(1, 10000);  <waiting ...>
 
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t2'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
@@ -110,6 +122,12 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
 
 -- Insert a small amount of data into blocked_t3. It will hang up at check_rejectmap_by_relfilenode().
 1&: INSERT INTO blocked_t3 SELECT generate_series(1, 10000);  <waiting ...>
+
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
 
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t3'::regclass, 'NAMESPACE'::text, false);
@@ -152,6 +170,12 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
 -- Insert a small amount of data into blocked_t4. It will hang up at check_rejectmap_by_relfilenode().
 1&: INSERT INTO blocked_t4 SELECT generate_series(1, 10000);  <waiting ...>
 
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t4_index'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
@@ -188,6 +212,13 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
  Success:                 
 (1 row)
 1&: INSERT INTO blocked_t5 SELECT generate_series(1, 10000);  <waiting ...>
+
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
 SELECT block_relation_on_seg0('blocked_t5'::regclass, 'NAMESPACE_TABLESPACE'::text, true);
  block_relation_on_seg0 
 ------------------------
@@ -218,7 +249,15 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
 --------------------------
  Success:                 
 (1 row)
+
 1&: INSERT INTO blocked_t6 SELECT generate_series(1, 10000);  <waiting ...>
+
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
 SELECT block_relation_on_seg0('blocked_t6'::regclass, 'ROLE_TABLESPACE'::text, true);
  block_relation_on_seg0 
 ------------------------

--- a/tests/isolation2/expected/test_rejectmap.out
+++ b/tests/isolation2/expected/test_rejectmap.out
@@ -23,14 +23,32 @@ CREATE TABLE blocked_t1(i int) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t1 SELECT generate_series(1, 100);
 INSERT 100
+-- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Insert a small amount of data into blocked_t1. It will hang up at check_rejectmap_by_relfilenode().
+1&: INSERT INTO blocked_t1 SELECT generate_series(1, 10000);  <waiting ...>
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t1'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-INSERT INTO blocked_t1 SELECT generate_series(1, 10000);
-ERROR:  schema's disk space quota exceeded with name: public  (seg0 127.0.0.1:6002 pid=92815)
+
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
+1<:  <... completed>
+ERROR:  schema's disk space quota exceeded with name: 2200  (seg0 127.0.0.1:6002 pid=2163)
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -44,14 +62,32 @@ CREATE TABLE blocked_t2(i text) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t2 SELECT generate_series(1, 100);
 INSERT 100
+-- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Insert a small amount of data into blocked_t2. It will hang up at check_rejectmap_by_relfilenode().
+1&: INSERT INTO blocked_t2 SELECT generate_series(1, 10000);  <waiting ...>
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t2'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-INSERT INTO blocked_t2 SELECT generate_series(1, 10000);
-ERROR:  schema's disk space quota exceeded with name: public  (seg0 127.0.0.1:6002 pid=92815)
+
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
+1<:  <... completed>
+ERROR:  schema's disk space quota exceeded with name: 2200  (seg0 127.0.0.1:6002 pid=2163)
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -65,15 +101,32 @@ CREATE TABLE blocked_t3(i int) WITH (appendonly=true) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t3 SELECT generate_series(1, 100);
 INSERT 100
+-- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Insert a small amount of data into blocked_t3. It will hang up at check_rejectmap_by_relfilenode().
+1&: INSERT INTO blocked_t3 SELECT generate_series(1, 10000);  <waiting ...>
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t3'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
--- Insert a small amount of data into blocked_t3. It will hang up at check_rejectmap_by_relfilenode().
-INSERT INTO blocked_t3 SELECT generate_series(1, 10000);
-ERROR:  schema's disk space quota exceeded with name: public  (seg0 127.0.0.1:6002 pid=92815)
+
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
+1<:  <... completed>
+ERROR:  schema's disk space quota exceeded with name: 2200  (seg0 127.0.0.1:6002 pid=2163)
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -89,15 +142,32 @@ CREATE INDEX blocked_t4_index ON blocked_t4(i);
 CREATE
 INSERT INTO blocked_t4 SELECT generate_series(1, 100);
 INSERT 100
+-- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Insert a small amount of data into blocked_t4. It will hang up at check_rejectmap_by_relfilenode().
+1&: INSERT INTO blocked_t4 SELECT generate_series(1, 10000);  <waiting ...>
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t4_index'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
--- Insert a small amount of data into blocked_t4. It will hang up at check_rejectmap_by_relfilenode().
-INSERT INTO blocked_t4 SELECT generate_series(1, 10000);
-ERROR:  schema's disk space quota exceeded with name: public  (seg0 127.0.0.1:6002 pid=92815)
+
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
+1<:  <... completed>
+ERROR:  schema's disk space quota exceeded with name: 2200  (seg0 127.0.0.1:6002 pid=2163)
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -111,14 +181,25 @@ CREATE TABLE blocked_t5(i int) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t5 SELECT generate_series(1, 100);
 INSERT 100
+-- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1&: INSERT INTO blocked_t5 SELECT generate_series(1, 10000);  <waiting ...>
 SELECT block_relation_on_seg0('blocked_t5'::regclass, 'NAMESPACE_TABLESPACE'::text, true);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-INSERT INTO blocked_t5 SELECT generate_series(1, 10000);
-ERROR:  tablespace: pg_default, schema: public diskquota exceeded  (seg0 127.0.0.1:6002 pid=92815)
-
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  tablespace: 1663, schema: 2200 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=2163)
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
  refresh_rejectmap 
@@ -131,14 +212,25 @@ CREATE TABLE blocked_t6(i int) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t6 SELECT generate_series(1, 100);
 INSERT 100
+-- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1&: INSERT INTO blocked_t6 SELECT generate_series(1, 10000);  <waiting ...>
 SELECT block_relation_on_seg0('blocked_t6'::regclass, 'ROLE_TABLESPACE'::text, true);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-INSERT INTO blocked_t6 SELECT generate_series(1, 10000);
-ERROR:  tablespace: pg_default, role: wxiaoran diskquota exceeded  (seg0 127.0.0.1:6002 pid=92815)
-
+SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ERROR:  tablespace: 1663, role: 10 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=2163)
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
  refresh_rejectmap 

--- a/tests/isolation2/expected/test_rejectmap.out
+++ b/tests/isolation2/expected/test_rejectmap.out
@@ -23,32 +23,14 @@ CREATE TABLE blocked_t1(i int) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t1 SELECT generate_series(1, 100);
 INSERT 100
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-
--- Insert a small amount of data into blocked_t1. It will hang up at check_rejectmap_by_relfilenode().
-1&: INSERT INTO blocked_t1 SELECT generate_series(1, 10000);  <waiting ...>
-
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t1'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-
--- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
-1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name: 2200  (seg0 127.0.0.1:6002 pid=2163)
+INSERT INTO blocked_t1 SELECT generate_series(1, 10000);
+ERROR:  schema's disk space quota exceeded with name: public  (seg0 127.0.0.1:6002 pid=92815)
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -62,32 +44,14 @@ CREATE TABLE blocked_t2(i text) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t2 SELECT generate_series(1, 100);
 INSERT 100
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-
--- Insert a small amount of data into blocked_t2. It will hang up at check_rejectmap_by_relfilenode().
-1&: INSERT INTO blocked_t2 SELECT generate_series(1, 10000);  <waiting ...>
-
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t2'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-
--- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
-1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name: 2200  (seg0 127.0.0.1:6002 pid=2163)
+INSERT INTO blocked_t2 SELECT generate_series(1, 10000);
+ERROR:  schema's disk space quota exceeded with name: public  (seg0 127.0.0.1:6002 pid=92815)
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -101,32 +65,15 @@ CREATE TABLE blocked_t3(i int) WITH (appendonly=true) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t3 SELECT generate_series(1, 100);
 INSERT 100
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-
--- Insert a small amount of data into blocked_t3. It will hang up at check_rejectmap_by_relfilenode().
-1&: INSERT INTO blocked_t3 SELECT generate_series(1, 10000);  <waiting ...>
-
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t3'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-
--- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
-1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name: 2200  (seg0 127.0.0.1:6002 pid=2163)
+-- Insert a small amount of data into blocked_t3. It will hang up at check_rejectmap_by_relfilenode().
+INSERT INTO blocked_t3 SELECT generate_series(1, 10000);
+ERROR:  schema's disk space quota exceeded with name: public  (seg0 127.0.0.1:6002 pid=92815)
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -142,32 +89,15 @@ CREATE INDEX blocked_t4_index ON blocked_t4(i);
 CREATE
 INSERT INTO blocked_t4 SELECT generate_series(1, 100);
 INSERT 100
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-
--- Insert a small amount of data into blocked_t4. It will hang up at check_rejectmap_by_relfilenode().
-1&: INSERT INTO blocked_t4 SELECT generate_series(1, 10000);  <waiting ...>
-
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t4_index'::regclass, 'NAMESPACE'::text, false);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-
--- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
-1<:  <... completed>
-ERROR:  schema's disk space quota exceeded with name: 2200  (seg0 127.0.0.1:6002 pid=2163)
+-- Insert a small amount of data into blocked_t4. It will hang up at check_rejectmap_by_relfilenode().
+INSERT INTO blocked_t4 SELECT generate_series(1, 10000);
+ERROR:  schema's disk space quota exceeded with name: public  (seg0 127.0.0.1:6002 pid=92815)
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
@@ -181,25 +111,14 @@ CREATE TABLE blocked_t5(i int) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t5 SELECT generate_series(1, 100);
 INSERT 100
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-1&: INSERT INTO blocked_t5 SELECT generate_series(1, 10000);  <waiting ...>
 SELECT block_relation_on_seg0('blocked_t5'::regclass, 'NAMESPACE_TABLESPACE'::text, true);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-1<:  <... completed>
-ERROR:  tablespace: 1663, schema: 2200 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=2163)
+INSERT INTO blocked_t5 SELECT generate_series(1, 10000);
+ERROR:  tablespace: pg_default, schema: public diskquota exceeded  (seg0 127.0.0.1:6002 pid=92815)
+
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
  refresh_rejectmap 
@@ -212,25 +131,14 @@ CREATE TABLE blocked_t6(i int) DISTRIBUTED BY (i);
 CREATE
 INSERT INTO blocked_t6 SELECT generate_series(1, 100);
 INSERT 100
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-1&: INSERT INTO blocked_t6 SELECT generate_series(1, 10000);  <waiting ...>
 SELECT block_relation_on_seg0('blocked_t6'::regclass, 'ROLE_TABLESPACE'::text, true);
  block_relation_on_seg0 
 ------------------------
                         
 (1 row)
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
- gp_inject_fault_infinite 
---------------------------
- Success:                 
-(1 row)
-1<:  <... completed>
-ERROR:  tablespace: 1663, role: 10 diskquota exceeded per segment quota  (seg0 127.0.0.1:6002 pid=2163)
+INSERT INTO blocked_t6 SELECT generate_series(1, 10000);
+ERROR:  tablespace: pg_default, role: wxiaoran diskquota exceeded  (seg0 127.0.0.1:6002 pid=92815)
+
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap( ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[]) FROM gp_dist_random('gp_id') WHERE gp_segment_id=0;
  refresh_rejectmap 

--- a/tests/isolation2/sql/test_rejectmap.sql
+++ b/tests/isolation2/sql/test_rejectmap.sql
@@ -79,6 +79,9 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
 -- Insert a small amount of data into blocked_t1. It will hang up at check_rejectmap_by_relfilenode().
 1&: INSERT INTO blocked_t1 SELECT generate_series(1, 10000);
 
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t1'::regclass, 'NAMESPACE'::text, false);
 
@@ -103,6 +106,9 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
 -- Insert a small amount of data into blocked_t2. It will hang up at check_rejectmap_by_relfilenode().
 1&: INSERT INTO blocked_t2 SELECT generate_series(1, 10000);
 
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t2'::regclass, 'NAMESPACE'::text, false);
 
@@ -126,6 +132,9 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
 
 -- Insert a small amount of data into blocked_t3. It will hang up at check_rejectmap_by_relfilenode().
 1&: INSERT INTO blocked_t3 SELECT generate_series(1, 10000);
+
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
 
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t3'::regclass, 'NAMESPACE'::text, false);
@@ -152,6 +161,9 @@ SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbi
 -- Insert a small amount of data into blocked_t4. It will hang up at check_rejectmap_by_relfilenode().
 1&: INSERT INTO blocked_t4 SELECT generate_series(1, 10000);
 
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t4_index'::regclass, 'NAMESPACE'::text, false);
 
@@ -173,6 +185,10 @@ INSERT INTO blocked_t5 SELECT generate_series(1, 100);
 SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content=0;
 1&: INSERT INTO blocked_t5 SELECT generate_series(1, 10000);
+
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+
 SELECT block_relation_on_seg0('blocked_t5'::regclass, 'NAMESPACE_TABLESPACE'::text, true);
 SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content=0;
@@ -188,7 +204,12 @@ INSERT INTO blocked_t6 SELECT generate_series(1, 100);
 -- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
 SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content=0;
+
 1&: INSERT INTO blocked_t6 SELECT generate_series(1, 10000);
+
+SELECT gp_wait_until_triggered_fault('check_rejectmap_by_relfilenode', 1, dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+
 SELECT block_relation_on_seg0('blocked_t6'::regclass, 'ROLE_TABLESPACE'::text, true);
 SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content=0;

--- a/tests/isolation2/sql/test_rejectmap.sql
+++ b/tests/isolation2/sql/test_rejectmap.sql
@@ -72,21 +72,9 @@ SELECT gp_inject_fault_infinite('enable_check_quota_by_relfilenode', 'skip', dbi
 -- 1. Test canceling the extending of an ordinary table.
 CREATE TABLE blocked_t1(i int) DISTRIBUTED BY (i);
 INSERT INTO blocked_t1 SELECT generate_series(1, 100);
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-
--- Insert a small amount of data into blocked_t1. It will hang up at check_rejectmap_by_relfilenode().
-1&: INSERT INTO blocked_t1 SELECT generate_series(1, 10000);
-
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t1'::regclass, 'NAMESPACE'::text, false);
-
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-
--- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
-1<:
+INSERT INTO blocked_t1 SELECT generate_series(1, 10000);
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap(
@@ -96,21 +84,9 @@ SELECT diskquota.refresh_rejectmap(
 -- 2. Test canceling the extending of a toast relation.
 CREATE TABLE blocked_t2(i text) DISTRIBUTED BY (i);
 INSERT INTO blocked_t2 SELECT generate_series(1, 100);
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-
--- Insert a small amount of data into blocked_t2. It will hang up at check_rejectmap_by_relfilenode().
-1&: INSERT INTO blocked_t2 SELECT generate_series(1, 10000);
-
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t2'::regclass, 'NAMESPACE'::text, false);
-
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-
--- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
-1<:
+INSERT INTO blocked_t2 SELECT generate_series(1, 10000);
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap(
@@ -120,21 +96,10 @@ SELECT diskquota.refresh_rejectmap(
 -- 3. Test canceling the extending of an appendonly relation.
 CREATE TABLE blocked_t3(i int) WITH (appendonly=true) DISTRIBUTED BY (i);
 INSERT INTO blocked_t3 SELECT generate_series(1, 100);
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-
--- Insert a small amount of data into blocked_t3. It will hang up at check_rejectmap_by_relfilenode().
-1&: INSERT INTO blocked_t3 SELECT generate_series(1, 10000);
-
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t3'::regclass, 'NAMESPACE'::text, false);
-
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-
--- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
-1<:
+-- Insert a small amount of data into blocked_t3. It will hang up at check_rejectmap_by_relfilenode().
+INSERT INTO blocked_t3 SELECT generate_series(1, 10000);
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap(
@@ -145,21 +110,10 @@ SELECT diskquota.refresh_rejectmap(
 CREATE TABLE blocked_t4(i int) DISTRIBUTED BY (i);
 CREATE INDEX blocked_t4_index ON blocked_t4(i);
 INSERT INTO blocked_t4 SELECT generate_series(1, 100);
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-
--- Insert a small amount of data into blocked_t4. It will hang up at check_rejectmap_by_relfilenode().
-1&: INSERT INTO blocked_t4 SELECT generate_series(1, 10000);
-
 -- Dispatch rejectmap to seg0.
 SELECT block_relation_on_seg0('blocked_t4_index'::regclass, 'NAMESPACE'::text, false);
-
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-
--- Session 1 will return and emit an error message saying that the quota limit is exceeded on seg0.
-1<:
+-- Insert a small amount of data into blocked_t4. It will hang up at check_rejectmap_by_relfilenode().
+INSERT INTO blocked_t4 SELECT generate_series(1, 10000);
 
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap(
@@ -169,14 +123,9 @@ SELECT diskquota.refresh_rejectmap(
 -- 5. Test error message for NAMESPACE_TABLESPACE_QUOTA when the quota limit is exceeded on segments.
 CREATE TABLE blocked_t5(i int) DISTRIBUTED BY (i);
 INSERT INTO blocked_t5 SELECT generate_series(1, 100);
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-1&: INSERT INTO blocked_t5 SELECT generate_series(1, 10000);
 SELECT block_relation_on_seg0('blocked_t5'::regclass, 'NAMESPACE_TABLESPACE'::text, true);
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-1<:
+INSERT INTO blocked_t5 SELECT generate_series(1, 10000);
+
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap(
   ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[])
@@ -185,14 +134,9 @@ SELECT diskquota.refresh_rejectmap(
 -- 6. Test error message for ROLE_TABLESPACE_QUOTA when the quota limit is exceeded on segments.
 CREATE TABLE blocked_t6(i int) DISTRIBUTED BY (i);
 INSERT INTO blocked_t6 SELECT generate_series(1, 100);
--- Inject 'suspension' to check_rejectmap_by_relfilenode on seg0.
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'suspend', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-1&: INSERT INTO blocked_t6 SELECT generate_series(1, 10000);
 SELECT block_relation_on_seg0('blocked_t6'::regclass, 'ROLE_TABLESPACE'::text, true);
-SELECT gp_inject_fault_infinite('check_rejectmap_by_relfilenode', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content=0;
-1<:
+INSERT INTO blocked_t6 SELECT generate_series(1, 10000);
+
 -- Clean up the rejectmap on seg0.
 SELECT diskquota.refresh_rejectmap(
   ARRAY[]::diskquota.rejectmap_entry[], ARRAY[]::oid[])


### PR DESCRIPTION
As the table has been created, its relid is a valid oid, then `check_rejectmap_by_reloid(reloid)` in `quota_check_common` will be executed and quota exceeded error will be reported with schema name or role name or tablespace name.

Why the test case can run successfully before, but sometimes fails? Because it adds the reject entry after starting inserting data into the table. If the inserting has hang up on `check_rejectmap_by_relfilenode` and then adding the reject entry, hardlimit will be triggered. Otherwise, softlimit will be triggered.