### PR TITLE
Fix multiple definitions error when linking diskquota.

### DIFF
--- a/diskquota.h
+++ b/diskquota.h
@@ -175,7 +175,7 @@ typedef struct
 	*/
 } DiskquotaLauncherShmemStruct;
 
-DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
+extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
 
 /* In shmem, only used on master */
 struct DiskquotaDBEntry


### PR DESCRIPTION
When building diskquota, my linker complains that there're multiple definitions of `DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem`. This patch helps resolve it.

```
/usr/bin/ld: CMakeFiles/diskquota.dir/diskquota_utility.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: multiple definition of `DiskquotaLaunche
rShmem'; CMakeFiles/diskquota.dir/diskquota.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: first defined here
/usr/bin/ld: CMakeFiles/diskquota.dir/enforcement.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: multiple definition of `DiskquotaLauncherShmem
'; CMakeFiles/diskquota.dir/diskquota.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: first defined here
/usr/bin/ld: CMakeFiles/diskquota.dir/gp_activetable.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: multiple definition of `DiskquotaLauncherSh
mem'; CMakeFiles/diskquota.dir/diskquota.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: first defined here
/usr/bin/ld: CMakeFiles/diskquota.dir/quotamodel.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: multiple definition of `DiskquotaLauncherShmem'
; CMakeFiles/diskquota.dir/diskquota.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: first defined here
/usr/bin/ld: CMakeFiles/diskquota.dir/relation_cache.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: multiple definition of `DiskquotaLauncherSh
mem'; CMakeFiles/diskquota.dir/diskquota.c.o:/home/v/x/gh/diskquota-zh/diskquota.h:178: first defined here
collect2: error: ld returned 1 exit status
```

Seems that this is caused by my comment: https://github.com/greenplum-db/diskquota/pull/245#discussion_r1014996960

My bad ...