### PR TITLE
Skip fault injector case for release build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,7 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
+[cmake/**.cmake]
+indent_style = space
+indent_size = 4
+

--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -231,9 +231,7 @@ plan:
   - get: last_released_diskquota_bin
     resource: #@ conf["res_diskquota_bin"]
 - #@ _build_task(conf)
-#@   if conf["build_type"] != "Release":
 - #@ _test_task(conf)
-#@   end
 - put: #@ conf["res_intermediates_bin"]
   params:
     file: diskquota_artifacts/diskquota.tar.gz

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,12 @@ if (${GP_MAJOR_VERSION} EQUAL 7)
   set(EXPECTED_DIR_SUFFIX "7")
 endif()
 
+set(exclude_fault_injector OFF)
+# GP7 release build doesn't support fault injector.
+if (CMAKE_BUILD_TYPE STREQUAL "Release" AND ${GP_MAJOR_VERSION} EQUAL 7)
+  message(WARNING "Fault injector test cases will be disabled.")
+  set(exclude_fault_injector ON)
+endif()
 
 RegressTarget_Add(regress
     INIT_FILE
@@ -13,6 +19,7 @@ RegressTarget_Add(regress
     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/regress/diskquota_schedule${EXPECTED_DIR_SUFFIX}
+    EXCLUDE_FAULT_INJECT_TEST ${exclude_fault_injector}
     REGRESS_OPTS
     --load-extension=gp_inject_fault
     --load-extension=diskquota_test
@@ -28,6 +35,7 @@ RegressTarget_Add(isolation2
     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/isolation2/isolation2_schedule${EXPECTED_DIR_SUFFIX}
+    EXCLUDE_FAULT_INJECT_TEST ${exclude_fault_injector}
     REGRESS_OPTS
     --load-extension=gp_inject_fault
     --dbname=isolation2test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 set(exclude_fault_injector OFF)
 # GP7 release build doesn't support fault injector.
-if (CMAKE_BUILD_TYPE STREQUAL "Release" AND ${GP_MAJOR_VERSION} EQUAL 7)
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
   message(WARNING "Fault injector test cases will be disabled.")
   set(exclude_fault_injector ON)
 endif()


### PR DESCRIPTION
Due to the release build change for GP7, the fault injector doesn't work
with release build. So, all the tests are temporally disabled for GP7
release.

- Add 'EXCLUDE_FAULT_INJECT_TEST' to Regress.cmake, so it will be smart
  enough to check if there are any fault injector case in the give tests
  set. Ignore them if so.
- Skip the fault injector tests for release build.
- Enable the CI test task for GP7.
