### PR TITLE
Fix flaky test_fast_quota_view

### DIFF
--- a/tests/isolation2/expected/test_fast_quota_view.out
+++ b/tests/isolation2/expected/test_fast_quota_view.out
@@ -6,7 +6,6 @@ CREATE
 CREATE ROLE r LOGIN SUPERUSER;
 CREATE
 
--- start_ignore
 !\retcode mkdir -p /tmp/spc1;
 -- start_ignore
 
@@ -17,7 +16,7 @@ CREATE
 
 -- end_ignore
 (exited with code 0)
--- end_ignore
+
 DROP TABLESPACE IF EXISTS spc1;
 DROP
 CREATE TABLESPACE spc1 LOCATION '/tmp/spc1';
@@ -166,19 +165,18 @@ DROP
 DROP ROLE IF EXISTS r;
 DROP
 
--- start_ignore
-!\retcode rm -r /tmp/spc1;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
-!\retcode rm -r /tmp/spc2;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
--- end_ignore
 DROP TABLESPACE IF EXISTS spc1;
 DROP
 DROP TABLESPACE IF EXISTS spc2;
 DROP
+
+!\retcode rm -rf /tmp/spc1;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode rm -rf /tmp/spc2;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)

--- a/tests/isolation2/sql/test_fast_quota_view.sql
+++ b/tests/isolation2/sql/test_fast_quota_view.sql
@@ -3,10 +3,9 @@ CREATE SCHEMA s2;
 
 CREATE ROLE r LOGIN SUPERUSER;
 
--- start_ignore
 !\retcode mkdir -p /tmp/spc1;
 !\retcode mkdir -p /tmp/spc2;
--- end_ignore
+
 DROP TABLESPACE IF EXISTS spc1;
 CREATE TABLESPACE spc1 LOCATION '/tmp/spc1';
 DROP TABLESPACE IF EXISTS spc2;
@@ -67,9 +66,8 @@ DROP SCHEMA IF EXISTS s1;
 DROP SCHEMA IF EXISTS s2;
 DROP ROLE IF EXISTS r;
 
--- start_ignore
-!\retcode rm -r /tmp/spc1;
-!\retcode rm -r /tmp/spc2;
--- end_ignore
 DROP TABLESPACE IF EXISTS spc1;
 DROP TABLESPACE IF EXISTS spc2;
+
+!\retcode rm -rf /tmp/spc1;
+!\retcode rm -rf /tmp/spc2;


### PR DESCRIPTION
- Drop the table space before rm directory.
- '-f' to alway force rm.
- '-- start-ignore' doesn't seem to be working with retcode since retcode
  will add '-- start/stop-ignore' pair automatically to ignore the
  output, and the nested start/stop ignore doesn't seem to be handled
  well by the ancient perl script. Refer to
  'src/test/isolation2/sql_isolation_testcase.py'.

Seen flaky tests as below:

```diff
root@96831b9f-9150-4424-63a7-abe8f18c144e:/tmp# cat /home/gpadmin/diskquota_artifacts/tests/isolation2/regression.diffs
--- \/tmp\/build\/4eceba44\/bin_diskquota\/tests\/isolation2\/expected\/test_fast_quota_view\.out	2022-12-12 13:20:56.729354016 +0000
+++ \/tmp\/build\/4eceba44\/bin_diskquota\/tests\/isolation2\/results\/test_fast_quota_view\.out	2022-12-12 13:20:56.733354401 +0000
@@ -175,9 +175,11 @@
 (exited with code 0)
 !\retcode rm -r /tmp/spc2;
 GP_IGNORE:-- start_ignore
+GP_IGNORE:rm: cannot remove '/tmp/spc2/6/GPDB_6_301908232/16384/16413': No such file or directory
+GP_IGNORE:rm: cannot remove '/tmp/spc2/5/GPDB_6_301908232/16384/16413': No such file or directory
 GP_IGNORE:
 GP_IGNORE:-- end_ignore
-(exited with code 0)
+(exited with code 1)
 -- end_ignore
 DROP TABLESPACE IF EXISTS spc1;
 DROP
```