### PR TITLE
Error handling for disqkuota worker startup stage.

### DIFF
--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -215,8 +215,9 @@ struct DiskquotaDBEntry
 	TimestampTz last_run_time;
 	int16       cost; // ms
 
-	bool inited; // this entry is inited, will set to true after the worker finish the frist run.
-	bool in_use; // this slot is in using. AKA dbid != 0
+	bool inited;    // this entry is inited, will set to true after the worker finish the frist run.
+	bool in_use;    // this slot is in using. AKA dbid != 0
+	bool corrupted; // consider this entry as invalid to start the worker on
 
 	TimestampTz last_log_time; // the last time log current database info.
 };
@@ -251,7 +252,7 @@ extern void invalidate_database_rejectmap(Oid dbid);
 /* quota model interface*/
 extern void init_disk_quota_shmem(void);
 extern void init_disk_quota_model(uint32 id);
-extern void refresh_disk_quota_model(bool force);
+extern void refresh_disk_quota_model(DiskquotaDBEntry *dbEntry);
 extern bool check_diskquota_state_is_ready(void);
 extern bool quota_check_common(Oid reloid, RelFileNode *relfilenode);
 


### PR DESCRIPTION
During diskquota worker's first run the initial set of active tables with their sizes is being loaded from `diskquota.table_size` table in order to warm up diskquota rejectmap and other shared memory objects. If an error occurs during this initialization process, the error will be ignored in PG_CATCH() block. Such ignorance can be potentially harmful and can lead to undesired behaviour of the whole extension. For example, if an error ocurs during initialization, `local_active_table_stat_map` will not be filled properly. And at the next loop iteration, tables, that are not in acitive table list will be marked as irrelevant and to be deleted both from `table_size_map` and `table_size` table in `flush_to_table_size` function. This situation produces extra perfomance load, which is not guaranteed to be safe.

This commit proposes the handling of the initialization errors, which occur during worker's first run. In the `DiskquotaDBEntry` structure the bool variable `corrupted` is added in order to indicate, that the worker wasn't able to initialize itself on given database. And `DiskquotaDBEntry` also is now passed to `refresh_disk_quota_model` function from worker main loop, because one need to change the state of dbEntry. The state is changed when the `refresh_disk_quota_usage` function catches an error, which occured during the initialization step, in PG_CATCH() block. And after the error is catched, the `corrupted` flag is set in given dbEntry, and then the error is rethrown. This leads to worker process termination. The launcher will not be able to start it again, because added flag is set in the database structure, and this flag is being checked inside the `disk_quota_launcher_main` function. The flag can be reseted by calling `resetBackgroundWorkerCorruption` function, which is currently called in SIGHUP handler.

This patch does not contain a proper test because the author couldn't find optimal architecture for the test. The behaviour of the patch can be testes either via putting fault injector or calling an error, for example, in the  [gp_fetch_active_tables](https://github.com/greenplum-db/diskquota/blob/f9e940fbaf3dbec7f156b5c7f2c3b3a384c4dd0b/src/gp_activetable.c#L381) function. The presence of diskquota bgworker process can be monitored via `ps` or `pg_stat_activity` for given database.