### PR TITLE
Fix bug: bgworker enters infinite loop after receiving notices from QE.

### DIFF
--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -322,9 +322,6 @@ disk_quota_worker_main(Datum main_arg)
 {
 	char *dbname = MyBgworkerEntry->bgw_name;
 
-	MyProcPort                = (Port *)calloc(1, sizeof(Port));
-	MyProcPort->database_name = dbname; /* To show the database in the log */
-
 	/* Disable ORCA to avoid fallback */
 	optimizer = false;
 

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -90,7 +90,8 @@ pg_atomic_uint32 *diskquota_table_size_entry_num;
 
 static DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
 
-#define MIN_SLEEPTIME 100 /* milliseconds */
+#define MIN_SLEEPTIME 100         /* milliseconds */
+#define BGWORKER_LOG_TIME 3600000 /* milliseconds */
 
 /*
  * bgworker handles, in launcher local memory,
@@ -477,10 +478,28 @@ disk_quota_worker_main(Datum main_arg)
 	}
 
 	if (!MyWorkerInfo->dbEntry->inited) update_monitordb_status(MyWorkerInfo->dbEntry->dbid, DB_RUNNING);
-	bool is_gang_destroyed = false;
+
+	bool        is_gang_destroyed   = false;
+	TimestampTz log_start_timestamp = GetCurrentTimestamp();
+	TimestampTz log_end_timestamp;
+	ereport(LOG, (errmsg("[diskquota] disk quota worker process is monitoring database:%s", dbname)));
+
 	while (!got_sigterm)
 	{
 		int rc;
+
+		/*
+		 * The log printed from the bgworker does not contain the database name
+		 * but contains the bgworker's pid. We should print the database name
+		 * every BGWORKER_LOG_TIME to ensure that we can find the database name
+		 * by the bgworker's pid in the log file.
+		 */
+		log_end_timestamp = GetCurrentTimestamp();
+		if (TimestampDifferenceExceeds(log_start_timestamp, log_end_timestamp, BGWORKER_LOG_TIME))
+		{
+			ereport(LOG, (errmsg("[diskquota] disk quota worker process is monitoring database:%s", dbname)));
+			log_start_timestamp = log_end_timestamp;
+		}
 
 		SIMPLE_FAULT_INJECTOR("diskquota_worker_main");
 		if (!diskquota_is_paused())

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -430,6 +430,13 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 	DiskQuotaSetOFCache       *cache           = NULL;
 	DiskQuotaActiveTableEntry *results_entry   = NULL;
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("ereport_warning_from_segment") == FaultInjectorTypeSkip)
+	{
+		ereport(WARNING, (errmsg("[Fault Injector] This is a warning reported from segment")));
+	}
+#endif
+
 	/* Init the container list in the first call and get the results back */
 	if (SRF_IS_FIRSTCALL())
 	{

--- a/tests/isolation2/expected/test_ereport_from_seg.out
+++ b/tests/isolation2/expected/test_ereport_from_seg.out
@@ -1,0 +1,62 @@
+CREATE SCHEMA efs1;
+CREATE
+SELECT diskquota.set_schema_quota('efs1', '1MB');
+ set_schema_quota 
+------------------
+                  
+(1 row)
+CREATE TABLE efs1.t(i int);
+CREATE
+
+INSERT INTO efs1.t SELECT generate_series(1, 10000);
+INSERT 10000
+-- wait for refresh of diskquota and check the quota size
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t                         
+(1 row)
+SELECT schema_name, quota_in_mb, nspsize_in_bytes FROM diskquota.show_fast_schema_quota_view WHERE schema_name = 'efs1';
+ schema_name | quota_in_mb | nspsize_in_bytes 
+-------------+-------------+------------------
+ efs1        | 1           | 688128           
+(1 row)
+
+-- Enable check quota by relfilenode on seg0.
+SELECT gp_inject_fault_infinite('ereport_warning_from_segment', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t                         
+(1 row)
+INSERT INTO efs1.t SELECT generate_series(1, 10000);
+INSERT 10000
+
+-- wait for refresh of diskquota and check whether the quota size changes
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t                         
+(1 row)
+SELECT schema_name, quota_in_mb, nspsize_in_bytes FROM diskquota.show_fast_schema_quota_view WHERE schema_name = 'efs1';
+ schema_name | quota_in_mb | nspsize_in_bytes 
+-------------+-------------+------------------
+ efs1        | 1           | 1081344          
+(1 row)
+
+DROP TABLE efs1.t;
+DROP
+DROP SCHEMA efs1;
+DROP
+
+-- Reset fault injection points set by us at the top of this test.
+SELECT gp_inject_fault_infinite('ereport_warning_from_segment', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)

--- a/tests/isolation2/isolation2_schedule
+++ b/tests/isolation2/isolation2_schedule
@@ -9,5 +9,6 @@ test: test_postmaster_restart
 test: test_worker_timeout
 test: test_per_segment_config
 test: test_relation_cache
+test: test_ereport_from_seg
 test: test_drop_extension
 test: reset_config

--- a/tests/isolation2/sql/test_ereport_from_seg.sql
+++ b/tests/isolation2/sql/test_ereport_from_seg.sql
@@ -1,0 +1,26 @@
+CREATE SCHEMA efs1;
+SELECT diskquota.set_schema_quota('efs1', '1MB');
+CREATE TABLE efs1.t(i int);
+
+INSERT INTO efs1.t SELECT generate_series(1, 10000);
+-- wait for refresh of diskquota and check the quota size
+SELECT diskquota.wait_for_worker_new_epoch();
+SELECT schema_name, quota_in_mb, nspsize_in_bytes FROM diskquota.show_fast_schema_quota_view WHERE schema_name = 'efs1';
+
+-- Enable check quota by relfilenode on seg0.
+SELECT gp_inject_fault_infinite('ereport_warning_from_segment', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;
+
+SELECT diskquota.wait_for_worker_new_epoch();
+INSERT INTO efs1.t SELECT generate_series(1, 10000);
+
+-- wait for refresh of diskquota and check whether the quota size changes
+SELECT diskquota.wait_for_worker_new_epoch();
+SELECT schema_name, quota_in_mb, nspsize_in_bytes FROM diskquota.show_fast_schema_quota_view WHERE schema_name = 'efs1';
+
+DROP TABLE efs1.t;
+DROP SCHEMA efs1;
+
+-- Reset fault injection points set by us at the top of this test.
+SELECT gp_inject_fault_infinite('ereport_warning_from_segment', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content=0;

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -1,6 +1,7 @@
 test: config
 test: test_create_extension
-test: test_readiness_logged
+# This test seems to depend on MyProcPort, let's skip this test firstly.
+# test: test_readiness_logged
 test: test_init_table_size_table
 test: test_relation_size
 test: test_relation_cache

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -1,7 +1,7 @@
 test: config
 test: test_create_extension
 # This test seems to depend on MyProcPort, let's skip this test firstly.
-# test: test_readiness_logged
+test: test_readiness_logged
 test: test_init_table_size_table
 test: test_relation_size
 test: test_relation_cache

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -1,6 +1,5 @@
 test: config
 test: test_create_extension
-# This test seems to depend on MyProcPort, let's skip this test firstly.
 test: test_readiness_logged
 test: test_init_table_size_table
 test: test_relation_size

--- a/tests/regress/expected/test_readiness_logged.out
+++ b/tests/regress/expected/test_readiness_logged.out
@@ -1,5 +1,27 @@
 CREATE DATABASE test_readiness_logged;
 \c test_readiness_logged
+-- Get bgworker's log by database name.
+-- 1. select bgworker pid by database name.
+-- 2. select logmessage by bgworker pid.
+CREATE VIEW logmessage_count_view AS WITH logp AS(
+    SELECT
+        MAX(logpid) as max_logpid
+    FROM
+        gp_toolkit.gp_log_system
+    WHERE
+        position(
+            '[diskquota] start disk quota worker process to monitor database' in logmessage
+        ) > 0
+        AND position(current_database() in logmessage) > 0
+)
+SELECT
+    count(*)
+FROM
+    gp_toolkit.gp_log_system,
+    logp
+WHERE
+    logmessage = '[diskquota] diskquota is not ready'
+    and logpid = max_logpid;
 CREATE TABLE t (i int) DISTRIBUTED BY (i);
 CREATE EXTENSION diskquota;
 WARNING:  [diskquota] diskquota is not ready because current database is not empty
@@ -11,8 +33,8 @@ SELECT diskquota_test.wait('SELECT diskquota_test.check_cur_db_status(''UNREADY'
  t
 (1 row)
 
-SELECT count(*) FROM gp_toolkit.gp_log_database
-WHERE logmessage = '[diskquota] diskquota is not ready';
+-- logmessage count should be 1
+SELECT * FROM logmessage_count_view;
  count 
 -------
      1
@@ -26,11 +48,11 @@ SELECT diskquota_test.wait('SELECT diskquota_test.check_cur_db_status(''UNREADY'
  t
 (1 row)
 
-SELECT count(*) FROM gp_toolkit.gp_log_database
-WHERE logmessage = '[diskquota] diskquota is not ready';
+-- logmessage count should be 1
+SELECT * FROM logmessage_count_view;
  count 
 -------
-     2
+     1
 (1 row)
 
 DROP EXTENSION diskquota;

--- a/tests/regress/expected/test_readiness_logged.out
+++ b/tests/regress/expected/test_readiness_logged.out
@@ -7,7 +7,7 @@ CREATE VIEW logmessage_count_view AS WITH logp AS(
     SELECT
         MAX(logpid) as max_logpid
     FROM
-        gp_toolkit.gp_log_system
+        gp_toolkit.__gp_log_master_ext
     WHERE
         position(
             '[diskquota] start disk quota worker process to monitor database' in logmessage
@@ -17,7 +17,7 @@ CREATE VIEW logmessage_count_view AS WITH logp AS(
 SELECT
     count(*)
 FROM
-    gp_toolkit.gp_log_system,
+    gp_toolkit.__gp_log_master_ext,
     logp
 WHERE
     logmessage = '[diskquota] diskquota is not ready'

--- a/tests/regress/sql/test_readiness_logged.sql
+++ b/tests/regress/sql/test_readiness_logged.sql
@@ -8,7 +8,7 @@ CREATE VIEW logmessage_count_view AS WITH logp AS(
     SELECT
         MAX(logpid) as max_logpid
     FROM
-        gp_toolkit.gp_log_system
+        gp_toolkit.__gp_log_master_ext
     WHERE
         position(
             '[diskquota] start disk quota worker process to monitor database' in logmessage
@@ -18,7 +18,7 @@ CREATE VIEW logmessage_count_view AS WITH logp AS(
 SELECT
     count(*)
 FROM
-    gp_toolkit.gp_log_system,
+    gp_toolkit.__gp_log_master_ext,
     logp
 WHERE
     logmessage = '[diskquota] diskquota is not ready'

--- a/tests/regress/sql/test_readiness_logged.sql
+++ b/tests/regress/sql/test_readiness_logged.sql
@@ -1,21 +1,44 @@
 CREATE DATABASE test_readiness_logged;
 \c test_readiness_logged
 
+-- Get bgworker's log by database name.
+-- 1. select bgworker pid by database name.
+-- 2. select logmessage by bgworker pid.
+CREATE VIEW logmessage_count_view AS WITH logp AS(
+    SELECT
+        MAX(logpid) as max_logpid
+    FROM
+        gp_toolkit.gp_log_system
+    WHERE
+        position(
+            '[diskquota] start disk quota worker process to monitor database' in logmessage
+        ) > 0
+        AND position(current_database() in logmessage) > 0
+)
+SELECT
+    count(*)
+FROM
+    gp_toolkit.gp_log_system,
+    logp
+WHERE
+    logmessage = '[diskquota] diskquota is not ready'
+    and logpid = max_logpid;
+
 CREATE TABLE t (i int) DISTRIBUTED BY (i);
 
 CREATE EXTENSION diskquota;
 CREATE EXTENSION diskquota_test;
 SELECT diskquota_test.wait('SELECT diskquota_test.check_cur_db_status(''UNREADY'');');
 
-SELECT count(*) FROM gp_toolkit.gp_log_database
-WHERE logmessage = '[diskquota] diskquota is not ready';
+-- logmessage count should be 1
+SELECT * FROM logmessage_count_view;
 
 \! gpstop -raf > /dev/null
 \c
 SELECT diskquota_test.wait('SELECT diskquota_test.check_cur_db_status(''UNREADY'');');
 
-SELECT count(*) FROM gp_toolkit.gp_log_database
-WHERE logmessage = '[diskquota] diskquota is not ready';
+-- logmessage count should be 1
+SELECT * FROM logmessage_count_view;
 
 DROP EXTENSION diskquota;
 


### PR DESCRIPTION
### Problem
A dead loop in bgworker will happen following these steps:

- Bgworker executes a query by SPI_execute().
- Some QE's generate notices(for example, the crash of this server) and pass them to QD(bgworker).
- The bgworker wants to forward notices to the client in SPI_execute(). But there's no client for bgworker to establish the pq connection, which will cause a dead loop for bgworker.

The diskquota bgworker will always wait for internal_putbytes(), and can not update the table size.

### Analyze
The problem is caused by initializing MyProcPort in bgworker. In GPDB, if `MyProcPort == NULL`, the notice will never be forwarded to the client.
```
/*
* If MyProcPort is NULL, there is no client, so no need to generate notice.
* One example is that there is no client for a background worker.
*/
if (!res || MyProcPort == NULL) 
return;
```

### Solution
We should not initialize the MyProcPort in bgworker, which will cause the database name to not be automatically added to the log message. In normal, the log printed from the bgworker does not contain the database name but contains the bgworker's pid. In order to facilitate debugging, we should print the database name every BGWORKER_LOG_TIME to ensure that we can find the database name by the bgworker's pid in the log file.

### Test
- The relevant test case is built in `test_primary_failure`.
- `test_readiness_logged` is disabled because this test relies on `MyProcPort`.