### PR TITLE
Fix bug: rejectmap entries should not be removed by other databases.

### DIFF
--- a/quotamodel.c
+++ b/quotamodel.c
@@ -2040,7 +2040,10 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 	/* Clear rejectmap entries. */
 	hash_seq_init(&hash_seq, disk_quota_reject_map);
 	while ((rejectmapentry = hash_seq_search(&hash_seq)) != NULL)
+	{
+		if (rejectmapentry->keyitem.relfilenode.dbNode != MyDatabaseId) continue;
 		hash_search(disk_quota_reject_map, &rejectmapentry->keyitem, HASH_REMOVE, NULL);
+	}
 
 	/* Flush the content of local_rejectmap to the global rejectmap. */
 	hash_seq_init(&hash_seq, local_rejectmap);

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -811,7 +811,8 @@ refresh_disk_quota_usage(bool is_init)
 		flush_to_table_size();
 		/* copy local reject map back to shared reject map */
 		bool reject_map_changed = flush_local_reject_map();
-		/* Dispatch rejectmap entries to segments to perform hard-limit.
+		/*
+		 * Dispatch rejectmap entries to segments to perform hard-limit.
 		 * If the bgworker is in init mode, the rejectmap should be refreshed anyway.
 		 * Otherwise, only when the rejectmap is changed or the active_table_list is
 		 * not empty the rejectmap should be dispatched to segments.
@@ -2043,7 +2044,6 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 	LWLockAcquire(diskquota_locks.reject_map_lock, LW_EXCLUSIVE);
 
 	/* Clear rejectmap entries. */
-	/* Pass two empty arrays to clear the reject map. */
 	hash_seq_init(&hash_seq, disk_quota_reject_map);
 	while ((rejectmapentry = hash_seq_search(&hash_seq)) != NULL)
 	{
@@ -2061,7 +2061,7 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 		GlobalRejectMapEntry *new_entry;
 
 		/*
-		 * Skip soft limit reject entry We don't perform soft-limit on segment servers, so we don't flush the
+		 * Skip soft limit reject entry. We don't perform soft-limit on segment servers, so we don't flush the
 		 * rejectmap entry with a valid targetoid to the global rejectmap on segment servers.
 		 */
 		if (OidIsValid(rejectmapentry->keyitem.targetoid)) continue;

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -2062,15 +2062,13 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 		bool                  found;
 		GlobalRejectMapEntry *new_entry;
 
-		/* Skip soft limit reject entry */
+		/*
+		 * Skip soft limit reject entry We don't perform soft-limit on segment servers, so we don't flush the
+		 * rejectmap entry with a valid targetoid to the global rejectmap on segment servers.
+		 */
 		if (OidIsValid(rejectmapentry->keyitem.targetoid)) continue;
 
 		new_entry = hash_search(disk_quota_reject_map, &rejectmapentry->keyitem, HASH_ENTER_NULL, &found);
-		/*
-		 * We don't perform soft-limit on segment servers, so we don't flush the
-		 * rejectmap entry with a valid targetoid to the global rejectmap on segment
-		 * servers.
-		 */
 		if (!found && new_entry) memcpy(new_entry, rejectmapentry, sizeof(GlobalRejectMapEntry));
 	}
 	LWLockRelease(diskquota_locks.reject_map_lock);

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -1807,7 +1807,6 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 	HASH_SEQ_STATUS       hash_seq;
 	HTAB                 *local_rejectmap;
 	HASHCTL               hashctl;
-	bool                  force_clean;
 
 	if (!superuser())
 		ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), errmsg("must be superuser to update rejectmap")));
@@ -2045,11 +2044,10 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 
 	/* Clear rejectmap entries. */
 	/* Pass two empty arrays to clear the reject map. */
-	force_clean = (reject_array_count == 0) && (active_array_count == 0);
 	hash_seq_init(&hash_seq, disk_quota_reject_map);
 	while ((rejectmapentry = hash_seq_search(&hash_seq)) != NULL)
 	{
-		if (!force_clean && rejectmapentry->keyitem.relfilenode.dbNode != MyDatabaseId &&
+		if (rejectmapentry->keyitem.relfilenode.dbNode != MyDatabaseId &&
 		    rejectmapentry->keyitem.databaseoid != MyDatabaseId)
 			continue;
 		hash_search(disk_quota_reject_map, &rejectmapentry->keyitem, HASH_REMOVE, NULL);

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -2071,8 +2071,7 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 		 * rejectmap entry with a valid targetoid to the global rejectmap on segment
 		 * servers.
 		 */
-		if (!found && new_entry)
-			memcpy(new_entry, rejectmapentry, sizeof(GlobalRejectMapEntry));
+		if (!found && new_entry) memcpy(new_entry, rejectmapentry, sizeof(GlobalRejectMapEntry));
 	}
 	LWLockRelease(diskquota_locks.reject_map_lock);
 

--- a/quotamodel.c
+++ b/quotamodel.c
@@ -2061,13 +2061,17 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 	{
 		bool                  found;
 		GlobalRejectMapEntry *new_entry;
+
+		/* Skip soft limit reject entry */
+		if (OidIsValid(rejectmapentry->keyitem.targetoid)) continue;
+
 		new_entry = hash_search(disk_quota_reject_map, &rejectmapentry->keyitem, HASH_ENTER_NULL, &found);
 		/*
 		 * We don't perform soft-limit on segment servers, so we don't flush the
 		 * rejectmap entry with a valid targetoid to the global rejectmap on segment
 		 * servers.
 		 */
-		if (!found && new_entry && !OidIsValid(rejectmapentry->keyitem.targetoid))
+		if (!found && new_entry)
 			memcpy(new_entry, rejectmapentry, sizeof(GlobalRejectMapEntry));
 	}
 	LWLockRelease(diskquota_locks.reject_map_lock);

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -31,6 +31,7 @@ test: test_fetch_table_stat
 test: test_appendonly
 test: test_rejectmap
 test: test_clean_rejectmap_after_drop
+test: test_rejectmap_mul_db
 test: test_ctas_pause
 test: test_ctas_role
 test: test_ctas_schema

--- a/tests/regress/expected/test_rejectmap_mul_db.out
+++ b/tests/regress/expected/test_rejectmap_mul_db.out
@@ -1,0 +1,89 @@
+-- One db's rejectmap update should not impact on other db's rejectmap
+CREATE DATABASE tjmu1;
+CREATE DATABASE tjmu2;
+-- start_ignore
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+\! gpstop -u > /dev/null
+-- end_ignore
+\c tjmu1
+CREATE EXTENSION diskquota;
+SELECT diskquota.set_schema_quota('public', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+-- Trigger hard limit to dispatch rejectmap for tjmu1
+INSERT INTO b SELECT generate_series(1, 100000000); -- fail
+ERROR:  schema's disk space quota exceeded with name: 2200  (seg1 127.0.0.1:6003 pid=3985762)
+-- NOTE: Pause to avoid tjmu1's worker clear the active table. Since the naptime is 0 on CI, this might be flaky.
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+-- The rejectmap should contain entries with dbnode = 0 and dbnode = tjmu1_oid. count = 1
+SELECT COUNT(DISTINCT r.dbnode) FROM (SELECT (diskquota.show_rejectmap()).* FROM gp_dist_random('gp_id')) as r where r.dbnode != 0;
+ count 
+-------
+     1
+(1 row)
+
+\c tjmu2
+CREATE EXTENSION diskquota;
+SELECT diskquota.set_schema_quota('public', '1MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+-- Trigger hard limit to dispatch rejectmap for tjmu2
+INSERT INTO b SELECT generate_series(1, 100000000); -- fail
+ERROR:  schema's disk space quota exceeded with name: 2200  (seg1 127.0.0.1:6003 pid=4001721)
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
+--\c tjmu1
+-- The rejectmap should contain entris with dbnode = 0 and dbnode = tjmu1_oid and tjmu2_oid. count = 2
+-- The entries for tjmu1 should not be cleared
+SELECT COUNT(DISTINCT r.dbnode) FROM (SELECT (diskquota.show_rejectmap()).* FROM gp_dist_random('gp_id')) as r where r.dbnode != 0;
+ count 
+-------
+     2
+(1 row)
+
+-- start_ignore
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
+\! gpstop -u > /dev/null
+-- end_ignore
+\c tjmu1
+DROP EXTENSION diskquota;
+\c tjmu2
+DROP EXTENSION diskquota;
+\c contrib_regression
+DROP DATABASE tjmu1;
+DROP DATABASE tjmu2;

--- a/tests/regress/sql/test_rejectmap_mul_db.sql
+++ b/tests/regress/sql/test_rejectmap_mul_db.sql
@@ -1,0 +1,53 @@
+-- One db's rejectmap update should not impact on other db's rejectmap
+CREATE DATABASE tjmu1;
+CREATE DATABASE tjmu2;
+
+-- start_ignore
+\! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
+-- increase the naptime to avoid active table gets cleared by tjmu1's worker
+\! gpconfig -c "diskquota.naptime" -v 1 > /dev/null
+\! gpstop -u > /dev/null
+-- end_ignore
+
+\c tjmu1
+CREATE EXTENSION diskquota;
+SELECT diskquota.set_schema_quota('public', '1MB');
+CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
+SELECT diskquota.wait_for_worker_new_epoch();
+-- Trigger hard limit to dispatch rejectmap for tjmu1
+INSERT INTO b SELECT generate_series(1, 100000000); -- fail
+-- NOTE: Pause to avoid tjmu1's worker clear the active table. Since the naptime is 0 on CI, this might be flaky.
+SELECT diskquota.pause();
+-- The rejectmap should contain entries with dbnode = 0 and dbnode = tjmu1_oid. count = 1
+SELECT COUNT(DISTINCT r.dbnode) FROM (SELECT (diskquota.show_rejectmap()).* FROM gp_dist_random('gp_id')) as r where r.dbnode != 0;
+
+\c tjmu2
+CREATE EXTENSION diskquota;
+SELECT diskquota.set_schema_quota('public', '1MB');
+CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
+SELECT diskquota.wait_for_worker_new_epoch();
+-- Trigger hard limit to dispatch rejectmap for tjmu2
+INSERT INTO b SELECT generate_series(1, 100000000); -- fail
+SELECT diskquota.wait_for_worker_new_epoch();
+SELECT diskquota.pause();
+
+--\c tjmu1
+-- The rejectmap should contain entris with dbnode = 0 and dbnode = tjmu1_oid and tjmu2_oid. count = 2
+-- The entries for tjmu1 should not be cleared
+SELECT COUNT(DISTINCT r.dbnode) FROM (SELECT (diskquota.show_rejectmap()).* FROM gp_dist_random('gp_id')) as r where r.dbnode != 0;
+
+-- start_ignore
+\! gpconfig -c "diskquota.hard_limit" -v "off" > /dev/null
+\! gpconfig -c "diskquota.naptime" -v 0 > /dev/null
+\! gpstop -u > /dev/null
+-- end_ignore
+
+\c tjmu1
+DROP EXTENSION diskquota;
+\c tjmu2
+DROP EXTENSION diskquota;
+
+\c contrib_regression
+DROP DATABASE tjmu1;
+DROP DATABASE tjmu2;
+


### PR DESCRIPTION
Previously, refresh_rejectmap() cleared all entries in rejectmap, including other databases' entries, which causes hardlimit can not to work correctly. This commit fixed the bug.

Meanwhile, this PR fixed a bug: soft-limit rejectmap entries should not be added into `disk_quota_reject_map` on segments.