### PR TITLE
Ignore some hint/notice for GPDB7

### DIFF
--- a/tests/init_file
+++ b/tests/init_file
@@ -10,6 +10,8 @@ m/WARNING:  \[diskquota\] database .* not found for getting epoch .*/
 m/^NOTICE:  CREATE TABLE will create partition */
 m/^WARNING:  skipping .* cannot calculate this foreign table size.*/
 m/^NOTICE:  resource queue required -- using default resource queue "pg_default"/
+m/NOTICE:  One or more columns in the following table\(s\) do not have statistics: /
+m/HINT:  For non-partitioned tables, run analyze .+\. For partitioned tables, run analyze rootpartition .+\. See log for columns missing statistics\./
 -- end_matchignore
 
 -- start_matchsubs


### PR DESCRIPTION
Some hint/notice causes the partition table test flaky. We just need to ignore them.