### PR TITLE
Rename diskquota.max_quotas to diskquota.max_quota_probe

### DIFF
--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -77,7 +77,7 @@ bool diskquota_hardlimit               = false;
 int  diskquota_max_workers             = 10;
 int  diskquota_max_table_segments      = 0;
 int  diskquota_max_monitored_databases = 0;
-int  diskquota_max_quotas              = 0;
+int  diskquota_max_quota_probes              = 0;
 
 DiskQuotaLocks       diskquota_locks;
 ExtensionDDLMessage *extension_ddl_message = NULL;
@@ -411,7 +411,7 @@ define_guc_variables(void)
 	                        INT_MAX, PGC_POSTMASTER, 0, NULL, NULL, NULL);
 	DefineCustomIntVariable("diskquota.max_monitored_databases", "Max number of database on the cluster.", NULL,
 	                        &diskquota_max_monitored_databases, 50, 1, 1024, PGC_POSTMASTER, 0, NULL, NULL, NULL);
-	DefineCustomIntVariable("diskquota.max_quotas", "Max number of quotas on the cluster.", NULL, &diskquota_max_quotas,
+	DefineCustomIntVariable("diskquota.max_quota_probes", "Max number of quotas on the cluster.", NULL, &diskquota_max_quota_probes,
 	                        1024 * 1024, 1024 * INIT_QUOTA_MAP_ENTRIES, INT_MAX, PGC_POSTMASTER, 0, NULL, NULL, NULL);
 }
 

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -77,7 +77,7 @@ bool diskquota_hardlimit               = false;
 int  diskquota_max_workers             = 10;
 int  diskquota_max_table_segments      = 0;
 int  diskquota_max_monitored_databases = 0;
-int  diskquota_max_quota_probes              = 0;
+int  diskquota_max_quota_probes        = 0;
 
 DiskQuotaLocks       diskquota_locks;
 ExtensionDDLMessage *extension_ddl_message = NULL;
@@ -411,8 +411,9 @@ define_guc_variables(void)
 	                        INT_MAX, PGC_POSTMASTER, 0, NULL, NULL, NULL);
 	DefineCustomIntVariable("diskquota.max_monitored_databases", "Max number of database on the cluster.", NULL,
 	                        &diskquota_max_monitored_databases, 50, 1, 1024, PGC_POSTMASTER, 0, NULL, NULL, NULL);
-	DefineCustomIntVariable("diskquota.max_quota_probes", "Max number of quotas on the cluster.", NULL, &diskquota_max_quota_probes,
-	                        1024 * 1024, 1024 * INIT_QUOTA_MAP_ENTRIES, INT_MAX, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+	DefineCustomIntVariable("diskquota.max_quota_probes", "Max number of quotas on the cluster.", NULL,
+	                        &diskquota_max_quota_probes, 1024 * 1024, 1024 * INIT_QUOTA_MAP_ENTRIES, INT_MAX,
+	                        PGC_POSTMASTER, 0, NULL, NULL, NULL);
 }
 
 /* ---- Functions for disk quota worker process ---- */

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -42,7 +42,7 @@
 #define MAX_NUM_KEYS_QUOTA_MAP 8
 /* init number of QuotaInfoEntry in quota_info_map */
 #define INIT_QUOTA_MAP_ENTRIES 128
-#define AVG_QUOTA_MAP_ENTRIES (diskquota_max_quotas / diskquota_max_monitored_databases)
+#define AVG_QUOTA_MAP_ENTRIES (diskquota_max_quota_probes / diskquota_max_monitored_databases)
 /* max number of QuotaInfoEntry in quota_info_map */
 #define MAX_QUOTA_MAP_ENTRIES (AVG_QUOTA_MAP_ENTRIES < 1024 ? 1024 : AVG_QUOTA_MAP_ENTRIES)
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -87,7 +87,7 @@ int                      SEGCOUNT = 0;
 extern int               diskquota_max_table_segments;
 extern pg_atomic_uint32 *diskquota_table_size_entry_num;
 extern int               diskquota_max_monitored_databases;
-extern int               diskquota_max_quotas;
+extern int               diskquota_max_quota_probes;
 extern pg_atomic_uint32 *diskquota_quota_info_entry_num;
 
 /*
@@ -232,7 +232,7 @@ put_quota_map_entry(QuotaInfoEntryKey *key, bool *found)
 {
 	QuotaInfoEntry *entry;
 	uint32          counter = pg_atomic_read_u32(diskquota_quota_info_entry_num);
-	if (counter >= diskquota_max_quotas)
+	if (counter >= diskquota_max_quota_probes)
 	{
 		entry = hash_search(quota_info_map, key, HASH_FIND, found);
 		/*
@@ -248,12 +248,12 @@ put_quota_map_entry(QuotaInfoEntryKey *key, bool *found)
 		if (!(*found))
 		{
 			counter = pg_atomic_add_fetch_u32(diskquota_quota_info_entry_num, 1);
-			if (counter >= diskquota_max_quotas)
+			if (counter >= diskquota_max_quota_probes)
 			{
 				ereport(WARNING, (errmsg("[diskquota] the number of quota exceeds the limit, please increase "
-				                         "the GUC value for diskquota.max_quotas. Current "
-				                         "diskquota.max_quotas value: %d",
-				                         diskquota_max_quotas)));
+				                         "the GUC value for diskquota.max_quota_probes. Current "
+				                         "diskquota.max_quota_probes value: %d",
+				                         diskquota_max_quota_probes)));
 			}
 		}
 	}

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -250,8 +250,8 @@ put_quota_map_entry(QuotaInfoEntryKey *key, bool *found)
 			counter = pg_atomic_add_fetch_u32(diskquota_quota_info_entry_num, 1);
 			if (counter >= diskquota_max_quota_probes)
 			{
-				ereport(WARNING, (errmsg("[diskquota] the number of quota exceeds the limit, please increase "
-				                         "the GUC value for diskquota.max_quota_probes. Current "
+				ereport(WARNING, (errmsg("[diskquota] the number of quota probe exceeds the limit, please "
+				                         "increase the GUC value for diskquota.max_quota_probes. Current "
 				                         "diskquota.max_quota_probes value: %d",
 				                         diskquota_max_quota_probes)));
 			}


### PR DESCRIPTION
GUC diskquota.max_quota_probes indicates the number of quota probes pre-allocated at the cluster level. Diskquota requires thousands of probes to collect different quota usage in the cluster, and each quota probe is only used to monitor a specific quota usage, such as how much disk space a role uses on a certain tablespace. Even if you do not define the corresponding disk quota rules, the corresponding probe will continue to run in the background.  

The max number of active probes equals `role_num + schema_num + role_num * tablespace_num + schema_num * tablespace_num`. role_num is the number of role in the cluster. tablespace_number is the number of tablespace in the cluster. schema_num is the total number of schema in all databases. database_number is the number of databases. For example, if role_num = 10, schema_num = 5, tablespace_num = 2, database_num = 10, then the number of quota probes equals `10 * 10 + 5 + 10 * 2 * 10 + 5 * 2 = 315`. 

The GUC variable needs to be set to a number greater than the expected maximum number of active quota probes. The higher the value, the more memory is used. The default value of diskquota.max_quotas is 1024 * 1024, which requires approximately 50 MB of memory. 