### PR TITLE
Remove gp7 from pipeline

### DIFF
--- a/concourse/pipeline/commit.yml
+++ b/concourse/pipeline/commit.yml
@@ -19,7 +19,7 @@
 #@   centos7_gpdb6_conf(),
 #@   rhel8_gpdb6_conf(),
 #@   ubuntu18_gpdb6_conf(),
-#@   rhel8_gpdb7_conf(),
+#! #@   rhel8_gpdb7_conf(),
 #@ ]
 jobs:
 #@ param = {

--- a/concourse/pipeline/pr.yml
+++ b/concourse/pipeline/pr.yml
@@ -22,7 +22,7 @@
 #@   centos7_gpdb6_conf(),
 #@   rhel8_gpdb6_conf(),
 #@   ubuntu18_gpdb6_conf(),
-#@   rhel8_gpdb7_conf(),
+#! #@   rhel8_gpdb7_conf(),
 #@ ]
 jobs:
 #@ param = {

--- a/concourse/pipeline/release.yml
+++ b/concourse/pipeline/release.yml
@@ -20,7 +20,7 @@
 #@   centos7_gpdb6_conf(release_build=True),
 #@   rhel8_gpdb6_conf(release_build=True),
 #@   ubuntu18_gpdb6_conf(release_build=True),
-#@   rhel8_gpdb7_conf(release_build=True)
+#! #@   rhel8_gpdb7_conf(release_build=True)
 #@ ]
 jobs:
 #@ param = {


### PR DESCRIPTION
After creating extension, the `diskquota.state` is always `unready` due to the change https://github.com/greenplum-db/gpdb/pull/15239. It makes the test timeout. We disable the job of gp7 in release/pr/merge pipeline until the problem is fixed.