### PR TITLE
Free tuple after use in refresh_rejectmap

### DIFF
--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -2028,6 +2028,8 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 								memcpy(&blocked_filenode_entry->auxblockinfo, &keyitem, sizeof(RejectMapEntry));
 								blocked_filenode_entry->segexceeded = rejectmapentry->segexceeded;
 							}
+
+							heap_freetuple(curr_tuple);
 						}
 					}
 					/*
@@ -2037,6 +2039,8 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 					break;
 				}
 			}
+
+			heap_freetuple(tuple);
 		}
 		else
 		{


### PR DESCRIPTION
refresh_rejectmap looks for a tuple using SearchSysCacheCopy1 which retrieves a copy of the tuple allocating memory for it. However, refresh_rejectmap didn't free these tuple copies after use. If lots of oids were passed, diskquota could work incorrectly because of huge memory leak. This patch frees these tuples and prevents memory leaks.