### PR TITLE
Fix flaky test

### DIFF
--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -805,7 +805,12 @@ get_active_tables_oid(void)
 		rnode.spcNode = active_table_file_entry->tablespaceoid;
 		relOid        = get_relid_by_relfilenode(rnode);
 
-		if (relOid != InvalidOid)
+		/* skip system catalog tables */
+		if (relOid < FirstNormalObjectId)
+		{
+			hash_search(local_active_table_file_map, active_table_file_entry, HASH_REMOVE, NULL);
+		}
+		else if (relOid != InvalidOid)
 		{
 			prelid             = get_primary_table_oid(relOid, true);
 			active_table_entry = hash_search(local_active_table_stats_map, &prelid, HASH_ENTER, &found);

--- a/tests/isolation2/expected/test_truncate.out
+++ b/tests/isolation2/expected/test_truncate.out
@@ -39,6 +39,13 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t                         
 (1 row)
 1&: TRUNCATE dummy_t1;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('diskquota_after_smgrcreate', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content<>-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
 -- Wait for the diskquota bgworker 'consumes' the newly created relfilenode from shmem.
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 

--- a/tests/isolation2/expected/test_vacuum.out
+++ b/tests/isolation2/expected/test_vacuum.out
@@ -52,6 +52,13 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t                         
 (1 row)
 1&: VACUUM FULL dummy_t1;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('object_access_post_alter', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content<>-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
 -- Wait for the diskquota bgworker 'consumes' the newly created relfilenode from shmem.
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 

--- a/tests/isolation2/expected7/test_truncate.out
+++ b/tests/isolation2/expected7/test_truncate.out
@@ -39,6 +39,13 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t                         
 (1 row)
 1&: TRUNCATE dummy_t1;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('diskquota_after_smgrcreate', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content<>-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
 -- Wait for the diskquota bgworker 'consumes' the newly created relfilenode from shmem.
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 

--- a/tests/isolation2/expected7/test_vacuum.out
+++ b/tests/isolation2/expected7/test_vacuum.out
@@ -52,6 +52,13 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t                         
 (1 row)
 1&: VACUUM FULL dummy_t1;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('object_access_post_alter', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content<>-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
 -- Wait for the diskquota bgworker 'consumes' the newly created relfilenode from shmem.
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 

--- a/tests/isolation2/sql/test_truncate.sql
+++ b/tests/isolation2/sql/test_truncate.sql
@@ -14,6 +14,8 @@ SELECT gp_inject_fault_infinite('diskquota_after_smgrcreate', 'suspend', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content<>-1;
 SELECT diskquota.wait_for_worker_new_epoch();
 1&: TRUNCATE dummy_t1;
+SELECT gp_wait_until_triggered_fault('diskquota_after_smgrcreate', 1, dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content<>-1;
 -- Wait for the diskquota bgworker 'consumes' the newly created relfilenode from shmem.
 SELECT diskquota.wait_for_worker_new_epoch();
 SELECT gp_inject_fault_infinite('diskquota_after_smgrcreate', 'reset', dbid)

--- a/tests/isolation2/sql/test_vacuum.sql
+++ b/tests/isolation2/sql/test_vacuum.sql
@@ -26,6 +26,8 @@ SELECT gp_inject_fault_infinite('object_access_post_alter', 'suspend', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content<>-1;
 SELECT diskquota.wait_for_worker_new_epoch();
 1&: VACUUM FULL dummy_t1;
+SELECT gp_wait_until_triggered_fault('object_access_post_alter', 1, dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content<>-1;
 -- Wait for the diskquota bgworker 'consumes' the newly created relfilenode from shmem.
 SELECT diskquota.wait_for_worker_new_epoch();
 SELECT gp_inject_fault_infinite('object_access_post_alter', 'reset', dbid)


### PR DESCRIPTION
- Fix flaky test test_ctas_before_set_quota. pg_type will be an active table
after `CREATE TABLE`. It does not affect the function of diskquota but
makes the test results unstable. In fact, we do not care about the table
size of the system catalog table. So we simply skip the active table oid
of these tables.

- Fix test_vacuum/test_truncate. gp_wait_until_triggered_fault
should be called after gp_inject_fault_infinite with suspend flag.

Co-authored-by: Xing Guo <higuoxing@gmail.com>
Co-authored-by: Xiaoran Wang <wxiaoran@vmware.com>
