### PR TITLE
Filter the useless relation type.

### DIFF
--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -485,7 +485,7 @@ is_database_empty(void)
 	        "  pg_class AS c, "
 	        "  pg_namespace AS n "
 	        "WHERE c.oid > 16384 and relnamespace = n.oid and nspname != 'diskquota'"
-	        " and (c.relstorage = 'h' or c.relstorage = 'a' or c.relstorage = 'c')",
+	        " and (relfilenode > 0)",
 	        true, 0);
 	if (ret != SPI_OK_SELECT)
 		elog(ERROR, "cannot select pg_class and pg_namespace table, reason: %s.", strerror(errno));

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -484,8 +484,8 @@ is_database_empty(void)
 	        "FROM "
 	        "  pg_class AS c, "
 	        "  pg_namespace AS n "
-	        /* Fileter relkind c = composite type */
-	        "WHERE c.oid > 16384 and relnamespace = n.oid and nspname != 'diskquota' and relkind != 'c'",
+	        "WHERE c.oid > 16384 and relnamespace = n.oid and nspname != 'diskquota'"
+	        " and (c.relstorage = 'h' or c.relstorage = 'a' or c.relstorage = 'c')",
 	        true, 0);
 	if (ret != SPI_OK_SELECT)
 		elog(ERROR, "cannot select pg_class and pg_namespace table, reason: %s.", strerror(errno));

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -485,7 +485,7 @@ is_database_empty(void)
 	        "  pg_class AS c, "
 	        "  pg_namespace AS n "
 	        "WHERE c.oid > 16384 and relnamespace = n.oid and nspname != 'diskquota'"
-	        " and (relfilenode > 0)",
+	        " and relkind not in ('v', 'c', 'f')",
 	        true, 0);
 	if (ret != SPI_OK_SELECT)
 		elog(ERROR, "cannot select pg_class and pg_namespace table, reason: %s.", strerror(errno));

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -242,9 +242,8 @@ report_altered_reloid(Oid reloid)
 static void
 report_relation_cache_helper(Oid relid)
 {
-	bool              found;
-	Relation          rel;
-	FormData_pg_class relclass;
+	bool     found;
+	Relation rel;
 
 	/* We do not collect the active table in mirror segments  */
 	if (IsRoleMirror())
@@ -265,11 +264,9 @@ report_relation_cache_helper(Oid relid)
 		return;
 	}
 
-	rel      = diskquota_relation_open(relid, NoLock);
-	relclass = rel->rd_rel;
+	rel = diskquota_relation_open(relid, NoLock);
+	if (rel->rd_rel->relfilenode > 0) update_relation_cache(relid);
 	relation_close(rel, NoLock);
-	/* TODO: filter system catalog table */
-	if (relclass->relfilenode > 0) update_relation_cache(relid);
 }
 
 /*

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -242,7 +242,9 @@ report_altered_reloid(Oid reloid)
 static void
 report_relation_cache_helper(Oid relid)
 {
-	bool found;
+	bool     found;
+	Relation rel;
+	char     relstorage; /* see RELSTORAGE_xxx constants below */
 
 	/* We do not collect the active table in mirror segments  */
 	if (IsRoleMirror())
@@ -263,7 +265,11 @@ report_relation_cache_helper(Oid relid)
 		return;
 	}
 
-	update_relation_cache(relid);
+	rel        = diskquota_relation_open(relid, NoLock);
+	relstorage = rel->rd_rel->relstorage;
+	relation_close(rel, NoLock);
+	if (relstorage == RELSTORAGE_HEAP || relstorage == RELSTORAGE_AOCOLS || relstorage == RELSTORAGE_AOROWS)
+		update_relation_cache(relid);
 }
 
 /*

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -265,7 +265,9 @@ report_relation_cache_helper(Oid relid)
 	}
 
 	rel = diskquota_relation_open(relid, NoLock);
-	if (rel->rd_rel->relfilenode > 0) update_relation_cache(relid);
+	if (rel->rd_rel->relkind != RELKIND_FOREIGN_TABLE || rel->rd_rel->relkind != RELKIND_COMPOSITE_TYPE ||
+	    rel->rd_rel->relkind != RELKIND_VIEW)
+		update_relation_cache(relid);
 	relation_close(rel, NoLock);
 }
 

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -242,9 +242,9 @@ report_altered_reloid(Oid reloid)
 static void
 report_relation_cache_helper(Oid relid)
 {
-	bool     found;
-	Relation rel;
-	char     relstorage; /* see RELSTORAGE_xxx constants below */
+	bool              found;
+	Relation          rel;
+	FormData_pg_class relclass;
 
 	/* We do not collect the active table in mirror segments  */
 	if (IsRoleMirror())
@@ -265,11 +265,11 @@ report_relation_cache_helper(Oid relid)
 		return;
 	}
 
-	rel        = diskquota_relation_open(relid, NoLock);
-	relstorage = rel->rd_rel->relstorage;
+	rel      = diskquota_relation_open(relid, NoLock);
+	relclass = rel->rd_rel;
 	relation_close(rel, NoLock);
-	if (relstorage == RELSTORAGE_HEAP || relstorage == RELSTORAGE_AOCOLS || relstorage == RELSTORAGE_AOROWS)
-		update_relation_cache(relid);
+	/* TODO: filter system catalog table */
+	if (relclass->relfilenode > 0) update_relation_cache(relid);
 }
 
 /*

--- a/tests/regress/expected/test_init_table_size_table.out
+++ b/tests/regress/expected/test_init_table_size_table.out
@@ -65,35 +65,7 @@ ORDER BY tableid;
  aocs_idx  |   524288 |    -1
 (8 rows)
 
--- diskquota.table_size should not change after creating a new type
-CREATE TYPE test_type AS (
-        "dbid" oid,
-        "datname" text
-);
-SELECT diskquota.init_table_size_table();
- init_table_size_table 
------------------------
- 
-(1 row)
-
-SELECT tableid::regclass, size, segid
-FROM diskquota.table_size 
-WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
-ORDER BY tableid;
-  tableid  |   size   | segid 
------------+----------+-------
- t         |  3932160 |    -1
- idx       |  2490368 |    -1
- toast     |   393216 |    -1
- toast_idx |   327680 |    -1
- ao        |  1591464 |    -1
- ao_idx    |  2490368 |    -1
- aocs      | 10813592 |    -1
- aocs_idx  |   524288 |    -1
-(8 rows)
-
 DROP TABLE t;
 DROP TABLE toast;
 DROP TABLE ao;
 DROP TABLE aocs;
-DROP TYPE test_type;

--- a/tests/regress/expected/test_init_table_size_table.out
+++ b/tests/regress/expected/test_init_table_size_table.out
@@ -65,7 +65,35 @@ ORDER BY tableid;
  aocs_idx  |   524288 |    -1
 (8 rows)
 
+-- diskquota.table_size should not change after creating a new type
+CREATE TYPE test_type AS (
+        "dbid" oid,
+        "datname" text
+);
+SELECT diskquota.init_table_size_table();
+ init_table_size_table 
+-----------------------
+ 
+(1 row)
+
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size 
+WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
+ORDER BY tableid;
+  tableid  |   size   | segid 
+-----------+----------+-------
+ t         |  3932160 |    -1
+ idx       |  2490368 |    -1
+ toast     |   393216 |    -1
+ toast_idx |   327680 |    -1
+ ao        |  1591464 |    -1
+ ao_idx    |  2490368 |    -1
+ aocs      | 10813592 |    -1
+ aocs_idx  |   524288 |    -1
+(8 rows)
+
 DROP TABLE t;
 DROP TABLE toast;
 DROP TABLE ao;
 DROP TABLE aocs;
+DROP TYPE test_type;

--- a/tests/regress/expected/test_relkind.out
+++ b/tests/regress/expected/test_relkind.out
@@ -1,0 +1,42 @@
+CREATE DATABASE test_relkind;
+\c test_relkind
+CREATE TYPE test_type AS (
+        "dbid" oid,
+        "datname" text
+);
+CREATE VIEW v AS select * from pg_class;
+CREATE EXTENSION diskquota;
+CREATE table test(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT diskquota.init_table_size_table();
+ init_table_size_table 
+-----------------------
+ 
+(1 row)
+
+-- diskquota.table_size should not change after creating a new type
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size 
+WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
+ORDER BY tableid;
+ tableid | size | segid 
+---------+------+-------
+ test    |    0 |    -1
+(1 row)
+
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+DROP EXTENSION diskquota;
+\c contrib_regression
+DROP DATABASE test_relkind;

--- a/tests/regress/sql/test_init_table_size_table.sql
+++ b/tests/regress/sql/test_init_table_size_table.sql
@@ -43,7 +43,20 @@ FROM diskquota.table_size
 WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
 ORDER BY tableid;
 
+
+-- diskquota.table_size should not change after creating a new type
+CREATE TYPE test_type AS (
+        "dbid" oid,
+        "datname" text
+);
+SELECT diskquota.init_table_size_table();
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size 
+WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
+ORDER BY tableid;
+
 DROP TABLE t;
 DROP TABLE toast;
 DROP TABLE ao;
 DROP TABLE aocs;
+DROP TYPE test_type;

--- a/tests/regress/sql/test_init_table_size_table.sql
+++ b/tests/regress/sql/test_init_table_size_table.sql
@@ -44,19 +44,7 @@ WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
 ORDER BY tableid;
 
 
--- diskquota.table_size should not change after creating a new type
-CREATE TYPE test_type AS (
-        "dbid" oid,
-        "datname" text
-);
-SELECT diskquota.init_table_size_table();
-SELECT tableid::regclass, size, segid
-FROM diskquota.table_size 
-WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
-ORDER BY tableid;
-
 DROP TABLE t;
 DROP TABLE toast;
 DROP TABLE ao;
 DROP TABLE aocs;
-DROP TYPE test_type;

--- a/tests/regress/sql/test_relkind.sql
+++ b/tests/regress/sql/test_relkind.sql
@@ -1,0 +1,21 @@
+CREATE DATABASE test_relkind;
+\c test_relkind
+CREATE TYPE test_type AS (
+        "dbid" oid,
+        "datname" text
+);
+CREATE VIEW v AS select * from pg_class;
+CREATE EXTENSION diskquota;
+CREATE table test(a int);
+SELECT diskquota.init_table_size_table();
+-- diskquota.table_size should not change after creating a new type
+SELECT tableid::regclass, size, segid
+FROM diskquota.table_size 
+WHERE segid = -1 AND tableid::regclass::name NOT LIKE '%.%'
+ORDER BY tableid;
+
+SELECT diskquota.pause();
+SELECT diskquota.wait_for_worker_new_epoch();
+DROP EXTENSION diskquota;
+\c contrib_regression
+DROP DATABASE test_relkind;


### PR DESCRIPTION
Previously, if we create a type/view before `create extension diskquota`, it is necessary to call `diskquota.init_table_size_table()`, but the size of the type/view does not count for diskquota. This PR modifies the condition for pg_class selection and relation_cache to filter the useless relation type.