### PR TITLE
Fix flaky "database not found"

### DIFF
--- a/monitored_db.c
+++ b/monitored_db.c
@@ -226,7 +226,7 @@ worker_get_epoch(Oid dbid)
 	if (!found)
 	{
 		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR),
-		                  errmsg("[diskquota] database \"%s\" not found", get_database_name(dbid))));
+		                  errmsg("[diskquota] database \"%s\" not found for getting epoch", get_database_name(dbid))));
 	}
 	return epoch;
 }
@@ -294,7 +294,8 @@ update_monitordb_status(Oid dbid, uint32 status)
 		pg_atomic_write_u32(&(entry->status), status);
 	}
 	else
-		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] database %u not found", dbid)));
+		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR),
+		                  errmsg("[diskquota] database %u not found for updating monitor db", dbid)));
 	LWLockRelease(diskquota_locks.monitored_dbid_cache_lock);
 }
 

--- a/tests/init_file
+++ b/tests/init_file
@@ -6,6 +6,7 @@
 # This pattern is extracted from gpdb/src/test/regress/init_file
 m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
 m/WARNING:  \[diskquota\] worker not found for database.*/
+m/WARNING:  \[diskquota\] database .* not found for getting epoch .*/
 -- end_matchignore
 
 -- start_matchsubs


### PR DESCRIPTION
Flaky has been seen like:
```
test test_extension           ... FAILED (176.97 sec)  (diff:0.15 sec)

    ...

SELECT diskquota.wait_for_worker_new_epoch();
+WARNING:  [diskquota] database "contrib_regression" not found (monitored_db.c:229)
...
  wait_for_worker_new_epoch

 ---------------------------

  t
```
Since there is a 'gpstop -ra' at the top of the test, there is a chance
that when the following 'wait_for_worker_new_epoch()' runs, the luancher
has not been fully initialized yet. In this case, 'wait_for_worker_new_epoch()'
prints timeout warnings and retry, until it succeeds. Warning here is
not an issue, just ignore it.
