### PR TITLE
Resource change for gpdb7 binary

### DIFF
--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -66,7 +66,7 @@ build_type: #@ "Release" if release_build else "Debug"
 #@ def rhel8_gpdb7_conf(release_build=False):
 res_build_image: rocky8-gpdb7-image-build
 res_test_images: [rocky8-gpdb7-image-test, rhel8-gpdb7-image-test]
-res_gpdb_bin: #@ "bin_gpdb7_rhel8" + ("" if release_build else "_debug")
+res_gpdb_bin: #@ "bin_gpdb7_el8" + ("" if release_build else "_debug")
 res_diskquota_bin: bin_diskquota_gpdb7_rhel8
 res_intermediates_bin: #@ inter_bin_name("bin_diskquota_gpdb7_rhel8_intermediates", release_build)
 release_bin: bin_diskquota_gpdb7_rhel8_release

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -158,7 +158,7 @@ resources:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.debug.tar.gz
-- name: bin_gpdb7_rhel8_debug
+- name: bin_gpdb7_el8_debug
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -163,7 +163,7 @@ resources:
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/server-rc-(.*)-rhel8_x86_64.debug.tar.gz
+    regexp: server/published/main/server-rc-(.*)-el8_x86_64.debug.tar.gz
 
 # Latest release candidates, no fault-injector, no assertion:
 # --disable-debug-extensions --disable-tap-tests --enable-ic-proxy
@@ -191,12 +191,12 @@ resources:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/release-candidates/gpdb6/greenplum-db-server-6\.([0-9]|([1-8][0-9])|(9[0-8]))\..*-dev.*-ubuntu18.04.tar.gz
-- name: bin_gpdb7_rhel8
+- name: bin_gpdb7_el8
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/release-candidates/gpdb7/greenplum-db-server-7\.([0-9]|([1-8][0-9])|(9[0-8]))\..*-dev.*-rhel8.tar.gz
+    regexp: server/release-candidates/gpdb7/greenplum-db-server-7\.([0-9]|([1-8][0-9])|(9[0-8]))\..*-dev.*-el8.tar.gz
 
 # Diskquota releases
 - name: bin_diskquota_gpdb6_rhel6

--- a/tests/init_file
+++ b/tests/init_file
@@ -9,6 +9,7 @@ m/WARNING:  \[diskquota\] worker not found for database.*/
 m/WARNING:  \[diskquota\] database .* not found for getting epoch .*/
 m/^NOTICE:  CREATE TABLE will create partition */
 m/^WARNING:  skipping .* cannot calculate this foreign table size.*/
+m/^NOTICE:  resource queue required -- using default resource queue "pg_default"/
 -- end_matchignore
 
 -- start_matchsubs

--- a/tests/regress/expected/test_clean_rejectmap_after_drop.out
+++ b/tests/regress/expected/test_clean_rejectmap_after_drop.out
@@ -4,7 +4,6 @@ CREATE EXTENSION diskquota;
 \! gpconfig -c "diskquota.hard_limit" -v "on" > /dev/null
 \! gpstop -u > /dev/null
 CREATE ROLE r;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT diskquota.set_role_quota('r', '1MB');
  set_role_quota 
 ----------------

--- a/tests/regress/expected/test_ctas_role.out
+++ b/tests/regress/expected/test_ctas_role.out
@@ -4,7 +4,6 @@
 \! gpstop -u > /dev/null
 -- end_ignore
 CREATE ROLE hardlimit_r;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT diskquota.set_role_quota('hardlimit_r', '1MB');
  set_role_quota 
 ----------------

--- a/tests/regress/expected/test_ctas_tablespace_role.out
+++ b/tests/regress/expected/test_ctas_tablespace_role.out
@@ -9,7 +9,6 @@ DROP TABLESPACE IF EXISTS ctas_rolespc;
 NOTICE:  tablespace "ctas_rolespc" does not exist, skipping
 CREATE TABLESPACE ctas_rolespc LOCATION '/tmp/ctas_rolespc';
 CREATE ROLE hardlimit_r;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 GRANT USAGE ON SCHEMA diskquota TO hardlimit_r;
 GRANT ALL ON TABLESPACE ctas_rolespc TO hardlimit_r;
 SELECT diskquota.set_role_tablespace_quota('hardlimit_r', 'ctas_rolespc', '1 MB');

--- a/tests/regress/expected/test_mistake.out
+++ b/tests/regress/expected/test_mistake.out
@@ -14,7 +14,6 @@ ERROR:  disk quota can not be set to 0 MB
 DROP ROLE IF EXISTS rmistake;
 NOTICE:  role "rmistake" does not exist, skipping
 CREATE ROLE rmistake;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select diskquota.set_role_quota('rmistake', '0 MB');
 ERROR:  disk quota can not be set to 0 MB
 -- start_ignore

--- a/tests/regress/expected/test_rename.out
+++ b/tests/regress/expected/test_rename.out
@@ -37,7 +37,6 @@ DROP SCHEMA srs2;
 -- test rename role
 CREATE SCHEMA srr1;
 CREATE ROLE srerole NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT diskquota.set_role_quota('srerole', '1MB');
  set_role_quota 
 ----------------

--- a/tests/regress/expected/test_role.out
+++ b/tests/regress/expected/test_role.out
@@ -2,9 +2,7 @@
 CREATE SCHEMA srole;
 SET search_path TO srole;
 CREATE ROLE u1 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE u2 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE b (t TEXT) DISTRIBUTED BY (t);
 ALTER TABLE b OWNER TO u1;
 CREATE TABLE b2 (t TEXT) DISTRIBUTED BY (t);
@@ -121,7 +119,6 @@ select diskquota.set_role_quota(:'rolname', '-1mb');
 (1 row)
 
 CREATE ROLE "Tn" NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT diskquota.set_role_quota('Tn', '-1 MB'); -- fail
 ERROR:  role "tn" does not exist
 SELECT diskquota.set_role_quota('"tn"', '-1 MB'); -- fail

--- a/tests/regress/expected/test_schema.out
+++ b/tests/regress/expected/test_schema.out
@@ -42,7 +42,6 @@ CREATE SCHEMA badquota;
 DROP ROLE IF EXISTS testbody;
 NOTICE:  role "testbody" does not exist, skipping
 CREATE ROLE testbody;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE badquota.t1(i INT) DISTRIBUTED BY (i);
 ALTER TABLE badquota.t1 OWNER TO testbody;
 INSERT INTO badquota.t1 SELECT generate_series(0, 100000);

--- a/tests/regress/expected/test_tablespace_role.out
+++ b/tests/regress/expected/test_tablespace_role.out
@@ -12,9 +12,7 @@ NOTICE:  role "rolespcu1" does not exist, skipping
 DROP ROLE IF EXISTS rolespcu2;
 NOTICE:  role "rolespcu2" does not exist, skipping
 CREATE ROLE rolespcu1 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE rolespcu2 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE b (t TEXT) TABLESPACE rolespc DISTRIBUTED BY (t);
 CREATE TABLE b2 (t TEXT) TABLESPACE rolespc DISTRIBUTED BY (t);
 ALTER TABLE b2 OWNER TO rolespcu1;
@@ -163,7 +161,6 @@ ERROR:  Can not set disk quota for system owner: sa
 DROP ROLE IF EXISTS "Rolespcu3";
 NOTICE:  role "Rolespcu3" does not exist, skipping
 CREATE ROLE "Rolespcu3" NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 DROP TABLESPACE  IF EXISTS "Rolespc3";
 NOTICE:  tablespace "Rolespc3" does not exist, skipping
 CREATE TABLESPACE "Rolespc3" LOCATION '/tmp/rolespc3';

--- a/tests/regress/expected/test_tablespace_role_perseg.out
+++ b/tests/regress/expected/test_tablespace_role_perseg.out
@@ -12,9 +12,7 @@ NOTICE:  role "rolespc_persegu1" does not exist, skipping
 DROP ROLE IF EXISTS rolespc_persegu2;
 NOTICE:  role "rolespc_persegu2" does not exist, skipping
 CREATE ROLE rolespc_persegu1 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE rolespc_persegu2 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE b (t TEXT) TABLESPACE rolespc_perseg DISTRIBUTED BY (t);
 ALTER TABLE b OWNER TO rolespc_persegu1;
 SELECT diskquota.set_role_tablespace_quota('rolespc_persegu1', 'rolespc_perseg', '1 MB');
@@ -213,7 +211,6 @@ DROP TABLESPACE  IF EXISTS "Rolespc_perseg3";
 NOTICE:  tablespace "Rolespc_perseg3" does not exist, skipping
 CREATE TABLESPACE "Rolespc_perseg3" LOCATION '/tmp/rolespc_perseg3';
 CREATE ROLE "Rolespc_persegu3" NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT diskquota.set_role_tablespace_quota('"Rolespc_persegu3"', '"Rolespc_perseg3"', '-1 MB');
  set_role_tablespace_quota 
 ---------------------------

--- a/tests/regress/expected/test_temp_role.out
+++ b/tests/regress/expected/test_temp_role.out
@@ -1,7 +1,6 @@
 -- Test temp table restrained by role id
 CREATE SCHEMA strole;
 CREATE ROLE u3temp NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET search_path TO strole;
 SELECT diskquota.set_role_quota('u3temp', '1MB');
  set_role_quota 

--- a/upgrade_test/expected/1.0_set_quota.out
+++ b/upgrade_test/expected/1.0_set_quota.out
@@ -18,7 +18,6 @@ insert into s1.a select generate_series(1, 10000000); -- ok, but should fail aft
 -- role quota
 create schema srole;
 create role u1 nologin;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table srole.b (t text) distributed by (t);
 alter table srole.b owner to u1;
 select diskquota.set_role_quota('u1', '1 MB');

--- a/upgrade_test/expected/2.0_set_quota.out
+++ b/upgrade_test/expected/2.0_set_quota.out
@@ -18,7 +18,6 @@ insert into s1.a select generate_series(1, 10000000); -- ok.
 -- role quota
 create schema srole;
 create role u1 nologin;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table srole.b (t text) distributed by (t);
 alter table srole.b owner to u1;
 select diskquota.set_role_quota('u1', '1 MB');
@@ -44,7 +43,6 @@ insert into spcs1.a select generate_series(1,100000); -- ok.
 \! mkdir -p /tmp/rolespc
 create tablespace rolespc location '/tmp/rolespc';
 create role rolespcu1 nologin;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create schema rolespcrole;
 create table rolespcrole.b (t text) tablespace rolespc distributed by (t);
 alter table rolespcrole.b owner to rolespcu1;

--- a/upgrade_test/expected/2.1_set_quota.out
+++ b/upgrade_test/expected/2.1_set_quota.out
@@ -18,7 +18,6 @@ insert into s1.a select generate_series(1, 10000000); -- ok.
 -- role quota
 create schema srole;
 create role u1 nologin;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table srole.b (t text) distributed by (t);
 alter table srole.b owner to u1;
 select diskquota.set_role_quota('u1', '1 MB');
@@ -44,7 +43,6 @@ insert into spcs1.a select generate_series(1,100000); -- ok.
 \! mkdir -p /tmp/rolespc
 create tablespace rolespc location '/tmp/rolespc';
 create role rolespcu1 nologin;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create schema rolespcrole;
 create table rolespcrole.b (t text) tablespace rolespc distributed by (t);
 alter table rolespcrole.b owner to rolespcu1;

--- a/upgrade_test/expected/2.2_set_quota.out
+++ b/upgrade_test/expected/2.2_set_quota.out
@@ -18,7 +18,6 @@ insert into s1.a select generate_series(1, 10000000); -- ok.
 -- role quota
 create schema srole;
 create role u1 nologin;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table srole.b (t text) distributed by (t);
 alter table srole.b owner to u1;
 select diskquota.set_role_quota('u1', '1 MB');
@@ -44,7 +43,6 @@ insert into spcs1.a select generate_series(1,100000); -- ok.
 \! mkdir -p /tmp/rolespc
 create tablespace rolespc location '/tmp/rolespc';
 create role rolespcu1 nologin;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create schema rolespcrole;
 create table rolespcrole.b (t text) tablespace rolespc distributed by (t);
 alter table rolespcrole.b owner to rolespcu1;

--- a/upgrade_test/init_file
+++ b/upgrade_test/init_file
@@ -3,6 +3,7 @@
 -- Individual tests can contain additional patterns specific to the test.
 
 -- start_matchignore
+m/^NOTICE:  resource queue required -- using default resource queue "pg_default"/
 -- end_matchignore
 -- start_matchsubs
 m/diskquota.c:\d+\)/

--- a/upgrade_test/init_file
+++ b/upgrade_test/init_file
@@ -3,12 +3,11 @@
 -- Individual tests can contain additional patterns specific to the test.
 
 -- start_matchignore
+m/^NOTICE:  resource queue required -- using default resource queue "pg_default"/
 -- end_matchignore
 -- start_matchsubs
 m/diskquota.c:\d+\)/
 s/diskquota.c:\d+\)/diskquota.c:xxx/
 m/diskquota_utility.c:\d+\)/
 s/diskquota_utility.c:\d+\)/diskquota_utility.c:xxx/
-m/^NOTICE:  resource queue required -- using default resource queue "pg_default"/
-s/^NOTICE:  resource queue required -- using default resource queue "pg_default"//
 -- end_matchsubs

--- a/upgrade_test/init_file
+++ b/upgrade_test/init_file
@@ -3,11 +3,12 @@
 -- Individual tests can contain additional patterns specific to the test.
 
 -- start_matchignore
-m/^NOTICE:  resource queue required -- using default resource queue "pg_default"/
 -- end_matchignore
 -- start_matchsubs
 m/diskquota.c:\d+\)/
 s/diskquota.c:\d+\)/diskquota.c:xxx/
 m/diskquota_utility.c:\d+\)/
 s/diskquota_utility.c:\d+\)/diskquota_utility.c:xxx/
+m/^NOTICE:  resource queue required -- using default resource queue "pg_default"/
+s/^NOTICE:  resource queue required -- using default resource queue "pg_default"//
 -- end_matchsubs


### PR DESCRIPTION
```
NOTICE:  resource queue required -- using default resource queue "pg_default"
```
has been removed in gpdb7 82851a0b85 . Ignore it in the tests.


