### PR TITLE
Fix upgrade version check

### DIFF
--- a/upgrade_test/CMakeLists.txt
+++ b/upgrade_test/CMakeLists.txt
@@ -30,21 +30,24 @@ regresstarget_add(
   REGRESS_OPTS
   --dbname=contrib_regression)
 
-exec_program(
-  git ${CMAKE_SOURCE_DIR} ARGS
-  tag | sort --version-sort -r | head -n 1
+execute_process(
+  COMMAND git describe --tags --abbrev=0
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE latest_tag
+  OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 # check whether DDL file (*.sql) is modified
-file(GLOB ddl_files ${CMAKE_SOURCE_DIR}/*.sql)
+file(GLOB ddl_files ${DISKQUOTA_DDL_DIR}/*.sql)
 foreach(ddl IN LISTS ddl_files)
   cmake_path(GET ddl FILENAME ddl)
-  exec_program(
-    git ${CMAKE_SOURCE_DIR} ARGS
-    diff ${latest_tag} --exit-code ${ddl}
-    OUTPUT_VARIABLE NULL
-    RETURN_VALUE "${ddl}_modified")
+  execute_process(
+    COMMAND
+    git diff ${latest_tag} --exit-code ${ddl}
+    OUTPUT_QUIET
+    WORKING_DIRECTORY ${DISKQUOTA_DDL_DIR}
+    RESULT_VARIABLE "${ddl}_modified"
+  )
 
   if("${${ddl}_modified}")
     message(


### PR DESCRIPTION
- Because of 97f1f9b46b, the sql file directory has been changed. The
  sql version check wouldn't work since it cannot find the sql files
  anymore. Change it to the correct ddl directory.
- 'exec_program' is deprecated, use 'execute_process' instead.
- 'git tag | sort' returns the latest version among all branches, but
  not the closest tag to the current commit. Use 'git describe --tags'
  instead. So the upgrade version check will work for the 2.1.x patch
  release.
