### PR TITLE
Fix flaky test of test_rejectmap_mul_db

### DIFF
--- a/tests/regress/expected/test_rejectmap_mul_db.out
+++ b/tests/regress/expected/test_rejectmap_mul_db.out
@@ -22,8 +22,8 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- Trigger hard limit to dispatch rejectmap for tjmu1
 INSERT INTO b SELECT generate_series(1, 100000000); -- fail
-ERROR:  schema's disk space quota exceeded with name: 2200  (seg1 127.0.0.1:6003 pid=3985762)
--- NOTE: Pause to avoid tjmu1's worker clear the active table. Since the naptime is 0 on CI, this might be flaky.
+ERROR:  schema's disk space quota exceeded with name: 2200  (seg0 127.0.0.1:6002 pid=87165)
+-- FIXME: Pause to avoid tjmu1's worker clear the active table. Since there are bugs, this might be flaky.
 SELECT diskquota.pause();
  pause 
 -------

--- a/tests/regress/expected/test_rejectmap_mul_db.out
+++ b/tests/regress/expected/test_rejectmap_mul_db.out
@@ -22,7 +22,14 @@ SELECT diskquota.wait_for_worker_new_epoch();
 
 -- Trigger hard limit to dispatch rejectmap for tjmu1
 INSERT INTO b SELECT generate_series(1, 100000000); -- fail
-ERROR:  schema's disk space quota exceeded with name: 2200  (seg1 127.0.0.1:8003 pid=43782)
+ERROR:  schema's disk space quota exceeded with name: 2200  (seg1 127.0.0.1:6003 pid=3985762)
+-- NOTE: Pause to avoid tjmu1's worker clear the active table. Since the naptime is 0 on CI, this might be flaky.
+SELECT diskquota.pause();
+ pause 
+-------
+ 
+(1 row)
+
 -- The rejectmap should contain entries with dbnode = 0 and dbnode = tjmu1_oid. count = 1
 SELECT COUNT(DISTINCT r.dbnode) FROM (SELECT (diskquota.show_rejectmap()).* FROM gp_dist_random('gp_id')) as r where r.dbnode != 0;
  count 
@@ -52,6 +59,12 @@ SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
  t
+(1 row)
+
+SELECT diskquota.pause();
+ pause 
+-------
+ 
 (1 row)
 
 --\c tjmu1

--- a/tests/regress/sql/test_rejectmap_mul_db.sql
+++ b/tests/regress/sql/test_rejectmap_mul_db.sql
@@ -16,7 +16,7 @@ CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
 SELECT diskquota.wait_for_worker_new_epoch();
 -- Trigger hard limit to dispatch rejectmap for tjmu1
 INSERT INTO b SELECT generate_series(1, 100000000); -- fail
--- NOTE: Pause to avoid tjmu1's worker clear the active table. Since the naptime is 0 on CI, this might be flaky.
+-- FIXME: Pause to avoid tjmu1's worker clear the active table. Since there are bugs, this might be flaky.
 SELECT diskquota.pause();
 -- The rejectmap should contain entries with dbnode = 0 and dbnode = tjmu1_oid. count = 1
 SELECT COUNT(DISTINCT r.dbnode) FROM (SELECT (diskquota.show_rejectmap()).* FROM gp_dist_random('gp_id')) as r where r.dbnode != 0;

--- a/tests/regress/sql/test_rejectmap_mul_db.sql
+++ b/tests/regress/sql/test_rejectmap_mul_db.sql
@@ -16,6 +16,8 @@ CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
 SELECT diskquota.wait_for_worker_new_epoch();
 -- Trigger hard limit to dispatch rejectmap for tjmu1
 INSERT INTO b SELECT generate_series(1, 100000000); -- fail
+-- NOTE: Pause to avoid tjmu1's worker clear the active table. Since the naptime is 0 on CI, this might be flaky.
+SELECT diskquota.pause();
 -- The rejectmap should contain entries with dbnode = 0 and dbnode = tjmu1_oid. count = 1
 SELECT COUNT(DISTINCT r.dbnode) FROM (SELECT (diskquota.show_rejectmap()).* FROM gp_dist_random('gp_id')) as r where r.dbnode != 0;
 
@@ -27,6 +29,7 @@ SELECT diskquota.wait_for_worker_new_epoch();
 -- Trigger hard limit to dispatch rejectmap for tjmu2
 INSERT INTO b SELECT generate_series(1, 100000000); -- fail
 SELECT diskquota.wait_for_worker_new_epoch();
+SELECT diskquota.pause();
 
 --\c tjmu1
 -- The rejectmap should contain entris with dbnode = 0 and dbnode = tjmu1_oid and tjmu2_oid. count = 2


### PR DESCRIPTION
There are some bugs in active tables, but we are not intended to fix them now. So just bring back the pause in the sql to make the test can run success at most time.