### PR TITLE
Fix bug

### DIFF
--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -810,12 +810,15 @@ get_active_tables_oid(void)
 		rnode.spcNode = active_table_file_entry->tablespaceoid;
 		relOid        = get_relid_by_relfilenode(rnode);
 
+		/* If relfilenode is not prepared for some relation, just skip it. */
+		if (!OidIsValid(relOid)) continue;
+
 		/* skip system catalog tables */
 		if (relOid < FirstNormalObjectId)
 		{
 			hash_search(local_active_table_file_map, active_table_file_entry, HASH_REMOVE, NULL);
 		}
-		else if (relOid != InvalidOid)
+		else
 		{
 			prelid             = get_primary_table_oid(relOid, true);
 			active_table_entry = hash_search(local_active_table_stats_map, &prelid, HASH_ENTER, &found);

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -268,12 +268,17 @@ report_relation_cache_helper(Oid relid)
 #if GP_VERSION_NUM < 70000
 	rel = diskquota_relation_open(relid, NoLock);
 #else
-	rel                             = diskquota_relation_open(relid, AccessShareLock);
+	rel = diskquota_relation_open(relid, AccessShareLock);
 #endif /* GP_VERSION_NUM */
-	if (rel->rd_rel->relkind != RELKIND_FOREIGN_TABLE || rel->rd_rel->relkind != RELKIND_COMPOSITE_TYPE ||
+	if (rel->rd_rel->relkind != RELKIND_FOREIGN_TABLE && rel->rd_rel->relkind != RELKIND_COMPOSITE_TYPE &&
 	    rel->rd_rel->relkind != RELKIND_VIEW)
 		update_relation_cache(relid);
+
+#if GP_VERSION_NUM < 70000
 	relation_close(rel, NoLock);
+#else
+	relation_close(rel, AccessShareLock);
+#endif /* GP_VERSION_NUM */
 }
 
 /*

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -166,7 +166,11 @@ update_relation_entry(Oid relid, DiskQuotaRelationCacheEntry *relation_entry, Di
 
 	relation_entry->primary_table_relid = relid;
 
+#if GP_VERSION_NUM < 70000
 	relation_close(rel, NoLock);
+#else
+	relation_close(rel, AccessShareLock);
+#endif /* GP_VERSION_NUM */
 }
 
 void
@@ -235,7 +239,11 @@ parse_primary_table_oid(Oid relid, bool on_bgworker)
 		}
 		namespace = rel->rd_rel->relnamespace;
 		memcpy(relname, rel->rd_rel->relname.data, NAMEDATALEN);
+#if GP_VERSION_NUM < 70000
 		relation_close(rel, NoLock);
+#else
+		relation_close(rel, AccessShareLock);
+#endif /* GP_VERSION_NUM */
 	}
 
 	parsed_oid = diskquota_parse_primary_table_oid(namespace, relname);


### PR DESCRIPTION
Fix the following bugs:
- Judgement condition for update_relation_cache should be `&&`, instead of `||`
- The lock for relation_open/relation_close should be AccessShareLock for gpdb7.
- For `truncate table`, we cannot get the table's oid by new relfilenode
immediately after `file_create_hook` is finished. So we should keep
the relfilenode in active_table_file_map and wait for the next loop to
calculate the correct size for this table.