### PR TITLE
Enable upgrade test for CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,12 +170,7 @@ BuildInfo_Create(${build_info_PATH}
 
 # Add installcheck targets
 add_subdirectory(tests)
-if(NOT DEFINED ENABLE_UPGRADE_TEST)
-  set(ENABLE_UPGRADE_TEST ON)
-endif()
-if(ENABLE_UPGRADE_TEST)
-  add_subdirectory(upgrade_test)
-endif()
+add_subdirectory(upgrade_test)
 
 # NOTE: keep install part at the end of file, to overwrite previous binary
 install(PROGRAMS "cmake/install_gpdb_component" DESTINATION ".")

--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -15,7 +15,7 @@
 res_build_image: centos6-gpdb6-image-build
 res_test_images: [centos6-gpdb6-image-test]
 res_gpdb_bin: #@ "bin_gpdb6_centos6" + ("" if release_build else "_debug")
-#! res_diskquota_bin: bin_diskquota_gpdb6_rhel6
+res_diskquota_bin: bin_diskquota_gpdb6_rhel6
 res_intermediates_bin: #@ inter_bin_name("bin_diskquota_gpdb6_rhel6_intermediates", release_build)
 release_bin: bin_diskquota_gpdb6_rhel6_release
 os: rhel6
@@ -28,7 +28,7 @@ build_type: #@ "Release" if release_build else "Debug"
 res_build_image: centos7-gpdb6-image-build
 res_test_images: [centos7-gpdb6-image-test]
 res_gpdb_bin: #@ "bin_gpdb6_centos7" + ("" if release_build else "_debug")
-#! res_diskquota_bin: bin_diskquota_gpdb6_rhel7
+res_diskquota_bin: bin_diskquota_gpdb6_rhel7
 res_intermediates_bin: #@ inter_bin_name("bin_diskquota_gpdb6_rhel7_intermediates", release_build)
 release_bin: bin_diskquota_gpdb6_rhel7_release
 os: rhel7
@@ -41,7 +41,7 @@ build_type: #@ "Release" if release_build else "Debug"
 res_build_image: rhel8-gpdb6-image-build
 res_test_images: [rhel8-gpdb6-image-test]
 res_gpdb_bin: #@ "bin_gpdb6_rhel8" + ("" if release_build else "_debug")
-#! res_diskquota_bin: bin_diskquota_gpdb6_rhel8
+res_diskquota_bin: bin_diskquota_gpdb6_rhel8
 res_intermediates_bin: #@ inter_bin_name("bin_diskquota_gpdb6_rhel8_intermediates", release_build)
 release_bin: bin_diskquota_gpdb6_rhel8_release
 os: rhel8
@@ -54,7 +54,7 @@ build_type: #@ "Release" if release_build else "Debug"
 res_build_image: ubuntu18-gpdb6-image-build
 res_test_images: [ubuntu18-gpdb6-image-test]
 res_gpdb_bin: #@ "bin_gpdb6_ubuntu18" + ("" if release_build else "_debug")
-#! res_diskquota_bin: bin_diskquota_gpdb6_ubuntu18
+res_diskquota_bin: bin_diskquota_gpdb6_ubuntu18
 res_intermediates_bin: #@ inter_bin_name("bin_diskquota_gpdb6_ubuntu18_intermediates", release_build)
 release_bin: bin_diskquota_gpdb6_ubuntu18_release
 os: ubuntu18.04
@@ -67,7 +67,7 @@ build_type: #@ "Release" if release_build else "Debug"
 res_build_image: rocky8-gpdb7-image-build
 res_test_images: [rocky8-gpdb7-image-test, rhel8-gpdb7-image-test]
 res_gpdb_bin: #@ "bin_gpdb7_rhel8" + ("" if release_build else "_debug")
-#! res_diskquota_bin: bin_diskquota_gpdb7_rhel8
+res_diskquota_bin: bin_diskquota_gpdb7_rhel8
 res_intermediates_bin: #@ inter_bin_name("bin_diskquota_gpdb7_rhel8_intermediates", release_build)
 release_bin: bin_diskquota_gpdb7_rhel8_release
 os: rhel8
@@ -228,8 +228,8 @@ plan:
   - get: #@ test_image
 #@   end
   - get: #@ conf["res_gpdb_bin"]
-  #! - get: last_released_diskquota_bin
-  #!   resource: #@ conf["res_diskquota_bin"]
+  - get: last_released_diskquota_bin
+    resource: #@ conf["res_diskquota_bin"]
 - #@ _build_task(conf)
 #@   if conf["build_type"] != "Release":
 - #@ _test_task(conf)

--- a/concourse/scripts/build_diskquota.sh
+++ b/concourse/scripts/build_diskquota.sh
@@ -12,10 +12,10 @@ function pkg() {
 
     pushd /home/gpadmin/diskquota_artifacts
     local last_release_path
-    # last_release_path=$(readlink -e /home/gpadmin/last_released_diskquota_bin/diskquota-*.tar.gz)
+    last_release_path=$(readlink -eq /home/gpadmin/last_released_diskquota_bin/diskquota-*.tar.gz)
     cmake /home/gpadmin/diskquota_src \
+        -DDISKQUOTA_LAST_RELEASE_PATH="${last_release_path}" \
         -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
-        # -DDISKQUOTA_LAST_RELEASE_PATH="${last_release_path}" \
     cmake --build . --target create_artifact
     popd
 }

--- a/concourse/scripts/test_diskquota.sh
+++ b/concourse/scripts/test_diskquota.sh
@@ -30,7 +30,7 @@ function _main() {
     # activate_standby
     # time cmake --build . --target installcheck
     # Run upgrade test (with standby master)
-    # time cmake --build . --target upgradecheck
+    time cmake --build . --target upgradecheck
     popd
 }
 

--- a/concourse/tasks/build_diskquota.yml
+++ b/concourse/tasks/build_diskquota.yml
@@ -6,7 +6,7 @@ inputs:
   - name: diskquota_src
   - name: gpdb_src
   - name: bin_cmake
-  # - name: last_released_diskquota_bin
+  - name: last_released_diskquota_bin
 
 outputs:
   - name: diskquota_artifacts

--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -57,6 +57,10 @@ endforeach()
 
 # if DDL file modified, insure the last release file passed in
 if(DISKQUOTA_DDL_CHANGE_CHECK AND DISKQUOTA_DDL_MODIFIED AND NOT DEFINED DISKQUOTA_LAST_RELEASE_PATH)
+  message(
+    FATAL_ERROR
+      "DDL file modify detected, upgrade test is required. Add -DDISKQUOTA_LAST_RELEASE_PATH=/<path>/diskquota-<version>-<os>_<arch>.tar.gz. And re-try the generation"
+  )
 endif()
 
 # check if current version is compatible with the upgrade strategy


### PR DESCRIPTION
Revert some modification from #285 .
- Add last_released_diskquota_bin back for CI.
- Enable upgradecheck.
- Add `-DDISKQUOTA_LAST_RELEASE_PATH` for cmake.