### PR TITLE
Add cmake opt DISKQUOTA_DDL_CHANGE_CHECK

### DIFF
--- a/diskquota.c
+++ b/diskquota.c
@@ -649,7 +649,7 @@ disk_quota_launcher_main(Datum main_arg)
 
 		if (nap.tv_sec != 0 || nap.tv_usec != 0)
 		{
-			elog(DEBUG1, "[diskquota] naptime sec:%ld, usec:%d", nap.tv_sec, nap.tv_usec);
+			elog(DEBUG1, "[diskquota] naptime sec:%ld, usec:%ld", nap.tv_sec, nap.tv_usec);
 			rc = WaitLatch(&MyProc->procLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
 			               (nap.tv_sec * 1000L) + (nap.tv_usec / 1000L));
 			ResetLatch(&MyProc->procLatch);

--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -1,5 +1,10 @@
 include(${CMAKE_SOURCE_DIR}/cmake/Regress.cmake)
 
+if(NOT DEFINED DISKQUOTA_DDL_CHANGE_CHECK)
+  set(DISKQUOTA_DDL_CHANGE_CHECK ON CACHE
+    STRING "Skip the DDL updates check. Should not be disabled on CI" FORCE)
+endif()
+
 regresstarget_add(
   upgradecheck
   INIT_FILE
@@ -44,7 +49,7 @@ foreach(ddl IN LISTS ddl_files)
 endforeach()
 
 # if DDL file modified, insure the last release file passed in
-if(DISKQUOTA_DDL_MODIFIED AND NOT DEFINED DISKQUOTA_LAST_RELEASE_PATH)
+if(DISKQUOTA_DDL_CHANGE_CHECK AND DISKQUOTA_DDL_MODIFIED AND NOT DEFINED DISKQUOTA_LAST_RELEASE_PATH)
   message(
     FATAL_ERROR
       "DDL file modify detected, upgrade test is required. Add -DDISKQUOTA_LAST_RELEASE_PATH=/<path>/diskquota-<version>-<os>_<arch>.tar.gz. And re-try the generation"


### PR DESCRIPTION
By default DISKQUOTA_DDL_CHANGE_CHECK is ON which will check the DDL
change and report errors if the previous version of so files don't
exist.

For dev:
cmake .. \
          -DPG_CONFIG=/path/to/pg_config \
          -DDISKQUOTA_DDL_CHANGE_CHECK=OFF

to disable the check

And fixed a build warning.
