### PR TITLE
Reduce memory usage.

### DIFF
--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -1133,8 +1133,7 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 				/* get the segid, tablesize for each table */
 				segId     = atoi(PQgetvalue(pgresult, j, 2));
 				key.segid = segId;
-
-				entry = (DiskQuotaActiveTableEntry *)hash_search(local_table_stats_map, &key, HASH_ENTER, &found);
+				entry     = (DiskQuotaActiveTableEntry *)hash_search(local_table_stats_map, &key, HASH_ENTER, &found);
 
 				if (!found)
 				{

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -88,7 +88,7 @@ int SEGCOUNT = 0;
  * local cache of table disk size and corresponding schema and owner.
  *
  * When id is 0, this TableSizeEntry stores the table size in the (-1 ~
- * SEGMENT_SIZE_ARRAY_LENGTH - 2)th segment, as so on.
+ * SEGMENT_SIZE_ARRAY_LENGTH - 2)th segment, and so on.
  * |---------|--------------------------------------------------------------------------|
  * |   id    |                                segment index                             |
  * |---------|--------------------------------------------------------------------------|


### PR DESCRIPTION
Refactor the structure of `TableSizeEntry` to reduce memory usage.

Previously, the size of each table in each segment should be maintained in `TableSizeEntry`, which wastes lots of memory. In this PR, we refactor the `TableSizeEntry` to:
```
struct TableSizeEntry
{
	Oid    reloid;
	int    segid;
	Oid    tablespaceoid;
	Oid    namespaceoid;
	Oid    owneroid;
	uint32 flag;
	int64 totalsize[SEGMENT_SIZE_ARRAY_LENGTH];
};
```

In this way, we can maintain multiple sizes in one `TableSizeEntry` and efficiently save memory usage.
- For 50 segments: reduced by 65%.
- For 100 segments: reduced by 82.5%.
- For 101 segments: reduced by 65.3%.
- For 1000 segments: reduced by 82.5%.