### PR TITLE
Enable continuous upgrade.

### DIFF
--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -178,14 +178,14 @@ _PG_init(void)
 	{
 		/*
 		 * To support the continuous upgrade/downgrade, we should skip the library
-		 * check in _PG_init() during upgrade/downgrade. If the POSTGRES backend 
+		 * check in _PG_init() during upgrade/downgrade. If the POSTGRES backend
 		 * process is in normal mode and meets one of the following conditions, we
 		 * skip the library check:
 		 * - The backend is not a QD. We only need to check the library on QD.
 		 * - The current command is `ALTER EXTENSION`.
 		 */
 		if (IsNormalProcessingMode() &&
-		    (Gp_role != GP_ROLE_DISPATCH || (ActivePortal && strcmp(ActivePortal->commandTag, "ALTER EXTENSION") == 0)))
+		    (Gp_role != GP_ROLE_DISPATCH || (ActivePortal && ActivePortal->sourceTag == T_AlterExtensionStmt)))
 			return;
 		ereport(ERROR, (errmsg("[diskquota] booting " DISKQUOTA_VERSION ", but " DISKQUOTA_BINARY_NAME
 		                       " not in shared_preload_libraries. abort.")));

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -184,9 +184,20 @@ _PG_init(void)
 		 * - The backend is not a QD. We only need to check the library on QD.
 		 * - The current command is `ALTER EXTENSION`.
 		 */
-		if (IsNormalProcessingMode() &&
-		    (Gp_role != GP_ROLE_DISPATCH || (ActivePortal && ActivePortal->sourceTag == T_AlterExtensionStmt)))
-			return;
+		if (IsNormalProcessingMode())
+		{
+			if (Gp_role != GP_ROLE_DISPATCH)
+			{
+				ereport(WARNING, (errmsg("[diskquota] booting " DISKQUOTA_VERSION ", but " DISKQUOTA_BINARY_NAME
+				                         " not in shared_preload_libraries.")));
+				return;
+			}
+			if (ActivePortal && ActivePortal->sourceTag == T_AlterExtensionStmt)
+			{
+				ereport(LOG, (errmsg("[diskquota] altering diskquota version to " DISKQUOTA_VERSION ".")));
+				return;
+			}
+		}
 		ereport(ERROR, (errmsg("[diskquota] booting " DISKQUOTA_VERSION ", but " DISKQUOTA_BINARY_NAME
 		                       " not in shared_preload_libraries. abort.")));
 	}

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -42,6 +42,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/timestamp.h"
+#include "tcop/pquery.h"
 
 PG_MODULE_MAGIC;
 
@@ -175,6 +176,17 @@ _PG_init(void)
 	/* diskquota.so must be in shared_preload_libraries to init SHM. */
 	if (!process_shared_preload_libraries_in_progress)
 	{
+		/*
+		 * To support the continuous upgrade/downgrade, we should skip the library
+		 * check in _PG_init() during upgrade/downgrade. If the POSTGRES backend 
+		 * process is in normal mode and meets one of the following conditions, we
+		 * skip the library check:
+		 * - The backend is not a QD. We only need to check the library on QD.
+		 * - The current command is `ALTER EXTENSION`.
+		 */
+		if (IsNormalProcessingMode() &&
+		    (Gp_role != GP_ROLE_DISPATCH || (ActivePortal && strcmp(ActivePortal->commandTag, "ALTER EXTENSION") == 0)))
+			return;
 		ereport(ERROR, (errmsg("[diskquota] booting " DISKQUOTA_VERSION ", but " DISKQUOTA_BINARY_NAME
 		                       " not in shared_preload_libraries. abort.")));
 	}


### PR DESCRIPTION
To achieve upgrading directly from 2.0 to 2.2, we should do the following things:
- cherry-pick this PR in diskquota-2.0, diskquota-2.1 and diskquota-2.2.
- set the shared_preload_libraries as `diskquota-2.2`: `gpconfig -c shared_preload_libraries -v 'diskquota-2.2'`
- restart cluster: `gpstop -ar`
- execute the following SQLs:
```
ALTER extension diskquota update to '2.2';
```