### PR TITLE
Change `diskquota.max_active_tables` default value to reduce memory cost

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -280,7 +280,7 @@ define_guc_variables(void)
 	                        2, min_naptime, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);
 
 	DefineCustomIntVariable("diskquota.max_active_tables", "Max number of active tables monitored by disk-quota.", NULL,
-	                        &diskquota_max_active_tables, 1 * 1024 * 1024, 1, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);
+	                        &diskquota_max_active_tables, 300 * 1024, 1, INT_MAX, PGC_POSTMASTER, 0, NULL, NULL, NULL);
 
 	DefineCustomIntVariable("diskquota.worker_timeout", "Duration between each check (in seconds).", NULL,
 	                        &diskquota_worker_timeout, 60, 1, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);

--- a/tests/isolation2/expected/config.out
+++ b/tests/isolation2/expected/config.out
@@ -21,7 +21,7 @@
 1: SHOW diskquota.max_active_tables;
  diskquota.max_active_tables 
 -----------------------------
- 1048576                     
+ 307200                      
 (1 row)
 1: SHOW diskquota.worker_timeout;
  diskquota.worker_timeout 

--- a/tests/regress/expected/config.out
+++ b/tests/regress/expected/config.out
@@ -11,7 +11,7 @@ SHOW diskquota.naptime;
 SHOW diskquota.max_active_tables;
  diskquota.max_active_tables 
 -----------------------------
- 1048576
+ 307200
 (1 row)
 
 SHOW diskquota.worker_timeout;


### PR DESCRIPTION
Change the default value of `diskquota.max_active_tables` from 1M to 300K, and the memory usage relevant is reduced from 300MB to 90MB.