### PR TITLE
Move llocal_disk_quota_reject_map from shared memory to local memory

### DIFF
--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1115,6 +1115,8 @@ flush_local_reject_map(void)
 	hash_seq_init(&iter, local_disk_quota_reject_map);
 	while ((localrejectentry = hash_seq_search(&iter)) != NULL)
 	{
+		/* Ethier the totalsize of table exceed the quota,or the tablesize on segment exceed the segment quota, the
+		 * isexceed is set to be true*/
 		if (localrejectentry->isexceeded)
 		{
 			rejectentry = (GlobalRejectMapEntry *)hash_search(disk_quota_reject_map, (void *)&localrejectentry->keyitem,
@@ -1136,7 +1138,6 @@ flush_local_reject_map(void)
 					rejectentry->keyitem.tablespaceoid = localrejectentry->keyitem.tablespaceoid;
 				}
 			}
-			rejectentry->segexceeded = localrejectentry->segexceeded;
 			rejectentry->segexceeded = localrejectentry->segexceeded;
 			(void)hash_search(local_disk_quota_reject_map, (void *)&localrejectentry->keyitem, HASH_REMOVE, NULL);
 		}


### PR DESCRIPTION
Move local_disk_quota_reject_map from shared memory to local memory
Before this change, local_disk_quota_reject_map is saved in shared memory. In each loop, (it saves all the reject entries of the last loop), diskquota marks the segexceeded and isexceeded of each item.  When flushing it to disk_quota_reject_map(global reject map), firstly flush all the exceeded ones, for unexceeded items, remove them in both map.
After moving it to local memory, in each flush, firstly remove all reject items of this database in disk_quota_reject_map, then flush all items in local_disk_quota_reject_map to it and clean up the local_disk_quota_reject_map .