### PR TITLE
Missing pause causes deadlock flaky

### DIFF
--- a/tests/isolation2/expected/test_relation_cache.out
+++ b/tests/isolation2/expected/test_relation_cache.out
@@ -37,8 +37,28 @@ INSERT 10000
 1:@db_name tempdb1: ABORT;
 ABORT
 
+1:@db_name tempdb1: SELECT diskquota.pause();
+ pause 
+-------
+       
+(1 row)
+1:@db_name tempdb1: SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t                         
+(1 row)
 1:@db_name tempdb1: DROP EXTENSION diskquota;
 DROP
+2:@db_name tempdb2: SELECT diskquota.pause();
+ pause 
+-------
+       
+(1 row)
+2:@db_name tempdb2: SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t                         
+(1 row)
 2:@db_name tempdb2: DROP EXTENSION diskquota;
 DROP
 1q: ... <quitting>

--- a/tests/isolation2/sql/test_relation_cache.sql
+++ b/tests/isolation2/sql/test_relation_cache.sql
@@ -17,7 +17,11 @@ CREATE DATABASE tempdb2;
 
 1:@db_name tempdb1: ABORT;
 
+1:@db_name tempdb1: SELECT diskquota.pause();
+1:@db_name tempdb1: SELECT diskquota.wait_for_worker_new_epoch();
 1:@db_name tempdb1: DROP EXTENSION diskquota;
+2:@db_name tempdb2: SELECT diskquota.pause();
+2:@db_name tempdb2: SELECT diskquota.wait_for_worker_new_epoch();
 2:@db_name tempdb2: DROP EXTENSION diskquota;
 1q:
 2q:


### PR DESCRIPTION
'Pause' needs to be called before the 'DROP EXTENSION'
