### PR TITLE
Change the max value of diskquota.max_workers to 20

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -595,7 +595,7 @@ disk_quota_launcher_main(Datum main_arg)
 			if (curDB != NULL)
 			{
 				curDBId = curDB->dbid;
-				elog(DEBUG1, "[diskquota] next db to run:%d", curDB->id);
+				elog(DEBUG1, "[diskquota] next db to run:%u", curDB->dbid);
 			}
 			else
 				elog(DEBUG1, "[diskquota] no db to run");

--- a/diskquota.c
+++ b/diskquota.c
@@ -595,7 +595,7 @@ disk_quota_launcher_main(Datum main_arg)
 			if (curDB != NULL)
 			{
 				curDBId = curDB->dbid;
-				elog(DEBUG1, "[diskquota] next db to run:%u", curDB->dbid);
+				elog(DEBUG1, "[diskquota] next db to run:%u", curDBId);
 			}
 			else
 				elog(DEBUG1, "[diskquota] no db to run");

--- a/diskquota.c
+++ b/diskquota.c
@@ -289,7 +289,7 @@ define_guc_variables(void)
 	DefineCustomIntVariable(
 	        "diskquota.max_workers",
 	        "Max number of backgroud workers to run diskquota extension, should be less than max_worker_processes.",
-	        NULL, &diskquota_max_workers, 10, 1, max_worker_processes, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+	        NULL, &diskquota_max_workers, 10, 1, 20, PGC_POSTMASTER, 0, NULL, NULL, NULL);
 }
 
 /* ---- Functions for disk quota worker process ---- */

--- a/tests/regress/expected/test_worker_schedule.out
+++ b/tests/regress/expected/test_worker_schedule.out
@@ -131,9 +131,22 @@ SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 
  f3      | 98304 |    -1
 (1 row)
 
+\c t4
+CREATE EXTENSION diskquota;
+\c t5
+CREATE EXTENSION diskquota;
+\c t6
+CREATE EXTENSION diskquota;
+\c t7
+CREATE EXTENSION diskquota;
+\c t8
+CREATE EXTENSION diskquota;
 --start_ignore
-\! gpconfig -c diskquota.max_workers -v 11;
-20220727:14:23:23:025074 gpconfig:wxiaoran-a01:xiwang-[INFO]:-completed successfully with parameters '-c diskquota.max_workers -v 11'
+\! gpconfig -c diskquota.max_workers -v 7;
+20221118:19:46:57:088045 gpconfig:wxiaoran-a02:wxiaoran-[INFO]:-completed successfully with parameters '-c diskquota.max_workers -v 7'
+-- available workers is 6
+\! gpconfig -c max_worker_processes -v 10;
+20221118:19:46:59:088207 gpconfig:wxiaoran-a02:wxiaoran-[INFO]:-completed successfully with parameters '-c max_worker_processes -v 10'
 \! gpstop -arf;
 20220719:17:38:28:030945 gpstop:wxiaoran-a01:xiwang-[INFO]:-Starting gpstop with args: -arf
 20220719:17:38:28:030945 gpstop:wxiaoran-a01:xiwang-[INFO]:-Gathering information and validating the environment...
@@ -166,15 +179,7 @@ SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 
 20220719:17:38:36:030945 gpstop:wxiaoran-a01:xiwang-[INFO]:-Cleaning up leftover shared memory
 20220719:17:38:38:030945 gpstop:wxiaoran-a01:xiwang-[INFO]:-Restarting System...
 --end_ignore
-\c 
-SHOW diskquota.max_workers;
- diskquota.max_workers 
------------------------
- 11
-(1 row)
-
 \c t4
-CREATE EXTENSION diskquota;
 CREATE TABLE f4(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -192,7 +197,6 @@ SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 
 (1 row)
 
 \c t5
-CREATE EXTENSION diskquota;
 CREATE TABLE f5(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -210,7 +214,6 @@ SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 
 (1 row)
 
 \c t6
-CREATE EXTENSION diskquota;
 CREATE TABLE f6(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -228,7 +231,6 @@ SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 
 (1 row)
 
 \c t7
-CREATE EXTENSION diskquota;
 CREATE TABLE f7(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -246,7 +248,6 @@ SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 
 (1 row)
 
 \c t8
-CREATE EXTENSION diskquota;
 CREATE TABLE f8(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/tests/regress/sql/test_worker_schedule.sql
+++ b/tests/regress/sql/test_worker_schedule.sql
@@ -54,44 +54,48 @@ INSERT into f3 SELECT generate_series(0,1000);
 SELECT diskquota.wait_for_worker_new_epoch();
 SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'f3'::regclass and segid = -1;
 
+\c t4
+CREATE EXTENSION diskquota;
+\c t5
+CREATE EXTENSION diskquota;
+\c t6
+CREATE EXTENSION diskquota;
+\c t7
+CREATE EXTENSION diskquota;
+\c t8
+CREATE EXTENSION diskquota;
 --start_ignore
-\! gpconfig -c diskquota.max_workers -v 11;
+\! gpconfig -c diskquota.max_workers -v 7;
+-- available workers is 6
+\! gpconfig -c max_worker_processes -v 10;
 \! gpstop -arf;
 --end_ignore
 
-\c 
-SHOW diskquota.max_workers;
-
 \c t4
-CREATE EXTENSION diskquota;
 CREATE TABLE f4(a int);
 INSERT into f4 SELECT generate_series(0,1000);
 SELECT diskquota.wait_for_worker_new_epoch();
 SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'f4'::regclass and segid = -1;
 
 \c t5
-CREATE EXTENSION diskquota;
 CREATE TABLE f5(a int);
 INSERT into f5 SELECT generate_series(0,1000);
 SELECT diskquota.wait_for_worker_new_epoch();
 SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'f5'::regclass and segid = -1;
 
 \c t6
-CREATE EXTENSION diskquota;
 CREATE TABLE f6(a int);
 INSERT into f6 SELECT generate_series(0,1000);
 SELECT diskquota.wait_for_worker_new_epoch();
 SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'f6'::regclass and segid = -1;
 
 \c t7
-CREATE EXTENSION diskquota;
 CREATE TABLE f7(a int);
 INSERT into f7 SELECT generate_series(0,1000);
 SELECT diskquota.wait_for_worker_new_epoch();
 SELECT tableid::regclass, size, segid FROM diskquota.table_size WHERE tableid = 'f7'::regclass and segid = -1;
 
 \c t8
-CREATE EXTENSION diskquota;
 CREATE TABLE f8(a int);
 INSERT into f8 SELECT generate_series(0,1000);
 SELECT diskquota.wait_for_worker_new_epoch();
@@ -221,5 +225,6 @@ DROP DATABASE t11;
 DROP DATABASE t12;
 \! gpconfig -r diskquota.worker_timeout;
 \! gpconfig -r diskquota.max_workers;
+\! gpconfig -r max_worker_processes;
 \! gpstop -arf;
 --end_ignore


### PR DESCRIPTION
If we set the diskquota.max_workers max value to be max_worker_processes, when max_worker_processes is less than 10 and we set diskquota.max_workers value more than max_worker_processes, the cluster will crash.

Set the max value to 20, when the max_worker_processes is less than the diskquota.max_workers, diskquota can work, only some parts of the databases can not be monitored as diskquota can not start bgworkers for them.