### PR TITLE
Refresh table size map in center worker

### DIFF
--- a/control/ddl/diskquota--3.0.sql
+++ b/control/ddl/diskquota--3.0.sql
@@ -7,6 +7,7 @@ CREATE TABLE diskquota.quota_config(
   config jsonb
 ) WITH (appendonly=false);
 
+-- TODO: replace diskquota.table_size with view and UDF
 CREATE TABLE diskquota.table_size(
 	tableid oid,
 	size bigint,

--- a/src/diskquota_center_worker.c
+++ b/src/diskquota_center_worker.c
@@ -40,6 +40,7 @@ static void disk_quota_sighup(SIGNAL_ARGS);
 void                     disk_quota_center_worker_main(Datum main_arg);
 static inline void       loop(DiskquotaLooper *looper);
 static DiskquotaMessage *disk_quota_message_handler(DiskquotaMessage *req_msg);
+static void              refresh_table_size(ReqMsgRefreshTableSize *req_msg_body);
 
 /* flags set by signal handlers */
 static volatile sig_atomic_t got_sighup  = false;
@@ -185,6 +186,11 @@ disk_quota_message_handler(DiskquotaMessage *req_msg)
 			TestMessageLoop *rsp_body = (TestMessageLoop *)MessageBody(rsp_msg);
 			rsp_body->a               = req_body->a + 1;
 		}
+		break;
+		case MSG_REFRESH_TABLE_SIZE: {
+			refresh_table_size((ReqMsgRefreshTableSize *)MessageBody(req_msg));
+		}
+		break;
 		default:
 			break;
 	}
@@ -195,4 +201,150 @@ disk_quota_message_handler(DiskquotaMessage *req_msg)
 	MemoryAccounting_Reset();
 #endif /* GP_VERSION_NUM */
 	return rsp_msg;
+}
+
+/*
+ * how to refresh table size map:
+ * - send table oid list
+ * 	- remove absent table
+ * - send delta table size with namespace/tablespace/role
+ * 	- update table size
+ * 	- get old_namespace stored in table_size_map
+ * 	- get new_namespace sent by bgworker
+ * 	- if old_namespace != new_namespace: update quota size
+ */
+static void
+refresh_table_size(ReqMsgRefreshTableSize *req_msg_body)
+{
+	Oid               dbid;
+	int               segcount;
+	int               oid_list_length;
+	int               table_size_map_num;
+	TableSizeEntry   *entry;
+	TableSizeEntryKey key;
+	TableSizeEntry   *new_entry;
+	bool              found;
+	StringInfoData    hash_map_name;
+	HashMap          *table_size_map;
+	HASH_SEQ_STATUS   iter;
+
+	dbid               = req_msg_body->dbid;
+	segcount           = req_msg_body->segcount;
+	oid_list_length    = req_msg_body->oid_list_length;
+	table_size_map_num = req_msg_body->table_size_map_entry_num;
+
+	initStringInfo(&hash_map_name);
+	appendStringInfo(&hash_map_name, "TableSizeMap_%d", dbid);
+
+	/* find the table size map related to the current database */
+	table_size_map = hash_search(toc_map, hash_map_name.data, HASH_ENTER, &found);
+	if (!found)
+	{
+		table_size_map->map = create_table_size_map(hash_map_name.data);
+	}
+
+	/* set the TABLE_EXIST flag for existing relations. */
+	for (int i = 0; i < oid_list_length; i++)
+	{
+		CopyValueFromMessageContentList(req_msg_body->oid_list, &key.reloid, i, sizeof(Oid));
+		for (int segid = -1; segid < segcount; segid += SEGMENT_SIZE_ARRAY_LENGTH)
+		{
+			key.id = TableSizeEntryId(segid);
+			entry  = hash_search(table_size_map->map, &key, HASH_FIND, &found);
+			if (!found) break;
+			set_table_size_entry_flag(entry, TABLE_EXIST);
+		}
+	}
+
+	/* update table size */
+	for (int i = 0; i < table_size_map_num; i++)
+	{
+		new_entry = (TableSizeEntry *)GetPointFromMessageContentList(req_msg_body->table_size_entry_list, i,
+		                                                             sizeof(TableSizeEntry));
+		entry     = hash_search(table_size_map->map, &new_entry->key, HASH_ENTER, &found);
+		if (!found)
+		{
+			memset(entry->totalsize, 0, sizeof(entry->totalsize));
+			entry->owneroid      = InvalidOid;
+			entry->namespaceoid  = InvalidOid;
+			entry->tablespaceoid = InvalidOid;
+			entry->flag          = 0;
+		}
+
+		int seg_st = TableSizeEntrySegidStart(entry);
+		int seg_ed = TableSizeEntrySegidEnd(entry);
+		for (int segid = seg_st; segid < seg_ed; segid++)
+		{
+			Size new_size     = TableSizeEntryGetSize(new_entry, segid);
+			Size updated_size = new_size - TableSizeEntryGetSize(entry, segid);
+			TableSizeEntrySetSize(entry, segid, new_size);
+
+			/* update the disk usage, there may be entries in the map whose keys are InvlidOid as the entry does
+			 * not exist in the table_size_map */
+			// TODO: move quota map to center worker
+			update_size_for_quota(updated_size, NAMESPACE_QUOTA, (Oid[]){entry->namespaceoid}, segid);
+			update_size_for_quota(updated_size, ROLE_QUOTA, (Oid[]){entry->owneroid}, segid);
+			update_size_for_quota(updated_size, ROLE_TABLESPACE_QUOTA, (Oid[]){entry->owneroid, entry->tablespaceoid},
+			                      segid);
+			update_size_for_quota(updated_size, NAMESPACE_TABLESPACE_QUOTA,
+			                      (Oid[]){entry->namespaceoid, entry->tablespaceoid}, segid);
+
+			/* if schema change, transfer the file size */
+			if (entry->namespaceoid != new_entry->namespaceoid)
+			{
+				// TODO: move quota map to center worker
+				transfer_table_for_quota(TableSizeEntryGetSize(entry, segid), NAMESPACE_QUOTA,
+				                         (Oid[]){entry->namespaceoid}, (Oid[]){new_entry->namespaceoid}, segid);
+			}
+			/* if owner change, transfer the file size */
+			if (entry->owneroid != new_entry->owneroid)
+			{
+				transfer_table_for_quota(TableSizeEntryGetSize(entry, segid), ROLE_QUOTA, (Oid[]){entry->owneroid},
+				                         (Oid[]){new_entry->owneroid}, segid);
+			}
+
+			if (entry->tablespaceoid != new_entry->tablespaceoid || entry->namespaceoid != new_entry->namespaceoid)
+			{
+				transfer_table_for_quota(TableSizeEntryGetSize(entry, segid), NAMESPACE_TABLESPACE_QUOTA,
+				                         (Oid[]){entry->namespaceoid, entry->tablespaceoid},
+				                         (Oid[]){new_entry->namespaceoid, new_entry->tablespaceoid}, segid);
+			}
+			if (entry->tablespaceoid != new_entry->tablespaceoid || entry->owneroid != new_entry->owneroid)
+			{
+				transfer_table_for_quota(TableSizeEntryGetSize(entry, segid), ROLE_TABLESPACE_QUOTA,
+				                         (Oid[]){entry->owneroid, entry->tablespaceoid},
+				                         (Oid[]){new_entry->owneroid, new_entry->tablespaceoid}, segid);
+			}
+		}
+
+		entry->namespaceoid  = new_entry->namespaceoid;
+		entry->owneroid      = new_entry->owneroid;
+		entry->tablespaceoid = new_entry->tablespaceoid;
+	}
+
+	/* remove absent table from table size map */
+	hash_seq_init(&iter, table_size_map->map);
+	while ((entry = hash_seq_search(&iter)) != NULL)
+	{
+		if (!get_table_size_entry_flag(entry, TABLE_EXIST))
+		{
+			int seg_st = TableSizeEntrySegidStart(entry);
+			int seg_ed = TableSizeEntrySegidEnd(entry);
+			for (int i = seg_st; i < seg_ed; i++)
+			{
+				update_size_for_quota(-TableSizeEntryGetSize(entry, i), NAMESPACE_QUOTA, (Oid[]){entry->namespaceoid},
+				                      i);
+				update_size_for_quota(-TableSizeEntryGetSize(entry, i), ROLE_QUOTA, (Oid[]){entry->owneroid}, i);
+				update_size_for_quota(-TableSizeEntryGetSize(entry, i), ROLE_TABLESPACE_QUOTA,
+				                      (Oid[]){entry->owneroid, entry->tablespaceoid}, i);
+				update_size_for_quota(-TableSizeEntryGetSize(entry, i), NAMESPACE_TABLESPACE_QUOTA,
+				                      (Oid[]){entry->namespaceoid, entry->tablespaceoid}, i);
+			}
+			hash_search(table_size_map->map, &entry->key, HASH_REMOVE, NULL);
+		}
+		else
+		{
+			reset_table_size_entry_flag(entry, TABLE_EXIST);
+		}
+	}
 }

--- a/src/message_def.h
+++ b/src/message_def.h
@@ -32,12 +32,12 @@ typedef struct TestMessageLoop
 
 typedef struct ReqMsgRefreshTableSize
 {
-	Oid   dbid;
-	int   segcount;
-	int   oid_list_length;
-	int   table_size_map_entry_num;
-	void *oid_list;
-	void *table_size_entry_list;
+	Oid    dbid;
+	int    segcount;
+	int    oid_list_len;
+	int    table_size_entry_list_len;
+	uint64 oid_list_offset;
+	uint64 table_size_entry_list_offset;
 } ReqMsgRefreshTableSize;
 
 #endif

--- a/src/message_def.h
+++ b/src/message_def.h
@@ -28,6 +28,16 @@ typedef struct TestMessageLoop
 #define MSG_DEBUG 1
 #define MSG_TestMessage 2
 #define MSG_TestMessageLoop 3
-#define TIMEOUT_EVENT 4
+#define MSG_REFRESH_TABLE_SIZE 4
+
+typedef struct ReqMsgRefreshTableSize
+{
+	Oid   dbid;
+	int   segcount;
+	int   oid_list_length;
+	int   table_size_map_entry_num;
+	void *oid_list;
+	void *table_size_entry_list;
+} ReqMsgRefreshTableSize;
 
 #endif

--- a/src/relation_cache.h
+++ b/src/relation_cache.h
@@ -37,13 +37,14 @@ typedef struct DiskQuotaRelidCacheEntry
 
 extern HTAB *relation_cache;
 
-extern void init_shm_worker_relation_cache(void);
-extern Oid  get_relid_by_relfilenode(RelFileNode relfilenode);
-extern void remove_cache_entry(Oid relid, Oid relfilenode);
-extern Oid  get_uncommitted_table_relid(Oid relfilenode);
-extern void update_relation_cache(Oid relid);
-extern Oid  get_primary_table_oid(Oid relid, bool on_bgworker);
-extern void remove_committed_relation_from_cache(void);
-extern Size calculate_table_size(Oid relid);
+extern void  init_shm_worker_relation_cache(void);
+extern Oid   get_relid_by_relfilenode(RelFileNode relfilenode);
+extern void  remove_cache_entry(Oid relid, Oid relfilenode);
+extern Oid   get_uncommitted_table_relid(Oid relfilenode);
+extern void  update_relation_cache(Oid relid);
+extern Oid   get_primary_table_oid(Oid relid, bool on_bgworker);
+extern void  remove_committed_relation_from_cache(void);
+extern Size  calculate_table_size(Oid relid);
+extern List *get_current_database_oid_list(void);
 
 #endif

--- a/src/table_size.c
+++ b/src/table_size.c
@@ -31,7 +31,7 @@ create_table_size_map(const char *name)
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize    = sizeof(TableSizeEntryKey);
 	ctl.entrysize  = sizeof(TableSizeEntry);
-	ctl.hcxt       = CurrentMemoryContext;
+	ctl.hcxt       = TopMemoryContext;
 	table_size_map = diskquota_hash_create(name, 1024, &ctl, HASH_ELEM | HASH_CONTEXT, DISKQUOTA_TAG_HASH);
 	return table_size_map;
 }
@@ -41,14 +41,7 @@ create_table_size_map(const char *name)
 void
 vacuum_table_size_map(HTAB *table_size_map)
 {
-	HASH_SEQ_STATUS iter;
-	TableSizeEntry *tsentry;
-
-	hash_seq_init(&iter, table_size_map);
-	while ((tsentry = hash_seq_search(&iter)) != NULL)
-	{
-		hash_search(table_size_map, &tsentry->key, HASH_REMOVE, NULL);
-	}
+	hash_destroy(table_size_map);
 }
 
 HTAB *

--- a/src/table_size.h
+++ b/src/table_size.h
@@ -84,16 +84,12 @@ typedef enum
 	TABLE_EXIST = (1 << 0), /* whether table is already dropped */
 } TableSizeEntryFlag;
 
-extern HTAB *table_size_map;
-
-extern void init_table_size_map(uint32 id);
-extern void vacuum_table_size_map(uint32 id);
-extern Size diskquota_table_size_shmem_size(void);
+extern HTAB *create_table_size_map(const char *name);
+extern void  vacuum_table_size_map(HTAB *table_size_map);
+extern HTAB *get_current_database_table_size_map(HTAB *local_active_table_map);
 
 extern bool get_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag);
 extern void reset_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag);
 extern void set_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag);
-
-extern void flush_to_table_size(void);
 
 #endif

--- a/src/toc_map.c
+++ b/src/toc_map.c
@@ -52,8 +52,7 @@ search_toc_map(HTAB *toc_map, HashMapType type, Oid dbid)
 		switch (type)
 		{
 			case TABLE_SIZE_MAP:
-				// TODO: enable in the next commit
-				// entry->map = create_table_size_map(name.data);
+				entry->map = create_table_size_map(name.data);
 				break;
 			case QUOTA_INFO_MAP:
 				// TODO: enable in the next commit


### PR DESCRIPTION
bgworker behavior:
- collect active table size from segments.
- get relation oid list in the current database.
- generate local_table_size_map.
- send database oid, relation oid list and local_table_size_map
  to center worker.

center worker behavior:
- find table_size_map by database oid.
- traverse the relation oid list, and  set TABLE_EXIST flag
  for each entry in table_size_map.
- update table_size_map by local_table_size_map.
- remove the entry without TABLE_EXIST flag.

TODO:
- update quota when the table size is changed.
- update rejectmap in center worker
- send rejectmap to bgworker
- send rejectmap to segments
- replace diskquota.table_size with view and UDF
- when drop extension, vacuum table size map
  in center worker
- do not load table size from diskquota.table_size
  when is_init == true


## Review Notification
- The memory offset calculation mixes (char *) and other type of structs. There may be some wrong.