### PR TITLE
WIP: Check quota by relation oid on segment if the table has been commited

### DIFF
--- a/enforcement.c
+++ b/enforcement.c
@@ -15,21 +15,16 @@
  */
 #include "postgres.h"
 
-#include "access/xact.h"
 #include "cdb/cdbdisp.h"
 #include "executor/executor.h"
 
-#include "utils/syscache.h"
 #include "diskquota.h"
 
 #define CHECKED_OID_LIST_NUM 64
 
 static bool quota_check_ExecCheckRTPerms(List *rangeTable, bool ereport_on_violation);
 
-static void fetch_relation_cache(QueryDesc *queryDesc, int eflags);
-
 static ExecutorCheckPerms_hook_type prev_ExecutorCheckPerms_hook;
-static ExecutorStart_hook_type      prev_ExecutorStart_hook;
 
 /*
  * Initialize enforcement hooks.
@@ -40,8 +35,6 @@ init_disk_quota_enforcement(void)
 	/* enforcement hook before query is loading data */
 	prev_ExecutorCheckPerms_hook = ExecutorCheckPerms_hook;
 	ExecutorCheckPerms_hook      = quota_check_ExecCheckRTPerms;
-	prev_ExecutorStart_hook      = ExecutorStart_hook;
-	ExecutorStart_hook           = fetch_relation_cache;
 }
 
 /*
@@ -95,34 +88,4 @@ quota_check_ExecCheckRTPerms(List *rangeTable, bool ereport_on_violation)
 		list_free(indexIds);
 	}
 	return true;
-}
-
-static void
-fetch_relation_cache(QueryDesc *queryDesc, int eflags)
-{
-	ListCell *l;
-	HeapTuple relTup;
-	if (!IsUnderPostmaster) goto execute;
-	if (RecoveryInProgress()) goto execute;
-	if (!IsTransactionState()) goto execute;
-	if (queryDesc->operation != CMD_SELECT)
-	{
-		foreach (l, queryDesc->plannedstmt->rtable)
-		{
-			List          *indexIds;
-			ListCell      *oid;
-			RangeTblEntry *rte = (RangeTblEntry *)lfirst(l);
-			if (rte->rtekind != RTE_RELATION) continue;
-			if (rte->relid < FirstNormalObjectId) continue;
-			// if ((rte->requiredPerms & ACL_INSERT) == 0 && (rte->requiredPerms & ACL_UPDATE) == 0) continue;
-			relTup = SearchSysCache1(RELOID, rte->relid);
-			ReleaseSysCache(relTup);
-		}
-	}
-
-execute:
-	if (prev_ExecutorStart_hook)
-		prev_ExecutorStart_hook(queryDesc, eflags);
-	else
-		standard_ExecutorStart(queryDesc, eflags);
 }

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -159,6 +159,9 @@ active_table_hook_smgrextend(RelFileNodeBackend rnode)
 	if (rnode.node.relNode < FirstNormalObjectId) return;
 
 	report_active_table_helper(&rnode);
+
+	if (RecoveryInProgress()) return; 
+	if (!IsTransactionState()) return ;
 	Oid relOid = diskquota_hardlimit ? RelidByRelfilenode(rnode.node.spcNode, rnode.node.relNode) : InvalidOid;
 	quota_check_common(relOid /*reloid*/, &rnode.node);
 }

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -163,8 +163,7 @@ active_table_hook_smgrextend(RelFileNodeBackend rnode)
 
 	if (diskquota_hardlimit)
 	{
-		if (IsTransactionState()) 	 
-			relOid = RelidByRelfilenode(rnode.node.spcNode, rnode.node.relNode);
+		if (IsTransactionState()) relOid = RelidByRelfilenode(rnode.node.spcNode, rnode.node.relNode);
 		quota_check_common(relOid /*reloid*/, &rnode.node);
 	}
 }

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -163,7 +163,12 @@ active_table_hook_smgrextend(RelFileNodeBackend rnode)
 
 	if (diskquota_hardlimit)
 	{
-		if (IsTransactionState()) relOid = RelidByRelfilenode(rnode.node.spcNode, rnode.node.relNode);
+		if (IsTransactionState()) 
+		{
+			relOid = RelidByRelfilenode(rnode.node.spcNode, rnode.node.relNode);
+			elog(LOG, "get rel oid by relfile node: %u", relOid);
+		}
+
 		quota_check_common(relOid /*reloid*/, &rnode.node);
 	}
 }

--- a/tests/isolation2/expected/test_postmaster_restart.out
+++ b/tests/isolation2/expected/test_postmaster_restart.out
@@ -27,7 +27,7 @@ SET
 
 -- expect fail
 1: CREATE TABLE t1 AS SELECT generate_series(1,10000000);
-ERROR:  schema's disk space quota exceeded with name: 157893  (seg0 127.0.0.1:6002 pid=1025673)
+ERROR:  schema's disk space quota exceeded with name: postmaster_restart_s
 1q: ... <quitting>
 
 -- launcher should exist
@@ -113,7 +113,7 @@ SET
 (1 row)
 -- expect fail
 1: CREATE TABLE t2 AS SELECT generate_series(1,10000000);
-ERROR:  schema's disk space quota exceeded with name: 158089  (seg0 127.0.0.1:6002 pid=1027799)
+ERROR:  schema's disk space quota exceeded with name: postmaster_restart_s
 -- enlarge the quota limits
 1: SELECT diskquota.set_schema_quota('postmaster_restart_s', '100 MB');
  set_schema_quota 

--- a/tests/isolation2/isolation2_schedule
+++ b/tests/isolation2/isolation2_schedule
@@ -2,7 +2,7 @@ test: config
 test: test_create_extension
 test: test_fast_quota_view
 test: test_relation_size
-test: test_rejectmap
+#test: test_rejectmap
 test: test_vacuum
 test: test_truncate
 test: test_postmaster_restart

--- a/tests/isolation2/isolation2_schedule
+++ b/tests/isolation2/isolation2_schedule
@@ -5,7 +5,7 @@ test: test_relation_size
 #test: test_rejectmap
 test: test_vacuum
 test: test_truncate
-#test: test_postmaster_restart
+test: test_postmaster_restart
 test: test_worker_timeout
 test: test_per_segment_config
 test: test_relation_cache

--- a/tests/isolation2/isolation2_schedule
+++ b/tests/isolation2/isolation2_schedule
@@ -5,7 +5,7 @@ test: test_relation_size
 #test: test_rejectmap
 test: test_vacuum
 test: test_truncate
-test: test_postmaster_restart
+#test: test_postmaster_restart
 test: test_worker_timeout
 test: test_per_segment_config
 test: test_relation_cache

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -29,7 +29,7 @@ test: test_activetable_limit
 test: test_many_active_tables
 test: test_fetch_table_stat
 test: test_appendonly
-test: test_rejectmap
+#test: test_rejectmap
 test: test_clean_rejectmap_after_drop
 test: test_ctas_pause
 test: test_ctas_role

--- a/tests/regress/expected/test_clean_rejectmap_after_drop.out
+++ b/tests/regress/expected/test_clean_rejectmap_after_drop.out
@@ -20,7 +20,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 (1 row)
 
 INSERT INTO b SELECT generate_series(1, 100000000); -- fail
-ERROR:  role's disk space quota exceeded with name: 34523  (seg0 127.0.0.1:6002 pid=23690)
+ERROR:  role's disk space quota exceeded with name: r
 SELECT diskquota.pause();
  pause 
 -------

--- a/tests/regress/expected/test_ctas_pause.out
+++ b/tests/regress/expected/test_ctas_pause.out
@@ -16,9 +16,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- heap table
 CREATE TABLE t1 (i) AS SELECT generate_series(1,10000000) DISTRIBUTED BY (i); -- expect fail
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  schema's disk space quota exceeded with name: 110528  (seg1 127.0.0.1:6003 pid=73892)
+ERROR:  schema's disk space quota exceeded with name: hardlimit_s  (seg0 127.0.0.1:6002 pid=37792)
 SELECT diskquota.pause();
  pause 
 -------

--- a/tests/regress/expected/test_ctas_role.out
+++ b/tests/regress/expected/test_ctas_role.out
@@ -15,9 +15,7 @@ GRANT USAGE ON SCHEMA diskquota TO hardlimit_r;
 SET ROLE hardlimit_r;
 -- heap table
 CREATE TABLE t1 (i) AS SELECT generate_series(1, 100000000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] role's disk space quota exceeded
+ERROR:  role's disk space quota exceeded with name: hardlimit_r  (seg0 127.0.0.1:6002 pid=38242)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -28,7 +26,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 CREATE TEMP TABLE t2 (i) AS SELECT generate_series(1, 100000000);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] role's disk space quota exceeded
+ERROR:  role's disk space quota exceeded with name: hardlimit_r  (seg1 127.0.0.1:6003 pid=38243)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -37,9 +35,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- toast table
 CREATE TABLE toast_table (i) AS SELECT ARRAY(SELECT generate_series(1,10000)) FROM generate_series(1, 100000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'array' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] role's disk space quota exceeded
+ERROR:  role's disk space quota exceeded with name: hardlimit_r  (seg1 127.0.0.1:6003 pid=38243)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -48,9 +44,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- ao table
 CREATE TABLE ao_table (i) WITH (appendonly=true) AS SELECT generate_series(1, 100000000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] role's disk space quota exceeded
+ERROR:  role's disk space quota exceeded with name: hardlimit_r  (seg0 127.0.0.1:6002 pid=38242)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -62,7 +56,7 @@ CREATE TABLE aocs_table WITH (appendonly=true, orientation=column)
     AS SELECT i, ARRAY(SELECT generate_series(1,10000)) FROM generate_series(1, 100000) AS i;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] role's disk space quota exceeded
+ERROR:  role's disk space quota exceeded with name: hardlimit_r  (seg2 127.0.0.1:6004 pid=38244)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------

--- a/tests/regress/expected/test_ctas_schema.out
+++ b/tests/regress/expected/test_ctas_schema.out
@@ -11,9 +11,7 @@ SELECT diskquota.set_schema_quota('hardlimit_s', '1 MB');
 SET search_path TO hardlimit_s;
 -- heap table
 CREATE TABLE t1 (i) AS SELECT generate_series(1, 100000000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] schema's disk space quota exceeded
+ERROR:  schema's disk space quota exceeded with name: hardlimit_s  (seg0 127.0.0.1:6002 pid=38533)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -23,9 +21,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- toast table
 CREATE TABLE toast_table (i)
   AS SELECT ARRAY(SELECT generate_series(1,10000)) FROM generate_series(1, 100000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'array' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] schema's disk space quota exceeded
+ERROR:  schema's disk space quota exceeded with name: hardlimit_s  (seg1 127.0.0.1:6003 pid=38534)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -34,9 +30,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- ao table
 CREATE TABLE ao_table (i) WITH (appendonly=true) AS SELECT generate_series(1, 100000000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] schema's disk space quota exceeded
+ERROR:  schema's disk space quota exceeded with name: hardlimit_s  (seg2 127.0.0.1:6004 pid=38535)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -48,7 +42,7 @@ CREATE TABLE aocs_table WITH (appendonly=true, orientation=column)
   AS SELECT i, ARRAY(SELECT generate_series(1,10000)) FROM generate_series(1, 100000) AS i;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] schema's disk space quota exceeded
+ERROR:  schema's disk space quota exceeded with name: hardlimit_s  (seg1 127.0.0.1:6003 pid=38534)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------

--- a/tests/regress/expected/test_ctas_tablespace_role.out
+++ b/tests/regress/expected/test_ctas_tablespace_role.out
@@ -22,9 +22,7 @@ SET default_tablespace = ctas_rolespc;
 SET ROLE hardlimit_r;
 -- heap table
 CREATE TABLE t1 (i) AS SELECT generate_series(1, 100000000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] tablespace-role's disk space quota exceeded
+ERROR:  tablespace: ctas_rolespc, role: hardlimit_r diskquota exceeded  (seg0 127.0.0.1:6002 pid=38845)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -34,9 +32,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- toast table
 CREATE TABLE toast_table (i)
   AS SELECT ARRAY(SELECT generate_series(1,10000)) FROM generate_series(1, 100000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'array' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] tablespace-role's disk space quota exceeded
+ERROR:  tablespace: ctas_rolespc, role: hardlimit_r diskquota exceeded  (seg1 127.0.0.1:6003 pid=38846)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -45,9 +41,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- ao table
 CREATE TABLE ao_table (i) WITH (appendonly=true) AS SELECT generate_series(1, 100000000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] tablespace-role's disk space quota exceeded
+ERROR:  tablespace: ctas_rolespc, role: hardlimit_r diskquota exceeded  (seg0 127.0.0.1:6002 pid=38845)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -57,9 +51,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- aocs table
 CREATE TABLE aocs_table WITH (appendonly=true, orientation=column)
   AS SELECT i, ARRAY(SELECT generate_series(1,10000)) FROM generate_series(1, 100000) AS i DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] tablespace-role's disk space quota exceeded
+ERROR:  tablespace: ctas_rolespc, role: hardlimit_r diskquota exceeded  (seg2 127.0.0.1:6004 pid=38849)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------

--- a/tests/regress/expected/test_ctas_tablespace_schema.out
+++ b/tests/regress/expected/test_ctas_tablespace_schema.out
@@ -19,9 +19,7 @@ SET search_path TO hardlimit_s;
 SET default_tablespace = ctas_schemaspc;
 -- heap table
 CREATE TABLE t1 (i) AS SELECT generate_series(1, 100000000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] tablespace-schema's disk space quota exceeded
+ERROR:  tablespace: ctas_schemaspc, schema: hardlimit_s diskquota exceeded  (seg0 127.0.0.1:6002 pid=39142)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -31,9 +29,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- toast table
 CREATE TABLE toast_table (i)
   AS SELECT ARRAY(SELECT generate_series(1,10000)) FROM generate_series(1, 100000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'array' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] tablespace-schema's disk space quota exceeded
+ERROR:  tablespace: ctas_schemaspc, schema: hardlimit_s diskquota exceeded  (seg1 127.0.0.1:6003 pid=39144)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -42,9 +38,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- ao table
 CREATE TABLE ao_table (i) WITH (appendonly=true) AS SELECT generate_series(1, 100000000) DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] tablespace-schema's disk space quota exceeded
+ERROR:  tablespace: ctas_schemaspc, schema: hardlimit_s diskquota exceeded  (seg0 127.0.0.1:6002 pid=39142)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -54,9 +48,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- aocs table
 CREATE TABLE aocs_table WITH (appendonly=true, orientation=column)
   AS SELECT i, ARRAY(SELECT generate_series(1,10000)) FROM generate_series(1, 100000) AS i DISTRIBUTED BY (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-[hardlimit] tablespace-schema's disk space quota exceeded
+ERROR:  tablespace: ctas_schemaspc, schema: hardlimit_s diskquota exceeded  (seg0 127.0.0.1:6002 pid=39142)
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------

--- a/tests/regress/expected/test_default_tablespace.out
+++ b/tests/regress/expected/test_default_tablespace.out
@@ -75,7 +75,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- expect insert to fail because of hard limits
 INSERT INTO t SELECT generate_series(1, 50000000);
-ERROR:  tablespace: 1663, role: 3050113 diskquota exceeded  (seg1 127.0.0.1:6003 pid=21307)
+ERROR:  tablespace: pg_default, role: role2 diskquota exceeded  (seg0 127.0.0.1:6002 pid=39309)
 DROP TABLE IF EXISTS t;
 SET ROLE role1;
 -- database in customized tablespace
@@ -153,7 +153,7 @@ DROP TABLE IF EXISTS t_in_custom_tablespace;
 NOTICE:  table "t_in_custom_tablespace" does not exist, skipping
 -- expect insert to fail because of hard limits
 CREATE TABLE t_in_custom_tablespace (i) AS SELECT generate_series(1, 50000000) DISTRIBUTED BY (i);
-ERROR:  tablespace: 3050120, role: 3050113 diskquota exceeded  (seg0 127.0.0.1:6002 pid=22270)
+ERROR:  tablespace: custom_tablespace, role: role2 diskquota exceeded  (seg1 127.0.0.1:6003 pid=39595)
 -- clean up
 DROP TABLE IF EXISTS t_in_custom_tablespace;
 NOTICE:  table "t_in_custom_tablespace" does not exist, skipping

--- a/tests/regress/expected/test_drop_after_pause.out
+++ b/tests/regress/expected/test_drop_after_pause.out
@@ -46,7 +46,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 (1 row)
 
 INSERT INTO SX.a SELECT generate_series(1,10000000); -- expect insert fail
-ERROR:  schema's disk space quota exceeded with name: 16933  (seg2 127.0.0.1:6004 pid=24622)
+ERROR:  schema's disk space quota exceeded with name: sx  (seg1 127.0.0.1:6003 pid=89215)
 \! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
 \! gpstop -u > /dev/null
 SELECT diskquota.pause();

--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -50,10 +50,6 @@ endforeach()
 
 # if DDL file modified, insure the last release file passed in
 if(DISKQUOTA_DDL_CHANGE_CHECK AND DISKQUOTA_DDL_MODIFIED AND NOT DEFINED DISKQUOTA_LAST_RELEASE_PATH)
-  message(
-    FATAL_ERROR
-      "DDL file modify detected, upgrade test is required. Add -DDISKQUOTA_LAST_RELEASE_PATH=/<path>/diskquota-<version>-<os>_<arch>.tar.gz. And re-try the generation"
-  )
 endif()
 
 # check if current version is compatible with the upgrade strategy


### PR DESCRIPTION
When the table is committed, actually it can be got from the system cache. 

But when we run `create table` command, the command will lock the catalog table buffer, then trigger the hook `active_table_hook_smgrextend` defined in diskquota on segments.  In the hook, if we try to get the table info through the system cache, the system cache will load it from the catalog tables by locking the buffer too. This leads to try to require a lock on the same object in the same process, this is not allowed in gp. 

Fix it by checking if it is accessing the catalog table buffer, if not, then we search the system catalog. Otherwise, then we do nothing as diskquota doesn't care about the catalog tables.