### PR TITLE
Skip refresh_disk_quota_model() when receiving a signal

### DIFF
--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -540,9 +540,9 @@ disk_quota_worker_main(Datum main_arg)
 			MemoryAccounting_Reset();
 #endif /* GP_VERSION_NUM */
 
-			loop_start_timestamp = GetCurrentTimestamp();
-			sleep_time           = diskquota_naptime * 1000;
+			sleep_time = diskquota_naptime * 1000;
 		}
+		loop_start_timestamp = GetCurrentTimestamp();
 
 		if (DiskquotaLauncherShmem->isDynamicWorker)
 		{

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -510,7 +510,10 @@ disk_quota_worker_main(Datum main_arg)
 		}
 
 		/*
-		 * diskquota model is refreshed every naptime. If the latch is set ahead of time,
+		 * If the bgworker receives a signal, the latch will be set ahead of the diskquota.naptime.
+		 * To avoid too frequent diskquota refresh caused by receiving the signal, we use
+		 * loop_start_timestamp and loop_end_timestamp to maintain the elapsed time since the last
+		 * diskquota refresh. If the latch is set ahead of diskquota.naptime,
 		 * refresh_disk_quota_model() should be skipped.
 		 */
 		loop_end_timestamp = GetCurrentTimestamp();


### PR DESCRIPTION
## Problem

When with often signals receiving diskquota may call refresh_disk_quota_model frequently than diskquota_naptime.

## Solution
When receiving a signal, the time waiting for latch `sleep_time` will be smaller than `diskquota_naptime`. We should skip refresh_disk_quota_model() when `sleep_time < diskquota_naptime`.