### PR TITLE
Replace relation_open/relation_close with RelationIdGetRelation/RelationClose.

### DIFF
--- a/diskquota.h
+++ b/diskquota.h
@@ -265,7 +265,7 @@ extern int      worker_spi_get_extension_version(int *major, int *minor);
 extern void     truncateStringInfo(StringInfo str, int nchars);
 extern List    *get_rel_oid_list(void);
 extern int64    calculate_relation_size_all_forks(RelFileNodeBackend *rnode, char relstorage, Oid relam);
-extern Relation diskquota_relation_open(Oid relid, LOCKMODE mode);
+extern Relation diskquota_relation_open(Oid relid);
 extern bool     get_rel_name_namespace(Oid relid, Oid *nsOid, char *relname);
 extern List    *diskquota_get_index_list(Oid relid);
 extern void     diskquota_get_appendonly_aux_oid_list(Oid reloid, Oid *segrelid, Oid *blkdirrelid, Oid *visimaprelid);

--- a/diskquota_utility.c
+++ b/diskquota_utility.c
@@ -1441,7 +1441,7 @@ relation_size_local(PG_FUNCTION_ARGS)
 }
 
 Relation
-diskquota_relation_open(Oid relid, LOCKMODE mode)
+diskquota_relation_open(Oid relid)
 {
 	Relation rel;
 	bool     success_open               = false;
@@ -1449,8 +1449,8 @@ diskquota_relation_open(Oid relid, LOCKMODE mode)
 
 	PG_TRY();
 	{
-		rel          = relation_open(relid, mode);
-		success_open = true;
+		rel = RelationIdGetRelation(relid);
+		if (rel) success_open = true;
 	}
 	PG_CATCH();
 	{

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -269,6 +269,10 @@ report_relation_cache_helper(Oid relid)
 #if GP_VERSION_NUM < 70000
 	rel = diskquota_relation_open(relid, NoLock);
 #else
+	/* In GPDB7, CheckRelationLockedByMe() is called in relation_open(). But there is no lock on the
+	 * relation before object_access_hook with OTA_POST_CREATE tag, so we should use AccessShareLock
+	 * for relation_open().
+	 */
 	rel = diskquota_relation_open(relid, AccessShareLock);
 #endif /* GP_VERSION_NUM */
 

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -246,6 +246,7 @@ report_relation_cache_helper(Oid relid)
 {
 	bool     found;
 	Relation rel;
+	char     relkind;
 
 	/* We do not collect the active table in mirror segments  */
 	if (IsRoleMirror())
@@ -270,15 +271,17 @@ report_relation_cache_helper(Oid relid)
 #else
 	rel = diskquota_relation_open(relid, AccessShareLock);
 #endif /* GP_VERSION_NUM */
-	if (rel->rd_rel->relkind != RELKIND_FOREIGN_TABLE && rel->rd_rel->relkind != RELKIND_COMPOSITE_TYPE &&
-	    rel->rd_rel->relkind != RELKIND_VIEW)
-		update_relation_cache(relid);
+
+	relkind = rel->rd_rel->relkind;
 
 #if GP_VERSION_NUM < 70000
 	relation_close(rel, NoLock);
 #else
 	relation_close(rel, AccessShareLock);
 #endif /* GP_VERSION_NUM */
+
+	if (relkind != RELKIND_FOREIGN_TABLE && relkind != RELKIND_COMPOSITE_TYPE && relkind != RELKIND_VIEW)
+		update_relation_cache(relid);
 }
 
 /*

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -266,23 +266,12 @@ report_relation_cache_helper(Oid relid)
 	{
 		return;
 	}
-#if GP_VERSION_NUM < 70000
-	rel = diskquota_relation_open(relid, NoLock);
-#else
-	/* In GPDB7, CheckRelationLockedByMe() is called in relation_open(). But there is no lock on the
-	 * relation before object_access_hook with OTA_POST_CREATE tag, so we should use AccessShareLock
-	 * for relation_open().
-	 */
-	rel = diskquota_relation_open(relid, AccessShareLock);
-#endif /* GP_VERSION_NUM */
+
+	rel = RelationIdGetRelation(relid);
 
 	relkind = rel->rd_rel->relkind;
 
-#if GP_VERSION_NUM < 70000
-	relation_close(rel, NoLock);
-#else
-	relation_close(rel, AccessShareLock);
-#endif /* GP_VERSION_NUM */
+	RelationClose(rel);
 
 	if (relkind != RELKIND_FOREIGN_TABLE && relkind != RELKIND_COMPOSITE_TYPE && relkind != RELKIND_VIEW)
 		update_relation_cache(relid);

--- a/gp_activetable.c
+++ b/gp_activetable.c
@@ -267,7 +267,11 @@ report_relation_cache_helper(Oid relid)
 		return;
 	}
 
-	rel = RelationIdGetRelation(relid);
+	rel = diskquota_relation_open(relid);
+	if (rel == NULL)
+	{
+		return;
+	}
 
 	relkind = rel->rd_rel->relkind;
 

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -139,6 +139,10 @@ update_relation_entry(Oid relid, DiskQuotaRelationCacheEntry *relation_entry, Di
 #if GP_VERSION_NUM < 70000
 	rel = diskquota_relation_open(relid, NoLock);
 #else
+	/* In GPDB7, CheckRelationLockedByMe() is called in relation_open(). But there is no lock on the
+	 * relation before object_access_hook with OTA_POST_CREATE tag, so we should use AccessShareLock
+	 * for relation_open().
+	 */
 	rel = diskquota_relation_open(relid, AccessShareLock);
 #endif /* GP_VERSION_NUM */
 
@@ -231,6 +235,10 @@ parse_primary_table_oid(Oid relid, bool on_bgworker)
 #if GP_VERSION_NUM < 70000
 		rel = diskquota_relation_open(relid, NoLock);
 #else
+		/* In GPDB7, CheckRelationLockedByMe() is called in relation_open(). But there is no lock on the
+		 * relation before object_access_hook with OTA_POST_CREATE tag, so we should use AccessShareLock
+		 * for relation_open().
+		 */
 		rel = diskquota_relation_open(relid, AccessShareLock);
 #endif /* GP_VERSION_NUM */
 
@@ -338,7 +346,7 @@ show_relation_cache(PG_FUNCTION_ARGS)
 	{
 		HASH_SEQ_STATUS iter;
 		HTAB           *relation_cache;
-	} * relation_cache_ctx;
+	} *relation_cache_ctx;
 
 	if (SRF_IS_FIRSTCALL())
 	{

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -233,12 +233,19 @@ parse_primary_table_oid(Oid relid, bool on_bgworker)
 #else
 		rel = diskquota_relation_open(relid, AccessShareLock);
 #endif /* GP_VERSION_NUM */
+
 		if (rel == NULL)
 		{
+#if GP_VERSION_NUM < 70000
+			relation_close(rel, NoLock);
+#else
+			relation_close(rel, AccessShareLock);
+#endif /* GP_VERSION_NUM */
 			return InvalidOid;
 		}
 		namespace = rel->rd_rel->relnamespace;
 		memcpy(relname, rel->rd_rel->relname.data, NAMEDATALEN);
+
 #if GP_VERSION_NUM < 70000
 		relation_close(rel, NoLock);
 #else

--- a/relation_cache.c
+++ b/relation_cache.c
@@ -136,7 +136,7 @@ static void
 update_relation_entry(Oid relid, DiskQuotaRelationCacheEntry *relation_entry, DiskQuotaRelidCacheEntry *relid_entry)
 {
 	Relation rel;
-	rel = RelationIdGetRelation(relid);
+	rel = diskquota_relation_open(relid);
 
 	if (rel == NULL)
 	{
@@ -220,11 +220,10 @@ parse_primary_table_oid(Oid relid, bool on_bgworker)
 	}
 	else
 	{
-		rel = RelationIdGetRelation(relid);
+		rel = diskquota_relation_open(relid);
 
 		if (rel == NULL)
 		{
-			RelationClose(rel);
 			return InvalidOid;
 		}
 		namespace = rel->rd_rel->relnamespace;


### PR DESCRIPTION
This PR replaces relation_open()/relation_close() with RelationIdGetRelation()/RelationClose() to avoid deadlock. We can only call relation_open()  with AccessSharedLock in object_access_hook(OAT_POST_CREATE) in GPDB7, which may cause deadlock. While RelationIdGetRelation()/RelationClose() just locks pg_class instead of user-defined relation, so we use these functions to get the information of relations. 
