### PR TITLE
Add error report to diskquota.status().

### DIFF
--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -17,6 +17,7 @@
  */
 #include "diskquota.h"
 #include "gp_activetable.h"
+#include "diskquota_error.h"
 
 #include "postgres.h"
 
@@ -1667,6 +1668,10 @@ diskquota_status(PG_FUNCTION_ARGS)
 	typedef struct Context
 	{
 		int index;
+		int error_indx;
+		int error_num;
+
+		BGworkerErrorEntry errors[BGWORKER_ERROR_MAP_SIZE];
 	} Context;
 
 	typedef struct FeatureStatus
@@ -1697,7 +1702,14 @@ diskquota_status(PG_FUNCTION_ARGS)
 			funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 			Context *context    = (Context *)palloc(sizeof(Context));
 			context->index      = 0;
+			context->error_indx = 0;
+			context->error_num  = diskquota_status_get_error_num();
 			funcctx->user_fctx  = context;
+
+			DiskQuotaBGworkerError *errors;
+			errors = diskquota_status_error_map_to_array();
+			memcpy(&context->errors, errors, sizeof(DiskQuotaBGworkerError) * context->error_num);
+			pfree(errors);
 		}
 		MemoryContextSwitchTo(oldcontext);
 	}
@@ -1707,6 +1719,18 @@ diskquota_status(PG_FUNCTION_ARGS)
 
 	if (context->index >= sizeof(fs) / sizeof(FeatureStatus))
 	{
+		if (context->error_indx < context->error_num)
+		{
+			DiskQuotaBGworkerError error    = context->errors[context->error_indx++].error;
+			bool                   nulls[2] = {false, false};
+			Datum                  v[2]     = {
+                    DirectFunctionCall1(textin, CStringGetDatum(diskquota_status_error_to_string(error))),
+                    DirectFunctionCall1(textin, CStringGetDatum(diskquota_status_error_hint(error))),
+            };
+			ReturnSetInfo *rsi   = (ReturnSetInfo *)fcinfo->resultinfo;
+			HeapTuple      tuple = heap_form_tuple(rsi->expectedDesc, v, nulls);
+			SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+		}
 		SRF_RETURN_DONE(funcctx);
 	}
 

--- a/src/diskquota_error.c
+++ b/src/diskquota_error.c
@@ -1,0 +1,86 @@
+/* -------------------------------------------------------------------------
+ *
+ * diskquota_error.c
+ *
+ * Copyright (c) 2023-Present VMware, Inc. or its affiliates
+ *
+ * IDENTIFICATION
+ *		diskquota/diskquota_error.c
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#include "diskquota.h"
+#include "diskquota_error.h"
+
+/* error map in bgworker */
+HTAB *diskquota_bgworker_error_map;
+
+void
+init_bgworker_error_map(uint32 id)
+{
+	StringInfoData str;
+	HASHCTL        hash_ctl;
+
+	initStringInfo(&str);
+	appendStringInfo(&str, "BGworkerErrorMap_%u", id);
+	memset(&hash_ctl, 0, sizeof(hash_ctl));
+	hash_ctl.keysize             = sizeof(BGworkerErrorEntry);
+	hash_ctl.entrysize           = sizeof(BGworkerErrorEntry);
+	diskquota_bgworker_error_map = DiskquotaShmemInitHash(str.data, BGWORKER_ERROR_MAP_SIZE, BGWORKER_ERROR_MAP_SIZE,
+	                                                      &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
+}
+
+void
+diskquota_status_push_error(DiskQuotaBGworkerError error)
+{
+	hash_search(diskquota_bgworker_error_map, &error, HASH_ENTER, NULL);
+}
+
+int
+diskquota_status_get_error_num(void)
+{
+	return hash_get_num_entries(diskquota_bgworker_error_map);
+}
+
+DiskQuotaBGworkerError *
+diskquota_status_error_map_to_array(void)
+{
+	DiskQuotaBGworkerError *array;
+	HASH_SEQ_STATUS         iter;
+	BGworkerErrorEntry     *entry;
+	int                     idx = 0;
+
+	array = palloc0(diskquota_status_get_error_num() * sizeof(DiskQuotaBGworkerError));
+	hash_seq_init(&iter, diskquota_bgworker_error_map);
+	while ((entry = hash_seq_search(&iter)) != NULL) memcpy(&array[idx++], entry, sizeof(BGworkerErrorEntry));
+
+	return array;
+}
+
+const char *
+diskquota_status_error_to_string(DiskQuotaBGworkerError error)
+{
+	switch (error)
+	{
+		case UPDATE_TABLE_SIZE_ERROR:
+			return "UPDATE_TABLE_SIZE_ERROR";
+		default:
+			break;
+	}
+	return "";
+}
+
+const char *
+diskquota_status_error_hint(DiskQuotaBGworkerError error)
+{
+	switch (error)
+	{
+		case UPDATE_TABLE_SIZE_ERROR:
+			return "Table size update failed, please run 'select diskquota.init_table_size_table()' to initialize "
+			       "diskquota.";
+		default:
+			break;
+	}
+	return "";
+}

--- a/src/diskquota_error.h
+++ b/src/diskquota_error.h
@@ -1,0 +1,36 @@
+/* -------------------------------------------------------------------------
+ *
+ * diskquota_error.h
+ *
+ * Copyright (c) 2023-Present VMware, Inc. or its affiliates
+ *
+ * IDENTIFICATION
+ *		diskquota/diskquota_error.h
+ *
+ * -------------------------------------------------------------------------
+ */
+#ifndef DISKQUOTA_ERROR_H
+#define DISKQUOTA_ERROR_H
+
+#include "c.h"
+
+#define BGWORKER_ERROR_MAP_SIZE 1024
+
+typedef enum
+{
+	UPDATE_TABLE_SIZE_ERROR
+} DiskQuotaBGworkerError;
+
+typedef struct BGworkerErrorEntry
+{
+	DiskQuotaBGworkerError error;
+} BGworkerErrorEntry;
+
+extern void                    init_bgworker_error_map(uint32 id);
+extern int                     diskquota_status_get_error_num(void);
+extern void                    diskquota_status_push_error(DiskQuotaBGworkerError error);
+extern const char             *diskquota_status_error_to_string(DiskQuotaBGworkerError error);
+extern const char             *diskquota_status_error_hint(DiskQuotaBGworkerError error);
+extern DiskQuotaBGworkerError *diskquota_status_error_map_to_array(void);
+
+#endif

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -17,6 +17,7 @@
 #include "diskquota.h"
 #include "gp_activetable.h"
 #include "relation_cache.h"
+#include "diskquota_error.h"
 
 #include "postgres.h"
 
@@ -562,6 +563,7 @@ diskquota_worker_shmem_size()
 	size = hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES / diskquota_max_monitored_databases + 100,
 	                          sizeof(TableSizeEntry));
 	size = add_size(size, hash_estimate_size(MAX_LOCAL_DISK_QUOTA_REJECT_ENTRIES, sizeof(LocalRejectMapEntry)));
+	size = add_size(size, hash_estimate_size(BGWORKER_ERROR_MAP_SIZE, sizeof(BGworkerErrorEntry)));
 	return size;
 }
 
@@ -708,6 +710,8 @@ vacuum_disk_quota_model(uint32 id)
 		}
 	}
 	pfree(str.data);
+
+	init_bgworker_error_map(id);
 }
 
 /*
@@ -901,6 +905,7 @@ refresh_disk_quota_usage(bool is_init)
 		HOLD_INTERRUPTS();
 		EmitErrorReport();
 		FlushErrorState();
+		diskquota_status_push_error(UPDATE_TABLE_SIZE_ERROR);
 		ret = false;
 		/* Now we can allow interrupts again */
 		RESUME_INTERRUPTS();


### PR DESCRIPTION
This PR adds error reports to diskquota.status(). Users can check whether some errors happen in the bgworker by diskquota.status() UDF.