### PR TITLE
fix creating extension with global option appendonly=true.

### DIFF
--- a/control/ddl/diskquota--2.3.sql
+++ b/control/ddl/diskquota--2.3.sql
@@ -11,7 +11,7 @@ CREATE TABLE diskquota.quota_config(
 	quotalimitMB int8,
 	segratio float4 DEFAULT 0,
 	PRIMARY KEY(targetOid, quotatype)
-) DISTRIBUTED BY (targetOid, quotatype);
+) WITH (appendonly=false) DISTRIBUTED BY (targetOid, quotatype);
 
 CREATE TABLE diskquota.target (
 	rowId serial,
@@ -19,19 +19,19 @@ CREATE TABLE diskquota.target (
 	primaryOid oid,
 	tablespaceOid oid, --REFERENCES pg_tablespace.oid,
 	PRIMARY KEY (primaryOid, tablespaceOid, quotatype)
-);
+) WITH (appendonly=false);
 
 CREATE TABLE diskquota.table_size(
 	tableid oid,
 	size bigint,
 	segid smallint,
 	PRIMARY KEY(tableid, segid)
-) DISTRIBUTED BY (tableid, segid);
+) WITH (appendonly=false) DISTRIBUTED BY (tableid, segid);
 
 CREATE TABLE diskquota.state(
 	state int,
 	PRIMARY KEY(state)
-) DISTRIBUTED BY (state);
+) WITH (appendonly=false) DISTRIBUTED BY (state);
 
 -- diskquota.quota_config AND diskquota.target is dump-able, other table can be generate on fly
 SELECT pg_catalog.pg_extension_config_dump('diskquota.quota_config', '');


### PR DESCRIPTION
# Problem
All tables in diskquota use primary keys. Unique index tables are created for primary keys. Unique index tables can not be created for tables with the option appendonly=true. This issue only occurs in gp6 since `set gp_default_storage_options='appendonly=true';` is disabled in gp7.

# Steps to reproduce.
1) build diskquota extension
2) append it to shared_preload_libraries
3) create diskquota database
4) restart cluster
5) execute in the postgres (on any other) database:
```
set gp_default_storage_options='appendonly=true';
create extension diskquota;
```
# Result
```
ERROR:  append-only tables do not support unique indexes
```

# Solution
Add appendonly=false to each table with the primary key.

This PR is refactored from #341 

Co-authored-by: Evgeniy Ratkov <e.ratkov@arenadata.io>