### PR TITLE
Fix compilation issue caused by GP7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,10 @@ set_target_properties(
              C_STANDARD 99
              LINKER_LANGUAGE "C")
 
+if (${GP_MAJOR_VERSION} STRGREATER_EQUAL "7")
+  TARGET_LINK_LIBRARIES(diskquota ${PG_LIB_DIR}/libpq.so)
+endif()
+
 # packing part, move to a separate file if this part is too large
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Distro.cmake)
 

--- a/concourse/pipeline/commit.yml
+++ b/concourse/pipeline/commit.yml
@@ -19,7 +19,7 @@
 #@   centos7_gpdb6_conf(),
 #@   rhel8_gpdb6_conf(),
 #@   ubuntu18_gpdb6_conf(),
-#! #@   rhel8_gpdb7_conf(),
+#@   rhel8_gpdb7_conf(),
 #@ ]
 jobs:
 #@ param = {

--- a/concourse/pipeline/pr.yml
+++ b/concourse/pipeline/pr.yml
@@ -22,7 +22,7 @@
 #@   centos7_gpdb6_conf(),
 #@   rhel8_gpdb6_conf(),
 #@   ubuntu18_gpdb6_conf(),
-#! #@   rhel8_gpdb7_conf(),
+#@   rhel8_gpdb7_conf(),
 #@ ]
 jobs:
 #@ param = {


### PR DESCRIPTION
- Fix the compilation issue caused by GP7. `libpq.so` needs to be linked. See https://github.com/greenplum-db/gpdb/pull/16234.
- Add GP7 jobs back to the pipeline.