### PR TITLE
Limit diskquota hash table's size according initial request

### DIFF
--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -286,6 +286,7 @@ extern Datum diskquota_fetch_table_stat(PG_FUNCTION_ARGS);
 extern int   diskquota_naptime;
 extern int   diskquota_max_active_tables;
 extern bool  diskquota_hardlimit;
+extern int   diskquota_hashmap_overflow_report_timeout;
 
 extern int      SEGCOUNT;
 extern int      worker_spi_get_extension_version(int *major, int *minor);
@@ -316,4 +317,6 @@ extern HTAB        *diskquota_hash_create(const char *tabname, long nelem, HASHC
 extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_size, HASHCTL *infoP, int hash_flags,
                                     DiskquotaHashFunction hash_function);
 extern void  refresh_monitored_dbid_cache(void);
+extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
+                                      TimestampTz *last_overflow_report);
 #endif

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -42,9 +42,7 @@ extern void  init_active_table_hook(void);
 extern void  init_shm_worker_active_tables(void);
 extern void  init_lock_active_tables(void);
 
-extern HTAB *active_tables_map;
 extern HTAB *monitored_dbid_cache;
-extern HTAB *altered_reloid_cache;
 
 #ifndef atooid
 #define atooid(x) ((Oid)strtoul((x), NULL, 10))

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -32,6 +32,7 @@ test: test_appendonly
 test: test_rejectmap
 test: test_clean_rejectmap_after_drop
 test: test_rejectmap_mul_db
+test: test_rejectmap_limit
 test: test_ctas_pause
 test: test_ctas_role
 test: test_ctas_schema

--- a/tests/regress/expected/test_activetable_limit.out
+++ b/tests/regress/expected/test_activetable_limit.out
@@ -1,5 +1,6 @@
 -- table in 'diskquota not enabled database' should not be activetable
-\! gpconfig -c diskquota.max_active_tables -v 2 > /dev/null
+\! gpconfig -c diskquota.max_active_tables -v 5 > /dev/null
+\! gpconfig -c diskquota.naptime -v 1 > /dev/null
 \! gpstop -arf > /dev/null
 \c
 CREATE DATABASE test_tablenum_limit_01;
@@ -13,6 +14,10 @@ INSERT INTO a02 values(generate_series(0, 500));
 INSERT INTO a03 values(generate_series(0, 500));
 \c test_tablenum_limit_02
 CREATE EXTENSION diskquota;
+-- we only read the current log file
+CREATE EXTERNAL WEB TABLE segment_logs(line text)
+    EXECUTE 'cat $GP_SEG_DATADIR/pg_log/$(ls -Art $GP_SEG_DATADIR/pg_log | tail -n 1)'
+    ON ALL FORMAT 'TEXT' (DELIMITER 'OFF');
 CREATE SCHEMA s;
 SELECT diskquota.set_schema_quota('s', '1 MB');
  set_schema_quota 
@@ -26,31 +31,54 @@ SELECT diskquota.wait_for_worker_new_epoch();
  t
 (1 row)
 
-CREATE TABLE s.t1(i int) DISTRIBUTED BY (i); -- activetable = 1
-INSERT INTO s.t1 SELECT generate_series(1, 100000); -- ok. diskquota soft limit does not check when first write
+-- We create twice as many tables as the limit to ensure that the active_tables table is overflow.
+CREATE TABLE s.t1 (a int, b int) DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b) ( START (0) END (10) EVERY (1) );
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_1" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_2" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_3" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_4" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_5" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_6" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_7" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_8" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_9" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_10" for table "t1"
+WARNING:  [diskquota] the number of active tables reached the limit, please increase the GUC value for diskquota.max_active_tables.
+SELECT count(*) FROM segment_logs WHERE line LIKE '%the number of active tables reached the limit%';
+ count 
+-------
+     3
+(1 row)
+
+CREATE TABLE s.t2(i int) DISTRIBUTED BY (i);
+INSERT INTO s.t2 SELECT generate_series(1, 100000);
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
  t
 (1 row)
 
-CREATE TABLE s.t2(i int) DISTRIBUTED BY (i); -- activetable = 2
-INSERT INTO s.t2 SELECT generate_series(1, 10);  -- expect failed
-ERROR:  schema's disk space quota exceeded with name: s
-CREATE TABLE s.t3(i int) DISTRIBUTED BY (i); -- activetable = 3 should not crash.
-INSERT INTO s.t3 SELECT generate_series(1, 10);  -- expect failed
-ERROR:  schema's disk space quota exceeded with name: s
--- Q: why diskquota still works when activetable = 3?
--- A: the activetable limit by shmem size, calculate by hash_estimate_size()
---    the result will bigger than sizeof(DiskQuotaActiveTableEntry) * max_active_tables
---    the real capacity of this data structure based on the hash conflict probability.
---    so we can not predict when the data structure will be fill in fully.
---
---    this test case is useless, remove this if anyone dislike it.
---    but the hash capacity is smaller than 6, so the test case works for issue 51
+INSERT INTO s.t1 SELECT a, a from generate_series(0, 9)a; -- should be successful
+SELECT count(*) FROM s.t1;
+ count 
+-------
+    10
+(1 row)
+
+-- altered reloid cache overflow check. expected warning.
+VACUUM FULL;
+WARNING:  [diskquota] the number of altered reloid cache entries reached the limit, please increase the GUC value for diskquota.max_active_tables.
+SELECT count(*) FROM segment_logs WHERE line LIKE '%the number of altered reloid cache entries reached the limit%';
+ count 
+-------
+     3
+(1 row)
+
 DROP EXTENSION diskquota;
 \c contrib_regression
 DROP DATABASE test_tablenum_limit_01;
 DROP DATABASE test_tablenum_limit_02;
 \! gpconfig -r diskquota.max_active_tables > /dev/null
+\! gpconfig -c diskquota.naptime -v 0 > /dev/null
 \! gpstop -arf > /dev/null

--- a/tests/regress/expected/test_rejectmap_limit.out
+++ b/tests/regress/expected/test_rejectmap_limit.out
@@ -1,0 +1,87 @@
+--
+-- This file contains tests for limiting reject map
+--
+\! gpconfig -c diskquota.max_reject_entries -v 4 > /dev/null
+\! gpstop -arf > /dev/null
+\c
+CREATE DATABASE test_reject_map_limit_01;
+\c test_reject_map_limit_01
+CREATE EXTENSION diskquota;
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+-- we only read the current log file
+CREATE EXTERNAL WEB TABLE master_log(line text)
+    EXECUTE 'cat $GP_SEG_DATADIR/pg_log/$(ls -Art $GP_SEG_DATADIR/pg_log | tail -n 1)'
+    ON MASTER FORMAT 'TEXT' (DELIMITER 'OFF');
+CREATE SCHEMA s1;
+CREATE SCHEMA s2;
+CREATE SCHEMA s3;
+CREATE SCHEMA s4;
+CREATE SCHEMA s5;
+SELECT diskquota.set_schema_quota('s1', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+SELECT diskquota.set_schema_quota('s2', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+SELECT diskquota.set_schema_quota('s3', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+SELECT diskquota.set_schema_quota('s4', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+SELECT diskquota.set_schema_quota('s5', '1 MB');
+ set_schema_quota 
+------------------
+ 
+(1 row)
+
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+CREATE TABLE s1.a(i int) DISTRIBUTED BY (i);
+CREATE TABLE s2.a(i int) DISTRIBUTED BY (i);
+CREATE TABLE s3.a(i int) DISTRIBUTED BY (i);
+CREATE TABLE s4.a(i int) DISTRIBUTED BY (i);
+CREATE TABLE s5.a(i int) DISTRIBUTED BY (i);
+INSERT INTO s1.a SELECT generate_series(1,100000);
+INSERT INTO s2.a SELECT generate_series(1,100000);
+INSERT INTO s3.a SELECT generate_series(1,100000);
+INSERT INTO s4.a SELECT generate_series(1,100000);
+INSERT INTO s5.a SELECT generate_series(1,100000);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SELECT count(*) FROM master_log WHERE line LIKE '%the number of local quota reject map entries reached the limit%' AND line NOT LIKE '%LOG%';
+ count 
+-------
+     1
+(1 row)
+
+DROP EXTENSION diskquota;
+\c contrib_regression
+DROP DATABASE test_reject_map_limit_01;
+\! gpconfig -r diskquota.max_reject_entries > /dev/null
+\! gpstop -arf > /dev/null

--- a/tests/regress/sql/test_rejectmap_limit.sql
+++ b/tests/regress/sql/test_rejectmap_limit.sql
@@ -1,0 +1,55 @@
+--
+-- This file contains tests for limiting reject map
+--
+
+\! gpconfig -c diskquota.max_reject_entries -v 4 > /dev/null
+\! gpstop -arf > /dev/null
+
+\c
+
+CREATE DATABASE test_reject_map_limit_01;
+
+\c test_reject_map_limit_01
+CREATE EXTENSION diskquota;
+SELECT diskquota.wait_for_worker_new_epoch();
+-- we only read the current log file
+CREATE EXTERNAL WEB TABLE master_log(line text)
+    EXECUTE 'cat $GP_SEG_DATADIR/pg_log/$(ls -Art $GP_SEG_DATADIR/pg_log | tail -n 1)'
+    ON MASTER FORMAT 'TEXT' (DELIMITER 'OFF');
+
+CREATE SCHEMA s1;
+CREATE SCHEMA s2;
+CREATE SCHEMA s3;
+CREATE SCHEMA s4;
+CREATE SCHEMA s5;
+
+SELECT diskquota.set_schema_quota('s1', '1 MB');
+SELECT diskquota.set_schema_quota('s2', '1 MB');
+SELECT diskquota.set_schema_quota('s3', '1 MB');
+SELECT diskquota.set_schema_quota('s4', '1 MB');
+SELECT diskquota.set_schema_quota('s5', '1 MB');
+SELECT diskquota.wait_for_worker_new_epoch();
+
+CREATE TABLE s1.a(i int) DISTRIBUTED BY (i);
+CREATE TABLE s2.a(i int) DISTRIBUTED BY (i);
+CREATE TABLE s3.a(i int) DISTRIBUTED BY (i);
+CREATE TABLE s4.a(i int) DISTRIBUTED BY (i);
+CREATE TABLE s5.a(i int) DISTRIBUTED BY (i);
+
+INSERT INTO s1.a SELECT generate_series(1,100000);
+INSERT INTO s2.a SELECT generate_series(1,100000);
+INSERT INTO s3.a SELECT generate_series(1,100000);
+INSERT INTO s4.a SELECT generate_series(1,100000);
+INSERT INTO s5.a SELECT generate_series(1,100000);
+
+SELECT diskquota.wait_for_worker_new_epoch();
+
+SELECT count(*) FROM master_log WHERE line LIKE '%the number of local quota reject map entries reached the limit%' AND line NOT LIKE '%LOG%';
+
+DROP EXTENSION diskquota;
+
+\c contrib_regression
+DROP DATABASE test_reject_map_limit_01;
+
+\! gpconfig -r diskquota.max_reject_entries > /dev/null
+\! gpstop -arf > /dev/null


### PR DESCRIPTION
Diskquota did not control the size of its hash tables in shared memory and could
have consumed shared memory not intended for it, potentially impacting the other
database subsystems. Hash tables can also grow indefinitely if the background
process on the coordinator has not started, which can happen for a number of
reasons: gone done with error, pause, isn’t started. In this case, data is not
collected from segments and some hash tables (active_tables_map, relation_cache,
relid_cache) would not be cleared and would overflow.

This patch adds a limit on the size of all hash tables in shared memory by
adding a function that checks whether the hash table is full. The function
returns HASH_FIND if the map is full and HASH_ENTER otherwise. It also report a
warning if the table is full. Implemented a GUC that controls how frequently the
warning will be reported, as it could be reported too frequently. Also added a
GUC to control size of local reject map. The size of global reject map is set
as diskquota_max_local_reject_entries * diskquota_max_monitored_databases.

The test_active_table_limit test has been changed. Firstly, the value of
max_active_tables was changed from 2 to 5, since tables from all databases
processed by diskquota are placed in active_tables_map and with a limit of 2
tables overflow occurs even when the extension is created. Secondly, now a
table with 10 partitions is created to overflow active_tables_map, after which
another table is created into which data is inserted that should exhaust the
quota, but since this table does not inserted into active_tables_map, its size
is not taken into account and we can insert into the table after that. At the
end, vacuum full is done to achieve the overflow of altered_reloid_cache.
