### PR TITLE
Add alter extension upgrade test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,20 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Distro.cmake)
 if(DEFINED DISKQUOTA_LAST_RELEASE_PATH)
   message(STATUS "Copy pervious installer from ${DISKQUOTA_LAST_RELEASE_PATH}")
   file(ARCHIVE_EXTRACT INPUT ${DISKQUOTA_LAST_RELEASE_PATH} PATTERNS "*.so")
-  file(GLOB DISKQUOTA_PREVIOUS_LIBRARY
+  file(GLOB so_files_list
        "${CMAKE_BINARY_DIR}/lib/postgresql/*.so")
+
+  foreach(so_path IN LISTS so_files_list)
+    get_filename_component(so_name ${so_path} NAME_WLE)
+    string(REPLACE "diskquota-" "" so_ver ${so_name})
+    # Install the previous so files. Those so files have versions less than current version.
+    # diskqutoa.so doesn't have version string in the file name. It belongs to 1.x release.
+    if((${so_ver} STREQUAL "diskquota") OR
+      ${so_ver} VERSION_LESS ${DISKQUOTA_MAJOR_VERSION}.${DISKQUOTA_MINOR_VERSION})
+      list(APPEND DISKQUOTA_PREVIOUS_LIBRARY ${so_path})
+    endif()
+  endforeach()
+
   install(PROGRAMS ${DISKQUOTA_PREVIOUS_LIBRARY} DESTINATION "lib/postgresql/")
 
   get_filename_component(

--- a/concourse/scripts/test_diskquota.sh
+++ b/concourse/scripts/test_diskquota.sh
@@ -41,6 +41,8 @@ function _main() {
     # Run upgrade test (with standby master)
     time cmake --build . --target upgradecheck
     popd
+
+    time /home/gpadmin/diskquota_src/upgrade_test/alter_test.sh
 }
 
 _main

--- a/upgrade_test/alter_test.sh
+++ b/upgrade_test/alter_test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Test if all the previous diskquota minor versions can be directly upgraded
+# to the current version.
+
+set -ex
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+SRC_DIR="$(cd "$(dirname "${SCRIPT_PATH}")"/.. >/dev/null 2>&1 && pwd)"
+
+# Versions like major.minor
+CUR_VERSION=$(cut --delimiter="." --fields=1-2 "${SRC_DIR}/VERSION")
+ALL_VERSIONS=$(git tag | cut --delimiter="." --fields=1-2 | sort -V -u)
+VERSIONS_TO_TEST=()
+
+test_alter_from() {
+    local from_ver=$1
+    local to_ver=$CUR_VERSION
+
+    gpconfig -c shared_preload_libraries -v ""
+    gpstop -rai
+    dropdb diskquota --if-exists
+    dropdb diskquota_alter_test --if-exists
+    createdb diskquota
+
+    local so_name="diskquota"
+    if [ "${from_ver}" != "1.0" ];then
+        so_name="diskquota-${from_ver}"
+    fi
+
+    gpconfig -c shared_preload_libraries -v "${so_name}"
+    gpstop -rai
+
+    createdb diskquota_alter_test
+
+    # Test if the extension and be upgraded directly
+    psql -d diskquota_alter_test -c "CREATE EXTENSION diskquota version '${from_ver}'"
+    psql -d diskquota_alter_test -c "ALTER EXTENSION diskquota update to '${to_ver}'"
+    psql -d diskquota_alter_test -c "DROP EXTENSION diskquota"
+}
+
+# Find all minor versions before current one
+while IFS= read -r ver; do
+    if [ "${ver}" = "${CUR_VERSION}" ]; then
+        break
+    fi
+    if [ "${ver}" = "0.8" ]; then
+        continue
+    fi
+    VERSIONS_TO_TEST+=("${ver}")
+done <<< "$ALL_VERSIONS"
+
+for from_ver in "${VERSIONS_TO_TEST[@]}"; do
+    test_alter_from "${from_ver}"
+done


### PR DESCRIPTION
- By #340, diskquota should be able to upgraded directly from any previous
  version. A script is added to test this.
- Modify the cmakefile so before installing/packaing, only previous so
  files will copied. This would help us to make patch release for
  2.0/2.1.
